### PR TITLE
add migration to increase string limit, and updated redirects in transfrom controller

### DIFF
--- a/app/controllers/transform_controller.rb
+++ b/app/controllers/transform_controller.rb
@@ -85,7 +85,7 @@ class TransformController < ApplicationController
     else
       config[:source_directory] = source_dir
       process_source_directory(source_dir)
-      redirect_to :action => 'reprise', :image_set_id => config[:image_set_id]
+      redirect_to :action => 'reprise', :image_set_id => @image_set.id
     end
   end
 
@@ -188,9 +188,9 @@ class TransformController < ApplicationController
     # apply the crop to the rest of the pages
     debug("Cropping other files...")
     call_rake :process_crop
-#    MiddleMan.get_worker(session[:job_key]).begin_crop_sextodecimo(start_of_band, band_height)
+		#MiddleMan.get_worker(session[:job_key]).begin_crop_sextodecimo(start_of_band, band_height)
 
-    redirect_to :action => 'number_format_form', :image_set_id => config[:image_set_id]
+    redirect_to :action => 'number_format_form', :image_set_id => @image_set.id
   end
 
 
@@ -208,9 +208,9 @@ class TransformController < ApplicationController
     config[:number_format] = params[:format]
     config[:interval_sequential] = (params[:interval] == 'Sequential')
     if('Date' == config[:number_format])
-      redirect_to :action => 'date_format_form', :image_set_id => config[:image_set_id]
+      redirect_to :action => 'date_format_form', :image_set_id => @image_set.id
     else
-      redirect_to :action => 'numeric_format_start_form', :image_set_id => config[:image_set_id]
+      redirect_to :action => 'numeric_format_start_form', :image_set_id => @image_set.id
     end
   end
 
@@ -220,7 +220,7 @@ class TransformController < ApplicationController
 
   def numeric_format_start_process
     config[:numeric_start] = params[:numeric_start]
-    redirect_to :action => 'partial_list_form', :image_set_id => config[:image_set_id]
+    redirect_to :action => 'partial_list_form', :image_set_id => @image_set.id
   end
 
   #############################################################################
@@ -246,7 +246,7 @@ class TransformController < ApplicationController
     end
     @image_set.title_format = date_format
     @image_set.save!
-    redirect_to :action => 'date_format_start_form', :image_set_id => config[:image_set_id]
+    redirect_to :action => 'date_format_start_form', :image_set_id => @image_set.id
   end
 
   def date_format_ajax_test

--- a/db/migrate/20140922134648_increase_action_limit_in_interactions.rb
+++ b/db/migrate/20140922134648_increase_action_limit_in_interactions.rb
@@ -1,0 +1,5 @@
+class IncreaseActionLimitInInteractions < ActiveRecord::Migration
+  def change
+		change_column(:interactions, :action, :string, :limit => 100 )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140528213120) do
+ActiveRecord::Schema.define(version: 20140922134648) do
 
   create_table "article_article_links", force: true do |t|
     t.integer  "source_article_id"
@@ -203,7 +203,7 @@ ActiveRecord::Schema.define(version: 20140528213120) do
     t.integer  "collection_id"
     t.integer  "work_id"
     t.integer  "page_id"
-    t.string   "action",        limit: 20
+    t.string   "action",        limit: 100
     t.string   "params"
     t.string   "browser",       limit: 128
     t.string   "session_id",    limit: 40
@@ -345,7 +345,7 @@ ActiveRecord::Schema.define(version: 20140528213120) do
   end
 
   add_index "pages", ["work_id"], name: "index_pages_on_work_id", using: :btree
-  add_index "pages", ["xml_text"], name: "pages_xml_text_index", length: {"xml_text"=>333}, using: :btree
+  add_index "pages", ["xml_text"], name: "pages_xml_text_index", length: {"xml_text"=>255}, using: :btree
 
   create_table "plugin_schema_info", id: false, force: true do |t|
     t.string  "plugin_name"


### PR DESCRIPTION
Hey Ben. Thought I would give a pull request a shot. In the transform_controller any instance of:

```
redirect_to :action => ... :image_set_id => config[:image_set_id]
```

...I changed to...

```
redirect_to :action => ... :image_set_id => @image_set.id
```

On the migration addition I was getting some errors in mysql because the action was longer than 20 chars, so I increased that to 100.

After these changes I'm getting this error http://pastie.org/9584439 on transform/date_format_form?image_set_id=3 (
