### PR TITLE
Implemented #264 by adding a form.  Further UI work needed

### DIFF
--- a/app/assets/stylesheets/components/shared.scss
+++ b/app/assets/stylesheets/components/shared.scss
@@ -962,11 +962,24 @@ button, .button, .dropdown dd a {
   table-layout: fixed;
   border-collapse: separate;
   th {
+    padding: 10px 0;
     line-height: 30px;
     color: $bodyFgFaded;
-    padding: 0 0 5px 10px;
-    vertical-align: bottom;
-    &:first-child { width: 25%; }
+    &:first-child {
+      width: 25%;
+      padding-left: 10px;
+    }
+    form {
+      position: relative;
+      padding-left: 115px;
+      label {
+        left: 0;
+        top: 50%;
+        line-height: 1;
+        margin-top: -0.5em;
+        position: absolute;
+      }
+    }
   }
   td {
     vertical-align: top;

--- a/app/controllers/page_version_controller.rb
+++ b/app/controllers/page_version_controller.rb
@@ -11,5 +11,4 @@ class PageVersionController < ApplicationController
     render 'show'
   end
 
-
 end

--- a/app/controllers/page_version_controller.rb
+++ b/app/controllers/page_version_controller.rb
@@ -4,11 +4,12 @@ class PageVersionController < ApplicationController
 
   def set_versions
     @selected_version = @page_version.present? ? @page_version : @page.page_versions.first
-    @previous_version = @selected_version.prev
+    @previous_version = params[:compare_version_id] ? PageVersion.find(params[:compare_version_id]) : @selected_version.prev
   end
 
   def list
     render 'show'
   end
+
 
 end

--- a/app/models/page_version.rb
+++ b/app/models/page_version.rb
@@ -3,10 +3,8 @@ class PageVersion < ActiveRecord::Base
   belongs_to :user
 
   def display
-    self.created_on.strftime("%b %d, %Y")+ " "+self.user.display_name
-
+    self.created_on.strftime("%b %d, %Y") + " - " + self.user.display_name
   end
-    
 
   def prev
     page.page_versions.where("id < ?", id).first

--- a/app/models/page_version.rb
+++ b/app/models/page_version.rb
@@ -2,6 +2,12 @@ class PageVersion < ActiveRecord::Base
   belongs_to :page
   belongs_to :user
 
+  def display
+    self.created_on.strftime("%b %d, %Y")+ " "+self.user.display_name
+
+  end
+    
+
   def prev
     page.page_versions.where("id < ?", id).first
   end

--- a/app/views/page_version/show.html.slim
+++ b/app/views/page_version/show.html.slim
@@ -9,7 +9,7 @@ table.diff-versions(data-fullheight='{ "bottom": 30, "cssrule": "min-height" }')
   tr
     th: h5 =pluralize(@page.page_versions.size, 'revision')
     th =="#{selected_version_user} at #{selected_version_date}"
-    th Revision changes
+    th Differences with <b>Form Goes Here</b>
   tr
     td.diff-list
       .scroll-container
@@ -39,6 +39,11 @@ table.diff-versions(data-fullheight='{ "bottom": 30, "cssrule": "min-height" }')
         div(data-diff-translation="original" data-empty="No translation provided")
           ==xml_to_html((@previous_version.xml_translation rescue ""))
 
+=form_tag({ :action => 'show' }) do 
+  =hidden_field_tag :page_version_id, @selected_version.id
+  =select_tag :compare_version_id, options_from_collection_for_select(@page.page_versions.all.to_a, :id, :display, @previous_version.id.to_s)
+  =button_tag "Go"
+  
 -content_for :javascript
   =javascript_include_tag 'textdiff'
   javascript:

--- a/app/views/page_version/show.html.slim
+++ b/app/views/page_version/show.html.slim
@@ -7,9 +7,13 @@ p.diff-help Here you can see all page revisions and compare the changes have bee
 
 table.diff-versions(data-fullheight='{ "bottom": 30, "cssrule": "min-height" }')
   tr
-    th: h5 =pluralize(@page.page_versions.size, 'revision')
+    th: h5.nomargin =pluralize(@page.page_versions.size, 'revision')
     th =="#{selected_version_user} at #{selected_version_date}"
-    th Differences with <b>Form Goes Here</b>
+    th
+      =form_tag({ :action => 'show' }, :method => 'get', :enforce_utf8 => false, :'data-compare-with' => '') do
+        =hidden_field_tag :page_version_id, @selected_version.id
+        =label_tag :compare_version_id, 'Compared with'
+        =select_tag :compare_version_id, options_from_collection_for_select(@page.page_versions.all.to_a, :id, :display, @previous_version.id.to_s)
   tr
     td.diff-list
       .scroll-container
@@ -17,7 +21,7 @@ table.diff-versions(data-fullheight='{ "bottom": 30, "cssrule": "min-height" }')
           =link_to({ :action => 'show', :page_version_id => version.id }, class: ('selected' if version == @selected_version))
             =time_tag(version.created_on)
               =version.created_on.strftime("%b %d, %Y")
-            span =version.user.display_name
+            small =version.user.display_name
 
     td.diff-version
       h4(data-diff-title="changed" data-empty="Untitled") =@selected_version.title
@@ -39,11 +43,6 @@ table.diff-versions(data-fullheight='{ "bottom": 30, "cssrule": "min-height" }')
         div(data-diff-translation="original" data-empty="No translation provided")
           ==xml_to_html((@previous_version.xml_translation rescue ""))
 
-=form_tag({ :action => 'show' }) do 
-  =hidden_field_tag :page_version_id, @selected_version.id
-  =select_tag :compare_version_id, options_from_collection_for_select(@page.page_versions.all.to_a, :id, :display, @previous_version.id.to_s)
-  =button_tag "Go"
-  
 -content_for :javascript
   =javascript_include_tag 'textdiff'
   javascript:
@@ -72,5 +71,10 @@ table.diff-versions(data-fullheight='{ "bottom": 30, "cssrule": "min-height" }')
         if(!$.trim($element.html())) {
           $element.empty();
         }
+      });
+
+      // Auto submit form when select value changed
+      $('select#compare_version_id').on('change', function() {
+        $(this).closest('form').submit();
       });
     });


### PR DESCRIPTION
Currently the page version screen lets users view a version and see both the state of the page at that version and the differences with the previous version.  The University of Texas wants to be able to see the differences between one version with any other version, not just the previous one.

I've implemented the base functionality, but we need to make this more visually appealing.  Ideally, the select list for the comparison version would appear at the header of the `diff` view, where I have added the text *Form goes here*.  This would serve the two purposes of 1) showing the user which version was being compared, and 2) allowing them to select a different version to compare against.

So the final behavior should be:
* Users may select from the existing list on the left column and see that version compared against the previous version, as before.
* Users may select a different version from the existing list on the left column and see that version compared against is previous version, as before.
* Users may choose a different comparison version from a select list, which will compare the currently selected version against the comparison version of the page.

I'm open to other ideas on how to accomplish this in a visually appealing manner.