### PR TITLE
Ui design

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Run
     rake db:migrate
 to load the schema definition into the database account.
 
+Modify the configuration parameters in config/initializers/01fromthepage.rb.
+
 Finally, start the application
 
     rails server

--- a/app/mailers/system_mailer.rb
+++ b/app/mailers/system_mailer.rb
@@ -1,12 +1,12 @@
 class SystemMailer < ActionMailer::Base
 
-  default from: "FromThePage <from@example.com>"
+  default from: "FromThePage <support@fromthepage.com>"
   layout "mailer"
 
   before_filter :add_inline_attachments!
 
   def config_test(target_email)
-    mail to: target_email, subject: "Mail config test for FromThePage"
+    mail from: SENDING_EMAIL_ADDRESS, to: target_email, subject: "Mail config test for FromThePage"
   end
 
 
@@ -17,7 +17,7 @@ class SystemMailer < ActionMailer::Base
   #
   def new_upload(document_upload)
     @document_upload = document_upload
-    mail to: admin_emails, subject: "New document upload - #{document_upload.name}"
+    mail from: SENDING_EMAIL_ADDRESS, to: ADMIN_EMAILS, subject: "New document upload - #{document_upload.name}"
   end
 
   # Subject can be set in your I18n file at config/locales/en.yml
@@ -27,7 +27,7 @@ class SystemMailer < ActionMailer::Base
   #
   def upload_succeeded(document_upload)
     @document_upload = document_upload
-    mail to: admin_emails, subject: "Upload succeeded - #{document_upload.name}"
+    mail from: SENDING_EMAIL_ADDRESS, to: ADMIN_EMAILS, subject: "Upload succeeded - #{document_upload.name}"
   end
 
   # Subject can be set in your I18n file at config/locales/en.yml
@@ -37,7 +37,7 @@ class SystemMailer < ActionMailer::Base
   #
   def new_user
     @greeting = "Hi"
-    mail to: admin_emails, subject: "New FromThePage user "
+    mail from: SENDING_EMAIL_ADDRESS, to: ADMIN_EMAILS, subject: "New FromThePage user "
   end
 
   private

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,6 @@
 class UserMailer < ActionMailer::Base
 
-  default from: "FromThePage <from@example.com>"
+  default from: "FromThePage" + SENDING_EMAIL_ADDRESS
   layout "mailer"
 
   before_filter :add_inline_attachments!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,6 +13,18 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
+  # action mailer config -- required for password resets and the bulk uploader
+    config.action_mailer.smtp_settings = {
+    :address   => "smtp.yourdomain.com",
+    :port      => 587, # ports 587 and 2525 are also supported with STARTTLS
+    :enable_starttls_auto => true, # detects and uses STARTTLS
+    :user_name => "XXXXX",
+    :password  => "XXXXX",
+    :authentication => 'login', 
+    :domain => 'yourdomain.com', # your domain to identify your server when connecting
+  }
+  config.action_mailer.default_url_options =  { host: 'hostname' } //change this to match your server URL, i.e. www.fromthepage.com
+  config.action_mailer.default_options
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/config/initializers/01fromthepage.rb
+++ b/config/initializers/01fromthepage.rb
@@ -1,0 +1,2 @@
+ADMIN_EMAILS = 'saracarl@gmail.com, benwbrum@gmail.com'
+SENDING_EMAIL_ADDRESS = 'support@fromthepage.com'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -10,7 +10,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'fromthepage@fromthepage.com'
+  config.mailer_sender = "FromThePage" + SENDING_EMAIL_ADDRESS
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -10,7 +10,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "FromThePage" + SENDING_EMAIL_ADDRESS
+  config.mailer_sender = SENDING_EMAIL_ADDRESS
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
Mailer changes:
-- Allows administrators to configure the "sending" email address for system generated emails
-- Allows administrators to configure who will receive emails when users upload documents and perform some other high level tasks.

Created an initializer for FromThePage -- include initializer tasks and settings here in the future.  With the 01 at the beginning of the filename it ensures this initializer will be run *before* all the others, so values set here could be used by the devise initializer (for example).