### PR TITLE
Issue #435, bug in transcription tab access

### DIFF
--- a/app/views/shared/_page_tabs.html.slim
+++ b/app/views/shared/_page_tabs.html.slim
@@ -7,7 +7,7 @@
   },
 }]
 
--if current_user.can_transcribe?(@work)
+-if user_signed_in? && current_user.can_transcribe?(@work)
   -tabs += [{\
     :name => 'Transcribe',
     :selected => 3,


### PR DESCRIPTION
Check to see if the user is signed in before checking their access to the transcribe tab.