### PR TITLE
#627 New user sign up and redirect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   before_filter :load_objects_from_params
   before_filter :update_ia_work_server
   before_filter :log_interaction
-  # before_filter :store_location_for_login
+  before_action :store_current_location, :unless => :devise_controller?
   before_filter :load_html_blocks
   # after_filter :complete_interaction
   before_filter :authorize_collection
@@ -45,7 +45,6 @@ class ApplicationController < ActionController::Base
   rescue_from ActiveRecord::RecordNotFound, with: :bad_record_id
 
   def load_objects_from_params
-
     # this needs to be ordered from the specific to the
     # general, so that parent_id will load the appropriate
     # object without being overridden by child_id.parent
@@ -209,12 +208,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def store_location_for_login
-    unless action_name == 'login' || action_name == 'signup'
-      store_location
-    end
-  end
-
   def authorize_collection
     # skip irrelevant cases
     return unless @collection
@@ -268,6 +261,11 @@ end
     else
       { :action => 'display_page', :page_id => page.id}
     end
+  end
+
+private
+  def store_current_location
+    store_location_for(:user, request.url)
   end
 
 # class ApplicationController < ActionController::Base

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -42,4 +42,10 @@ class RegistrationsController < Devise::RegistrationsController
       respond_with resource
     end
   end
+
+  #redirect new sign up back to starting page
+  def after_sign_up_path_for(resource)
+    session[:user_return_to] || root_path
+  end
+
 end

--- a/app/controllers/transcribe_controller.rb
+++ b/app/controllers/transcribe_controller.rb
@@ -7,6 +7,8 @@ class TranscribeController  < ApplicationController
   include Magick
   before_filter :authorized?, :except => [:zoom, :guest]
   protect_from_forgery :except => [:zoom, :unzoom]
+  #this prevents failed redirects after sign up
+  skip_before_action :store_current_location
 
   def authorized?
     unless user_signed_in? && current_user.can_transcribe?(@work)

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -56,7 +56,7 @@ html
           =link_to 'Dashboard', dashboard_role_path, class: 'header_link'
           =link_to 'Collections', dashboard_path, class: 'header_link'
           =link_to 'FAQ', { controller: 'static', action: 'faq' }, class: 'header_link'
-          -unless user_signed_in?
+          -if (user_signed_in? && current_user.guest) || !user_signed_in?
             =link_to 'Sign Up', new_user_registration_path, class: 'header_link'
 
           -if user_signed_in?

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -56,7 +56,7 @@ html
           =link_to 'Dashboard', dashboard_role_path, class: 'header_link'
           =link_to 'Collections', dashboard_path, class: 'header_link'
           =link_to 'FAQ', { controller: 'static', action: 'faq' }, class: 'header_link'
-          -if user_signed_in? && current_user.guest
+          -unless user_signed_in?
             =link_to 'Sign Up', new_user_registration_path, class: 'header_link'
 
           -if user_signed_in?

--- a/spec/features/guest_spec.rb
+++ b/spec/features/guest_spec.rb
@@ -59,7 +59,8 @@ describe "guest user actions" do
     @user = User.last
     expect(@user.login).to eq('martha') 
     expect(@guest.id).to eq(@user.id)
-    expect(page.current_path). to eq ("/display/display_page?page_id=#{@page.id}")
+    save_and_open_page
+    expect(page.current_path). to eq ("/display/display_page")
     page.find('.tabs').click_link("Versions")
     expect(page).to have_link("Martha")
     expect(page.find('.diff-list')).not_to have_content("Guest")

--- a/spec/features/guest_spec.rb
+++ b/spec/features/guest_spec.rb
@@ -59,7 +59,6 @@ describe "guest user actions" do
     @user = User.last
     expect(@user.login).to eq('martha') 
     expect(@guest.id).to eq(@user.id)
-    save_and_open_page
     expect(page.current_path). to eq ("/display/display_page")
     page.find('.tabs').click_link("Versions")
     expect(page).to have_link("Martha")

--- a/spec/features/guest_spec.rb
+++ b/spec/features/guest_spec.rb
@@ -59,7 +59,7 @@ describe "guest user actions" do
     @user = User.last
     expect(@user.login).to eq('martha') 
     expect(@guest.id).to eq(@user.id)
-    visit "/display/display_page?page_id=#{@page.id}"
+    expect(page.current_path). to eq ("/display/display_page?page_id=#{@page.id}")
     page.find('.tabs').click_link("Versions")
     expect(page).to have_link("Martha")
     expect(page.find('.diff-list')).not_to have_content("Guest")

--- a/spec/features/role_view_spec.rb
+++ b/spec/features/role_view_spec.rb
@@ -12,10 +12,8 @@ describe "different user role logins" do
   it "creates a new user account" do
     user_count = User.all.count
     visit root_path
-    expect(page).to have_content("Sign In")
-    page.find('a', text: 'Sign In').click
-    expect(page.current_path).to eq new_user_session_path
-    click_link('Sign up for a new account')
+    expect(page).to have_content("Sign Up")
+    page.find('a', text: 'Sign Up').click
     expect(page.current_path).to eq new_user_registration_path
     click_button('Create Account')
     expect(page).to have_content('4 errors prohibited this user from being saved')
@@ -26,8 +24,7 @@ describe "different user role logins" do
     page.fill_in 'Display name', with: 'Alexander'
     click_button('Create Account')
     new_user_count = User.all.count
-    expect(page.current_path).to eq dashboard_watchlist_path
-    expect(page).to have_content("Collaborator Dashboard")
+    expect(page.current_path).to eq root_path
     expect(new_user_count).to eq (user_count + 1)
   end
 


### PR DESCRIPTION
When a user first signs up, they should be redirected back to the page where they were when they clicked the sign up button.