### PR TITLE
#662, Label field length in IIIF imports

### DIFF
--- a/app/models/sc_manifest.rb
+++ b/app/models/sc_manifest.rb
@@ -32,7 +32,7 @@ class ScManifest < ActiveRecord::Base
     unless collection
       collection = Collection.new
       collection.owner = user
-      collection.title = sc_collection.label
+      collection.title = sc_collection.label.truncate(255, separator: ' ', omission: '')
       collection.save!
       
       sc_collection.collection = collection
@@ -45,7 +45,7 @@ class ScManifest < ActiveRecord::Base
   def convert_with_no_collection(user)
 	collection = Collection.new
     collection.owner = user
-    collection.title = self.label
+    collection.title = self.label.truncate(255, separator: ' ', omission: '')
     collection.save!	  
     convert_with_collection(user, collection)
   end
@@ -55,7 +55,7 @@ class ScManifest < ActiveRecord::Base
     
     work = Work.new    
     work.owner = user
-    work.title = self.label
+    work.title = self.label.truncate(255, separator: ' ', omission: '')
     work.description = self.html_description
     work.collection = collection
     work.save!

--- a/db/migrate/20170523151631_change_label_size_in_sc_manifests.rb
+++ b/db/migrate/20170523151631_change_label_size_in_sc_manifests.rb
@@ -1,0 +1,8 @@
+class ChangeLabelSizeInScManifests < ActiveRecord::Migration
+  def up
+    change_column :sc_manifests, :label, :text, :limit => 512
+  end
+  def down
+    change_column :sc_manifests, :label, :string
+  end
+end

--- a/spec/features/add_data_spec.rb
+++ b/spec/features/add_data_spec.rb
@@ -27,20 +27,7 @@ describe "uploads data for collections", :order => :defined do
   end
 
   it "imports IIIF manifests" do
-    visit dashboard_owner_path
-    works_count = Work.all.count
-    page.find('.tabs').click_link("Start A Project")
-    page.fill_in 'at_id', with: "https://data.ucd.ie/api/img/manifests/duchas:5141774"
-    click_button('Import')
-    expect(page).to have_content("Metadata")
-    click_link('Import')
-    expect(page).to have_content("Import Manifest")
-    select(@collection.title, :from => 'sc_manifest_collection_id')
-    click_button('Import')
-    expect(page).to have_content(@collection.title)
-    new_works = Work.all.count
-  #  expect(new_works).to eq (works_count + 1)
-  #import another manifest for test data
+    #import a manifest for test data
     visit dashboard_owner_path
     page.find('.tabs').click_link("Start A Project")
     page.fill_in 'at_id', with: "https://data.ucd.ie/api/img/manifests/ivrla:2638"
@@ -51,6 +38,22 @@ describe "uploads data for collections", :order => :defined do
     select(@collection.title, :from => 'sc_manifest_collection_id')
     click_button('Import')
     expect(page).to have_content(@collection.title)
+    visit dashboard_owner_path
+    works_count = Work.all.count
+    page.find('.tabs').click_link("Start A Project")
+    #this manifest has a very long title
+    page.fill_in 'at_id', with: "https://data.ucd.ie/api/img/manifests/ivrla:7645"
+    click_button('Import')
+    expect(page).to have_content("Metadata")
+    click_link('Import')
+    expect(page).to have_content("Import Manifest")
+    select(@collection.title, :from => 'sc_manifest_collection_id')
+    click_button('Import')
+    expect(page).to have_content(@collection.title)
+    expect((@collection.works.last.title).length).to be < 255
+    new_works = Work.all.count
+    expect(new_works).to eq (works_count + 1)
+  
   end
 
   it "creates an empty work" do

--- a/spec/features/needs_review_spec.rb
+++ b/spec/features/needs_review_spec.rb
@@ -6,7 +6,7 @@ describe "needs review", :order => :defined do
   before :all do
     @user = User.find_by(login: USER)
     @collection = Collection.second
-    @work = @collection.works.second
+    @work = @collection.works.third
     @page1 = @work.pages.first
     @page2 = @work.pages.second
     @page3 = @work.pages.third


### PR DESCRIPTION
Just FYI: I have the limit in the migration, but it looks like mysql won't actually let you set a limit on a text field, but strings can't be longer than 255 characters.  So the field is big enough for anything now, but doesn't have a 512 limit.