### PR TITLE
#682 - Uploads failing on SMTP errors

### DIFF
--- a/app/helpers/add_work_helper.rb
+++ b/app/helpers/add_work_helper.rb
@@ -1,7 +1,5 @@
 module AddWorkHelper
-
-  SMTP_ERRORS = [
-    IOError, Net::SMTPAuthenticationError, Net::SMTPServerBusy, Net::SMTPUnknownError, TimeoutError, Net::SMTPFatalError, Net::SMTPSyntaxError]
+  include ErrorHelper
 
   def new_work
     @document_upload = DocumentUpload.new
@@ -11,7 +9,6 @@ module AddWorkHelper
     @universe_collections = ScCollection.universe
     @sc_collections = ScCollection.all
   end
-
 
   # Owner Dashboard - staging area
   def staging
@@ -33,18 +30,17 @@ module AddWorkHelper
     @document_upload.user = current_user
 
     if @document_upload.save
-        if SMTP_ENABLED
-          begin
-            SystemMailer.new_upload(@document_upload).deliver!
-            flash[:notice] = "Document has been uploaded and will be processed shortly. We'll email you at #{@document_upload.user.email} when ready."
-          rescue *SMTP_ERRORS => e
-            logger.error(e)
-            logger.error(e.backtrace.join("\n"))
-            flash[:notice] = "Document has been uploaded and will be processed shortly. Reload this page in a few minutes to see it."
-          end
-        else
+      if SMTP_ENABLED
+        begin
+          SystemMailer.new_upload(@document_upload).deliver!
+          flash[:notice] = "Document has been uploaded and will be processed shortly. We'll email you at #{@document_upload.user.email} when ready."
+        rescue *SMTP_ERRORS => e
+          log_smtp_error(e, current_user)
           flash[:notice] = "Document has been uploaded and will be processed shortly. Reload this page in a few minutes to see it."
         end
+      else
+        flash[:notice] = "Document has been uploaded and will be processed shortly. Reload this page in a few minutes to see it."
+      end
       @document_upload.submit_process
       ajax_redirect_to controller: 'collection', action: 'show', collection_id: @document_upload.collection.id
     else

--- a/app/helpers/add_work_helper.rb
+++ b/app/helpers/add_work_helper.rb
@@ -31,8 +31,13 @@ module AddWorkHelper
 
     if @document_upload.save
         if SMTP_ENABLED
-          flash[:notice] = "Document has been uploaded and will be processed shortly. We'll email you at #{@document_upload.user.email} when ready."
-          SystemMailer.new_upload(@document_upload).deliver!
+          begin
+            SystemMailer.new_upload(@document_upload).deliver!
+            flash[:notice] = "Document has been uploaded and will be processed shortly. We'll email you at #{@document_upload.user.email} when ready."
+          rescue IOError, Net::SMTPAuthenticationError, Net::SMTPServerBusy, Net::SMTPUnknownError, TimeoutError, Net::SMTPFatalError, Net::SMTPSyntaxError => e
+            print e
+            flash[:notice] = "Document has been uploaded and will be processed shortly. Reload this page in a few minutes to see it."
+          end
         else
           flash[:notice] = "Document has been uploaded and will be processed shortly. Reload this page in a few minutes to see it."
         end

--- a/app/helpers/add_work_helper.rb
+++ b/app/helpers/add_work_helper.rb
@@ -1,5 +1,8 @@
 module AddWorkHelper
 
+  SMTP_ERRORS = [
+    IOError, Net::SMTPAuthenticationError, Net::SMTPServerBusy, Net::SMTPUnknownError, TimeoutError, Net::SMTPFatalError, Net::SMTPSyntaxError]
+
   def new_work
     @document_upload = DocumentUpload.new
     @document_upload.collection=@collection
@@ -34,8 +37,9 @@ module AddWorkHelper
           begin
             SystemMailer.new_upload(@document_upload).deliver!
             flash[:notice] = "Document has been uploaded and will be processed shortly. We'll email you at #{@document_upload.user.email} when ready."
-          rescue IOError, Net::SMTPAuthenticationError, Net::SMTPServerBusy, Net::SMTPUnknownError, TimeoutError, Net::SMTPFatalError, Net::SMTPSyntaxError => e
-            print e
+          rescue *SMTP_ERRORS => e
+            logger.error(e)
+            logger.error(e.backtrace.join("\n"))
             flash[:notice] = "Document has been uploaded and will be processed shortly. Reload this page in a few minutes to see it."
           end
         else

--- a/app/helpers/error_helper.rb
+++ b/app/helpers/error_helper.rb
@@ -1,0 +1,9 @@
+module ErrorHelper
+  SMTP_ERRORS = [IOError, Net::SMTPAuthenticationError, Net::SMTPServerBusy, Net::SMTPUnknownError, TimeoutError, Net::SMTPFatalError, Net::SMTPSyntaxError]
+
+  def log_smtp_error(e, user)
+    logger.error("Document upload by #{user.display_name} at #{Time.now}")
+    logger.error("SMTP Failed: Exception: #{e.message}")
+  end
+
+end

--- a/lib/tasks/ingestor.rake
+++ b/lib/tasks/ingestor.rake
@@ -1,6 +1,5 @@
 require 'image_helper'
 require 'open-uri' # TODO: Move elsewhere
-
 namespace :fromthepage do
 
   desc "Resize image file or directories of image files"
@@ -20,6 +19,9 @@ namespace :fromthepage do
 
   desc "Process a document upload"
   task :process_document_upload, [:document_upload_id] => :environment do |t,args|
+    require "#{Rails.root}/app/helpers/error_helper"
+    include ErrorHelper
+
     document_upload_id = args.document_upload_id
     print "fetching upload with ID=#{document_upload_id}\n"
     document_upload = DocumentUpload.find document_upload_id
@@ -41,9 +43,13 @@ namespace :fromthepage do
       document_upload.save
     end
 
-    if SMTP_ENABLED    
+    if SMTP_ENABLED
+      begin
         SystemMailer.upload_succeeded(document_upload).deliver!
         UserMailer.upload_finished(document_upload).deliver!
+      rescue *SMTP_ERRORS => e
+        print "SMTP Failed: Exception: #{e.message}"
+      end
     end
 
   end


### PR DESCRIPTION
I set up a module for SMTP error handling, to prevent the uploads from failing if there's something wrong with the SMTP configuration.  Right now it's only applied to the document uploads (in both the document upload process and the rake task), but it could be applied to other SMTP code if needed.