### PR TITLE
Reorganized tests to decrease dependencies

### DIFF
--- a/spec/features/add_data_spec.rb
+++ b/spec/features/add_data_spec.rb
@@ -12,7 +12,6 @@ describe "uploads data for collections", :order => :defined do
   end
 
   before :each do
-    @document_sets = DocumentSet.where(owner_user_id: @owner.id)
     login_as(@owner, :scope => :user)
   end
 
@@ -121,6 +120,7 @@ describe "uploads data for collections", :order => :defined do
   end
 
   it "adds works to document sets" do
+    @document_sets = DocumentSet.where(owner_user_id: @owner.id)
     visit dashboard_owner_path
     page.find('.maincol').find('a', text: @set_collection.title).click
     page.find('.tabs').click_link("Sets")

--- a/spec/features/admin_view_spec.rb
+++ b/spec/features/admin_view_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe "admin actions" do
 
-before :all do
-  @admin = User.find_by(login: ADMIN)
-  @owner = User.find_by(login: OWNER)
-end
+  before :all do
+    @admin = User.find_by(login: ADMIN)
+    @owner = User.find_by(login: OWNER)
+  end
 
-before :each do
-    login_as(@admin, :scope => :user)
-end  
+  before :each do
+      login_as(@admin, :scope => :user)
+  end  
 
   it "looks at admin tabs" do
     user = User.find_by(login: USER)

--- a/spec/features/check_upload_spec.rb
+++ b/spec/features/check_upload_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe "check for successful data upload" do
+
+  before :all do
+    @owner = User.find_by(login: OWNER)
+  end
+
+  it "checks that the file has been uploaded" do
+    login_as(@owner, :scope => :user)
+    sleep(60)
+    @work = Work.find_by(title: 'test')
+    visit "/display/read_work?work_id=#{@work.id}"
+    expect(page).to have_content(@work.title)
+    expect(page).to have_content(@work.pages.first.title)
+    click_link(@work.pages.first.title)
+    page.find('#page_source_text')
+    expect(page).to have_button('Preview')
+  end
+
+end

--- a/spec/features/document_sets_spec.rb
+++ b/spec/features/document_sets_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe "document sets", :order => :defined do
 
   before :all do
-
     @owner = User.find_by(login: 'margaret')
     @user = User.find_by(login: 'eleanor')
     @collections = @owner.all_owner_collections
@@ -13,45 +12,6 @@ describe "document sets", :order => :defined do
   before :each do
     @document_sets = DocumentSet.where(owner_user_id: @owner.id)
     @set = DocumentSet.first
-  end
-
-  it "adds new document sets" do
-    login_as(@owner, :scope => :user)
-    visit dashboard_owner_path
-    doc_set = DocumentSet.where(owner_user_id: @owner.id).count
-    page.find('.maincol').find('a', text: @collection.title).click
-    page.find('.tabs').click_link("Settings")
-    page.find('.button', text: 'Enable Document Sets').click
-    expect(page).to have_content('Create a Document Set')
-    page.find('.button', text: 'Create a Document Set').click
-    page.fill_in 'document_set_title', with: "Test Document Set 1"
-    page.find_button('Create Document Set').click
-    expect(DocumentSet.last.is_public).to be true
-    expect(page).to have_content("Assign Works to Document Sets")
-    expect(page).to have_content("Test Document Set 1")
-    after_doc_set = DocumentSet.where(owner_user_id: @owner.id).count
-    expect(after_doc_set).to eq (doc_set + 1)
-    doc_set = DocumentSet.where(owner_user_id: @owner.id).count
-    page.find('.button', text: 'Create a Document Set').click
-    page.fill_in 'document_set_title', with: "Test Document Set 2"
-    page.uncheck 'Public'
-    page.find_button('Create Document Set').click
-    expect(page).to have_content("Test Document Set 2")
-    expect(DocumentSet.last.is_public).to be false
-    after_doc_set = DocumentSet.where(owner_user_id: @owner.id).count
-    expect(after_doc_set).to eq (doc_set + 1)
-  end
-
-  it "adds works to document sets" do
-    login_as(@owner, :scope => :user)
-    visit dashboard_owner_path
-    page.find('.maincol').find('a', text: @collection.title).click
-    page.find('.tabs').click_link("Sets")
-    expect(page).to have_content("Document Sets for #{@collection.title}")
-    page.check("work_assignment_#{@document_sets.first.id}_#{@collection.works.first.id}")
-    page.check("work_assignment_#{@document_sets.first.id}_#{@collection.works.second.id}")
-    page.check("work_assignment_#{@document_sets.last.id}_#{@collection.works.last.id}")
-    page.find_button('Save').click
   end
 
   it "edits a document set (collection level)" do
@@ -300,7 +260,7 @@ describe "document sets", :order => :defined do
     login_as(@owner, :scope => :user)
     visit edit_collection_path(@collection.owner, @collection)
     page.find('.button', text: 'Disable Document Sets').click
-    expect(@collection.supports_document_sets).to be false
+    expect(Collection.find_by(id: @collection.id).supports_document_sets).to be false
   end
 
   it "enables document sets" do
@@ -310,6 +270,43 @@ describe "document sets", :order => :defined do
     expect(page.current_path).to eq document_sets_path
     @collection = @collections.last
     expect(@collection.supports_document_sets).to be true
+  end
+
+  it "edits a document set slug" do
+    login_as(@owner, :scope => :user)
+    slug = "new-#{@set.slug}"
+    visit "/#{@owner.slug}/#{@set.slug}"
+    expect(page).to have_selector('h1', text: @set.title)
+    @set.works.each do |w|
+      expect(page).to have_content w.title
+    end
+    #note - checking editing of the slug from w/i the collection
+    visit "/#{@owner.slug}/#{@set.collection.slug}"
+    page.find('.tabs').click_link('Sets')
+    within(page.find('#sets')) do
+      within(page.find('tr', text: @set.title)) do
+          page.find('a', text: 'Edit').click
+      end
+    end
+    expect(page).to have_field('document_set[slug]', with: @set.slug)
+    page.fill_in 'document_set_slug', with: "new-#{@set.slug}"
+    page.find_button('Save Document Set').click
+    expect(page).to have_content("Document Sets for #{@set.collection.title}")
+    expect(page).to have_content(@set.title)
+    expect(DocumentSet.find_by(id: @set.id).slug).to eq "#{slug}"
+    #check new path
+    visit "/#{@owner.slug}/#{slug}"
+    expect(page).to have_selector('h1', text: @set.title)
+    @set.works.each do |w|
+      expect(page).to have_content w.title
+    end
+    #check the old path 
+    #(this variable is stored at the beginning of the test, so it's the original)
+    visit "/#{@owner.slug}/#{@set.slug}"
+    expect(page).to have_selector('h1', text: @set.title)
+    @set.works.each do |w|
+      expect(page).to have_content w.title
+    end
   end
 
 end

--- a/spec/features/url_spec.rb
+++ b/spec/features/url_spec.rb
@@ -8,7 +8,6 @@ describe "URL tests" do
     @collection = Collection.joins(:deeds).where(deeds: {user_id: @user.id}).first
     @work = @collection.works.first
     @page = @work.pages.first
-    @document_set = DocumentSet.where(owner_user_id: @owner.id).first
   end
 
   it "visits old URLs" do
@@ -151,43 +150,6 @@ describe "URL tests" do
     visit "/#{@user.slug}"
     expect(page).to have_content(@user.display_name)
     expect(page).to have_content("User since #{@user.created_at.strftime("%b %d, %Y")}")
-  end
-
-  it "edits a document set slug" do
-    login_as(@owner, :scope => :user)
-    slug = "new-#{@document_set.slug}"
-    visit "/#{@owner.slug}/#{@document_set.slug}"
-    expect(page).to have_selector('h1', text: @document_set.title)
-    @document_set.works.each do |w|
-      expect(page).to have_content w.title
-    end
-    #note - have to edit slug from within the collection right now, not the doc set
-    visit "/#{@owner.slug}/#{@document_set.collection.slug}"
-    page.find('.tabs').click_link('Sets')
-    within(page.find('#sets')) do
-      within(page.find('tr', text: @document_set.title)) do
-          page.find('a', text: 'Edit').click
-      end
-    end
-    expect(page).to have_field('document_set[slug]', with: @document_set.slug)
-    page.fill_in 'document_set_slug', with: "new-#{@document_set.slug}"
-    page.find_button('Save Document Set').click
-    expect(page).to have_content("Document Sets for #{@document_set.collection.title}")
-    expect(page).to have_content(@document_set.title)
-    expect(DocumentSet.find_by(id: @document_set.id).slug).to eq "#{slug}"
-    #check new path
-    visit "/#{@owner.slug}/#{slug}"
-    expect(page).to have_selector('h1', text: @document_set.title)
-    @document_set.works.each do |w|
-      expect(page).to have_content w.title
-    end
-    #check the old path 
-    #(this variable is stored at the beginning of the test, so it's the original)
-    visit "/#{@owner.slug}/#{@document_set.slug}"
-    expect(page).to have_selector('h1', text: @document_set.title)
-    @document_set.works.each do |w|
-      expect(page).to have_content w.title
-    end
   end
 
 end

--- a/spec/features/zz_convention_spec.rb
+++ b/spec/features/zz_convention_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe "convention related tasks", :order => :defined do
   Capybara.javascript_driver = :webkit
 
-
   before :all do
     @owner = User.find_by(login: OWNER)
     @collections = @owner.all_owner_collections
@@ -15,7 +14,11 @@ describe "convention related tasks", :order => :defined do
     @clean_conventions.gsub!(/\n/, ' ')
     @new_convention = "Collection level transcription convention"
     @work_convention = "Work level transcription conventions"
-    @tab = "Correct"
+    if @work.ocr_correction == true
+      @tab = "Correct"
+    else
+      @tab = "Transcribe"
+    end
   end
 
   before :each do
@@ -25,7 +28,10 @@ describe "convention related tasks", :order => :defined do
   it "checks for collection level transcription conventions" do
     visit collection_read_work_path(@work.collection.owner, @work.collection, @work)
     page.find('.work-page_title', text: @page.title).click_link(@page.title)
-    page.find('.tabs').click_link(@tab)
+    #if the page isn't already transcribed, must go to Transcribe tab
+    if page.has_content?("Facsimile")
+      page.find('.tabs').click_link(@tab)
+    end
     expect(page).to have_content @clean_conventions
   end
 
@@ -38,7 +44,9 @@ describe "convention related tasks", :order => :defined do
     click_button 'Save Changes'
     visit collection_read_work_path(@work.collection.owner, @work.collection, @work)
     page.find('.work-page_title', text: @page.title).click_link(@page.title)
-    page.find('.tabs').click_link(@tab)
+    if page.has_content?("Facsimile")
+      page.find('.tabs').click_link(@tab)
+    end
     expect(page).not_to have_content @clean_conventions
     expect(page).to have_content @work_convention
     convention_work = Work.find_by(id: @work.id)
@@ -60,7 +68,9 @@ describe "convention related tasks", :order => :defined do
     #check changed work for collection conventions
     visit collection_read_work_path(@work.collection.owner, @work.collection, @work)
     page.find('.work-page_title', text: @page.title).click_link(@page.title)
-    page.find('.tabs').click_link(@tab)
+    if page.has_content?("Facsimile")
+      page.find('.tabs').click_link(@tab)
+    end
     expect(page).not_to have_content @new_convention
     expect(page).to have_content @work_convention
   end
@@ -79,7 +89,9 @@ describe "convention related tasks", :order => :defined do
     expect(convention_work.transcription_conventions).to eq nil
     visit "/display/read_work?work_id=#{@work.id}"
     page.find('.work-page_title', text: @page.title).click_link(@page.title)
-    page.find('.tabs').click_link(@tab)
+    if page.has_content?("Facsimile")
+      page.find('.tabs').click_link(@tab)
+    end
     expect(page).to have_content @new_convention
     expect(page).not_to have_content @work_convention
   end

--- a/spec/features/zz_deletion_spec.rb
+++ b/spec/features/zz_deletion_spec.rb
@@ -1,3 +1,4 @@
+
 #Note - this test must fall at the very end of the features specs
 require 'spec_helper'
 


### PR DESCRIPTION
Tests are only dependent on add_data_spec.rb - that needs to be run first, but then the rest of the tests can be run independently.