### PR TITLE
#783 static links

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -59,7 +59,7 @@ html
         .toolbar_group
           =link_to t('dashboard.plain'), dashboard_role_path, class: 'header_link'
           =link_to 'Collections', dashboard_path, class: 'header_link'
-          =link_to 'FAQ', { controller: 'static', action: 'faq' }, class: 'header_link'
+          =link_to 'FAQ', faq_path, class: 'header_link'
           -if (user_signed_in? && current_user.guest) || !user_signed_in?
             =link_to 'Sign Up', new_user_registration_path, class: 'header_link'
 
@@ -99,9 +99,9 @@ html
     footer.footer
       .footer_copyright &copy; #{Time.now.year} #{link_to 'FromThePage', root_path}. All rights reserved.
       .footer_nav
-        =link_to 'About', { controller: 'static', action: 'about' }
+        =link_to 'About', about_path
         =link_to 'Terms & Conditions', 'http://fromthepage.wpengine.com/terms-of-service/'
-        =link_to 'Privacy Policy', { controller: 'static', action: 'privacy' }
+        =link_to 'Privacy Policy', privacy_path
         =mail_to 'benwbrum@gmail.com', 'Contact Us'
 
     .page-busy-overlay

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,4 +109,8 @@ Fromthepage::Application.routes.draw do
 
   get 'collection/update/:id', to: 'collection#update', as: :update_collection
 
+  get 'static/faq', to: 'static#faq', as: :faq
+  get 'static/about', to: 'static#about', as: :about
+  get 'static/privacy', to: 'static#privacy', as: :privacy
+
 end


### PR DESCRIPTION
Added routes and path helpers for the static pages, because Rails couldn't locate them from the Devise controller.