### PR TITLE
Update mysql2, add tzinfo-data gem dependencies (fixes #349)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'capistrano-rails', '= 1.1.3'
 gem 'capistrano-bundler', '~> 1.1.2'
 gem 'jquery-rails'
 
-gem 'mysql2','0.3.16'
+gem 'mysql2','0.3.21'
 
 gem 'recaptcha', '0.3.6'
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'capistrano-bundler', '~> 1.1.2'
 gem 'jquery-rails'
 
 gem 'mysql2','0.3.21'
+gem 'tzinfo-data'
 
 gem 'recaptcha', '0.3.6'
 


### PR DESCRIPTION
To allow FromThePage to work with MySQL 5.7, the mysql2 gem is updated. The `tzinfo-data` gem was recommended on <https://github.com/tzinfo/tzinfo/wiki/Resolving-TZInfo::DataSourceNotFound-Errors> and helped resolve the error described on that page that I got when building FromThePage in Docker.