### PR TITLE
Use ScCanvas dimensions when Page dimensions don't exist (fixes #847)

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -304,11 +304,7 @@ private
   end
 
   def region_from_page(page)
-    if page.base_width.nil? && page.sc_canvas
-      canvas_id_from_page(page) + "#xywh=0,0,#{page.sc_canvas.width},#{page.sc_canvas.height}"
-    else
-      canvas_id_from_page(page) + "#xywh=0,0,#{page.base_width},#{page.base_height}"
-    end
+    canvas_id_from_page(page) + "#xywh=0,0,#{(page.base_width || page.sc_canvas.width)},#{(page.base_height || page.sc_canvas.height)}"
   end
 
   def iiif_create_image_resource(page)

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -4,19 +4,19 @@ class IiifController < ApplicationController
     site_collection = IIIF::Presentation::Collection.new
     site_collection['@id'] = url_for({:controller => 'iiif', :action => 'collections', :only_path => false})
     site_collection.label = "IIIF resources avaliable on the FromThePage installation at #{Rails.application.config.action_mailer.default_url_options[:host]}"
-    
+
     Collection.where(:restricted => false).each do |collection|
-      iiif_collection = iiif_collection_from_collection(collection,false)      
-      
+      iiif_collection = iiif_collection_from_collection(collection,false)
+
       site_collection.collections << iiif_collection
     end
-    
+
     render :text => site_collection.to_json(pretty: true), :content_type => "application/json"
   end
-    
+
   def collection
-    iiif_collection = iiif_collection_from_collection(@collection,true)      
-    
+    iiif_collection = iiif_collection_from_collection(@collection,true)
+
     render :text => iiif_collection.to_json(pretty: true), :content_type => "application/json"
   end
 
@@ -29,26 +29,26 @@ class IiifController < ApplicationController
     if sc_collection = ScCollection.where(:at_id => at_id).last
       redirect_to :controller => 'iiif', :action => 'collection', :collection_id => sc_collection.collection_id
       return
-    end    
+    end
 
     if sc_manifest = ScManifest.where(:at_id => at_id).last
       redirect_to({:controller => 'iiif', :action => 'manifest', :id => sc_manifest.work_id, :only_path => false})
       return
-    end    
+    end
 
     if sc_canvas = ScCanvas.where(:sc_canvas_id => at_id).last
       redirect_to :controller => 'iiif', :action => 'canvas', :page_id => sc_canvas.page_id
       return
-    end    
-    
+    end
+
     render :status => 404, :text => "No items that correspond to #{at_id} have been imported into the FromThePage server.  For a full list of public IIIF resources, see #{url_for(:controller => 'iiif', :action => 'collections')}"
   end
-    
+
   def manifest
     work_id =  params[:id]
     work = Work.find work_id
-    seed = { 
-              '@id' => url_for({:controller => 'iiif', :action => 'manifest', :id => work_id, :only_path => false}), 
+    seed = {
+              '@id' => url_for({:controller => 'iiif', :action => 'manifest', :id => work_id, :only_path => false}),
               'label' => work.title
             }
     manifest = IIIF::Presentation::Manifest.new(seed)
@@ -64,16 +64,16 @@ class IiifController < ApplicationController
     sequence = iiif_sequence_from_work_id(work_id)
     manifest.sequences << sequence
 
-    seed = { 
-              '@id' => url_for({:controller => 'iiif', :id => work_id, :action => 'layer', :type => 'transcription', :only_path => false}), 
+    seed = {
+              '@id' => url_for({:controller => 'iiif', :id => work_id, :action => 'layer', :type => 'transcription', :only_path => false}),
               'label' => "transcription layer"
             }
     layer = IIIF::Presentation::Layer.new(seed)
     manifest["otherContent"] = [layer]
 
     if work.supports_translation?
-      seed = { 
-              '@id' => url_for({:controller => 'iiif', :id => work_id, :action => 'layer', :type => 'translation', :only_path => false}), 
+      seed = {
+              '@id' => url_for({:controller => 'iiif', :id => work_id, :action => 'layer', :type => 'translation', :only_path => false}),
               'label' => "translation layer"
             }
       layer = IIIF::Presentation::Layer.new(seed)
@@ -81,8 +81,8 @@ class IiifController < ApplicationController
     end
 
     if true #any notes
-      seed = { 
-              '@id' => url_for({:controller => 'iiif', :id => work_id, :action => 'layer', :type => 'notes', :only_path => false}), 
+      seed = {
+              '@id' => url_for({:controller => 'iiif', :id => work_id, :action => 'layer', :type => 'notes', :only_path => false}),
               'label' => "notes layer"
             }
       layer = IIIF::Presentation::Layer.new(seed)
@@ -93,13 +93,13 @@ class IiifController < ApplicationController
   end
 
   def canvas
-    if @page.sc_canvas 
+    if @page.sc_canvas
       render :text => canvas_from_iiif_page(@page).to_json(pretty: true), :content_type => "application/json"
     else
       render :text => canvas_from_page(@page).to_json(pretty: true), :content_type => "application/json"
     end
   end
-  
+
   def list
     type = params[:annotation_type]
     annotation_list = IIIF::Presentation::AnnotationList.new
@@ -117,8 +117,8 @@ class IiifController < ApplicationController
     work = Work.find work_id
     #params[:type]
     if params[:type]=="transcription"
-      seed = { 
-                '@id' => url_for({:controller => 'iiif', :id => work_id, :action => 'layer', :type => params[:type], :only_path => false}), 
+      seed = {
+                '@id' => url_for({:controller => 'iiif', :id => work_id, :action => 'layer', :type => params[:type], :only_path => false}),
                 'label' => params[:type] + " layer"
               }
       layer = IIIF::Presentation::Layer.new(seed)
@@ -130,10 +130,10 @@ class IiifController < ApplicationController
         end
       end
     end
-   
+
    if work.supports_translation? && params[:type]=="translation"
-      seed = { 
-              '@id' => url_for({:controller => 'iiif', :id => work_id, :action => 'layer', :type => 'translation', :only_path => false}), 
+      seed = {
+              '@id' => url_for({:controller => 'iiif', :id => work_id, :action => 'layer', :type => 'translation', :only_path => false}),
               'label' => "translation layer"
             }
       layer = IIIF::Presentation::Layer.new(seed)
@@ -147,8 +147,8 @@ class IiifController < ApplicationController
     end
 
    if params[:type]=="notes"
-      seed = { 
-                '@id' => url_for({:controller => 'iiif', :id => work_id, :action => 'layer', :type => params[:type], :only_path => false}), 
+      seed = {
+                '@id' => url_for({:controller => 'iiif', :id => work_id, :action => 'layer', :type => params[:type], :only_path => false}),
                 'label' => params[:type] + " layer"
               }
       layer = IIIF::Presentation::Layer.new(seed)
@@ -165,11 +165,11 @@ class IiifController < ApplicationController
 
     render :text => layer.to_json(pretty: true), :content_type => "application/json"
   end
-  
+
   def sequence
     work_id = @work.id
     sequence = iiif_sequence_from_work_id(work_id)
-    render :text => sequence.to_json(pretty: true), :content_type => "application/json" 
+    render :text => sequence.to_json(pretty: true), :content_type => "application/json"
   end
 
   def annotation
@@ -177,7 +177,7 @@ class IiifController < ApplicationController
     type = params[:annotation_type]
     annotation = iiif_annotation_by_type(page_id,type)
     annotation['@id'] = url_for({:controller => 'iiif', :action => 'annotation', :page_id => @page.id, :annotation_type => type, :only_path => false})
-    render :text => annotation.to_json(pretty: true), :content_type => "application/json" 
+    render :text => annotation.to_json(pretty: true), :content_type => "application/json"
   end
 
   def notes
@@ -198,8 +198,8 @@ class IiifController < ApplicationController
     page = Page.find params[:page_id]
     note = iiif_page_note(@page,noteid)
     note['@id'] = url_for({:controller => 'iiif', :action => 'note', :page_id => @page.id, :note_id => noteid, :only_path => false})
-    render :text => note.to_json(pretty: true), :content_type => "application/json"   
-  end    
+    render :text => note.to_json(pretty: true), :content_type => "application/json"
+  end
 
 private
   def iiif_page_note(page, noteid)
@@ -221,7 +221,7 @@ private
       annotation['on'] = region_from_page(@page)
       annotation.resource = IIIF::Presentation::Resource.new({'@id' => "plaintext_export_for_#{@page.id}", '@type' => "cnt:ContentAsText"})
       annotation.resource["format"] =  "text/plain"
-    
+
       doc = Nokogiri::XML(@page.xml_text.gsub(/<\/p>/, "</p>\n\n").gsub("<lb/>", "\n"))
       no_tags = doc.text
 
@@ -233,7 +233,7 @@ private
         annotation['on'] = region_from_page(@page)
         annotation.resource = IIIF::Presentation::Resource.new({'@id' => "translation_export_for_#{@page.id}", '@type' => "cnt:ContentAsText"})
         annotation.resource["format"] =  "text/plain"
-    
+
         doc = Nokogiri::XML(@page.xml_translation.gsub(/<\/p>/, "</p>\n\n").gsub("<lb/>", "\n"))
         no_tags = doc.text
 
@@ -253,7 +253,7 @@ private
   def iiif_image_annotation_from_work_id(work_id)
     annotation
   end
- 
+
   def iiif_sequence_from_work_id(work_id)
     sequence = IIIF::Presentation::Sequence.new
     sequence['@id'] = url_for({:controller => 'iiif', :action => 'sequence', :work_id => work_id, :sequence_name => 'default', :only_path => false})
@@ -261,12 +261,12 @@ private
     work = Work.includes(:pages => [:sc_canvas, :notes]).where(id: work_id).first
     pages = work.pages
     pages.each do |page|
-      if page.sc_canvas 
+      if page.sc_canvas
         sequence.canvases << canvas_from_iiif_page(page)
       else
         sequence.canvases << canvas_from_page(page)
       end
-    end   
+    end
     sequence
   end
 
@@ -281,43 +281,47 @@ private
     if collection.sc_collection
       iiif_collection.metadata = [{"label" => "dc:source", "value" => collection.sc_collection.at_id }]
     end
-  
-    if depth == true   
+
+    if depth == true
       collection.works.each do |work|
         unless work.ia_work
-          seed = { 
-                    '@id' => url_for({:controller => 'iiif', :action => 'manifest', :id => work.id, :only_path => false}), 
+          seed = {
+                    '@id' => url_for({:controller => 'iiif', :action => 'manifest', :id => work.id, :only_path => false}),
                     'label' => work.title
                 }
           manifest = IIIF::Presentation::Manifest.new(seed)
           manifest.label = work.title
-        
-          iiif_collection.manifests << manifest            
+
+          iiif_collection.manifests << manifest
         end
       end
     end
-    iiif_collection  
+    iiif_collection
   end
 
   def canvas_id_from_page(page)
     url_for({ :controller => 'iiif', :action => 'canvas', :page_id => page.id, :work_id => page.work.id, :only_path => false })
   end
-  
+
   def region_from_page(page)
-    canvas_id_from_page(page) + "#xywh=0,0,#{page.base_width},#{page.base_height}"  
+    if page.base_width.nil? && page.sc_canvas
+      canvas_id_from_page(page) + "#xywh=0,0,#{page.sc_canvas.width},#{page.sc_canvas.height}"
+    else
+      canvas_id_from_page(page) + "#xywh=0,0,#{page.base_width},#{page.base_height}"
+    end
   end
 
   def iiif_create_image_resource(page)
     image_resource = IIIF::Presentation::ImageResource.create_image_api_image_resource(
       {
-        :service_id => "#{url_for(:root)}image-service/#{page.id}", 
+        :service_id => "#{url_for(:root)}image-service/#{page.id}",
         :resource_id => "#{url_for(:root)}image-service/#{page.id}/full/full/0/native.jpg",
         :height => page.base_height,
         :width => page.base_width,
         :profile => 'http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2',
-                
+
        })
-       
+
     image_resource.service['@context'] = 'http://iiif.io/api/image/1/context.json'
     image_resource
   end
@@ -329,10 +333,10 @@ private
         :resource_id => page.sc_canvas.sc_resource_id,
         :height => (page.base_height || page.sc_canvas.height),
         :width => (page.base_width || page.sc_canvas.width),
-        :profile => 'http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2',      
+        :profile => 'http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2',
        })
     #image_resource.service_id = page.sc_canvas.sc_service_id
-    #image_resource.resource_id = page.sc_canvas.sc_resource_id  
+    #image_resource.resource_id = page.sc_canvas.sc_resource_id
     #image_resource.service['@context'] = 'http://iiif.io/api/image/1/context.json'
 
     image_resource.service['@context'] = page.sc_canvas.sc_service_context
@@ -348,10 +352,10 @@ private
     canvas['@id'] = canvas_id_from_page(page)
 
     annotation = IIIF::Presentation::Annotation.new
-    annotation.resource = iiif_create_iiif_image_resource(page)    
+    annotation.resource = iiif_create_iiif_image_resource(page)
     annotation['on'] = canvas['@id']
     annotation['@id'] = page.sc_canvas.sc_service_id
-    
+
     canvas.images << annotation
 
     unless page.source_text.blank?
@@ -371,8 +375,8 @@ private
       canvas.other_content << annotation_list
     end
 
-    canvas     
-  
+    canvas
+
   end
 
   def canvas_from_page(page)
@@ -381,7 +385,7 @@ private
     canvas.width = page.base_width
     canvas.height = page.base_height
     canvas['@id'] = canvas_id_from_page(page)
-    
+
     annotation = IIIF::Presentation::Annotation.new
     annotation.resource = iiif_create_image_resource(page)
     annotation['on'] = canvas['@id']
@@ -420,7 +424,7 @@ private
       annotation_list = IIIF::Presentation::AnnotationList.new
       annotation_list['@id'] = url_for({:controller => 'iiif', :action => 'list', :page_id => page.id, :annotation_type => type, :only_path => false})
     end
-  when 'translation' 
+  when 'translation'
     unless page.source_translation.blank?
       annotation_list = IIIF::Presentation::AnnotationList.new
       annotation_list['@id'] = url_for({:controller => 'iiif', :action => 'list', :page_id => page.id, :annotation_type => type, :only_path => false})
@@ -433,5 +437,5 @@ private
   end
     annotation_list
   end
-  
+
 end


### PR DESCRIPTION
As promised in #847: this PR uses the width and height dimensions from a `Page`'s linked `ScCanvas` if the page has no recorded dimensions. I first used `if/then/else` but later found a more concise way to do the same was already in use elsewhere in the file, hence two commits.

I apologise for the extra (automatic) edits that remove whitespace that make this commit bigger – the actual edit is on line 307.