### PR TITLE
#974 - updated authentication for iiif requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -193,6 +193,7 @@ class ApplicationController < ActionController::Base
     # skip irrelevant cases
     return unless @collection
     return unless @collection.restricted
+    return if (params[:controller] == 'iiif')
 
     unless @collection.show_to?(current_user)
       redirect_to dashboard_path


### PR DESCRIPTION
The request for the IIIF transcription was being redirected by the authentication.  This fixes that problem.  I don't think we have tests for the IIIF API, so other calls to it should be manually tested.