### PR TITLE
#1048 Changed trial registration wording

### DIFF
--- a/app/views/devise/registrations/new_trial.html.slim
+++ b/app/views/devise/registrations/new_trial.html.slim
@@ -5,7 +5,7 @@ section.signon
   p 
     'Please fill in the following information and 
     a href='https://calendly.com/fromthepage/30-minute-meeting/' schedule a kickoff call 
-    ' with us to create a two-hundred page trial FromThePage project owner account.
+    ' with us to create a two hundred page trial FromThePage project owner account.
 
 
   =form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|

--- a/app/views/devise/registrations/new_trial.html.slim
+++ b/app/views/devise/registrations/new_trial.html.slim
@@ -2,7 +2,10 @@
 
 section.signon
   h1 Sign Up for a Trial
-  p Please fill in the following information and schedule a kickoff call with us to create a two week trial FromThePage project owner account.
+  p 
+    'Please fill in the following information and 
+    a href='https://calendly.com/fromthepage/30-minute-meeting/' schedule a kickoff call 
+    ' with us to create a two-hundred page trial FromThePage project owner account.
 
 
   =form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|


### PR DESCRIPTION
#1048 Changed trial wording from 'two weeks' to 'two hundred pages'; added link to kickoff call