### PR TITLE
#958 Removed location field from user profile

### DIFF
--- a/app/views/user/profile.html.slim
+++ b/app/views/user/profile.html.slim
@@ -26,8 +26,6 @@
         span ="User since #{@user.created_at.strftime("%b %d, %Y")}"
         -if @user.last_sign_in_at.present?
           span ="Last seen #{@user.last_sign_in_at.strftime("%b %d, %Y")}"
-      -if @user.location.present?
-        p.big(data-prefix='Location:') =@user.location
 
   h2 Recent Activity by #{@user.display_name}
   -if @notes.present?

--- a/app/views/user/update_profile.html.slim
+++ b/app/views/user/update_profile.html.slim
@@ -21,12 +21,12 @@
           th =f.label :website
           td =f.text_field :website, :placeholder => 'Your blog or homepage'
         tr
+          th =f.label :location
+          td =f.text_field :location, :placeholder => 'Where are you from?'
+        tr
           td(colspan="2")
             =f.label :about, 'About you', class: 'above'
             =f.text_area :about, rows: 4
-        tr
-          th =f.label :location
-          td =f.text_field :location, :placeholder => 'Where are you from?'
       -else
         =f.hidden_field :website, value: "NOTOWNER"
         =f.hidden_field :about, value: "NOTOWNER"

--- a/app/views/user/update_profile.html.slim
+++ b/app/views/user/update_profile.html.slim
@@ -1,6 +1,7 @@
 .litebox-embed(style="width:550px")
   h1 Update User Profile
-  p Your name is the only required field here, but we would appreciate if you tell the FromThePage community a little bit more about yourself.
+  -if @user.owner
+    p Your name is the only required field.
 
   =form_for(@user, { :url => { :action => 'update' }}) do |f|
     =hidden_field_tag :user_id, @user.id

--- a/app/views/user/update_profile.html.slim
+++ b/app/views/user/update_profile.html.slim
@@ -23,12 +23,12 @@
           td(colspan="2")
             =f.label :about, 'About you', class: 'above'
             =f.text_area :about, rows: 4
+        tr
+          th =f.label :location
+          td =f.text_field :location, :placeholder => 'Where are you from?'
       -else
         =f.hidden_field :website, value: "NOTOWNER"
         =f.hidden_field :about, value: "NOTOWNER"
-      tr
-        th =f.label :location
-        td =f.text_field :location, :placeholder => 'Where are you from?'
 
     p.email_notifications Select which of the following notifications you want to receive:
     table.form.email_notifications


### PR DESCRIPTION
For Issue #958
* Removed `Location` from user profile view and update form
* Removed required fields note from user profile update (there's only one field)
* Retained `Location` for owner profile
* Retained required fields note for owners
