### PR TITLE
Truncate overlong titles imported from IA

### DIFF
--- a/app/models/ia_work.rb
+++ b/app/models/ia_work.rb
@@ -4,6 +4,12 @@ class IaWork < ActiveRecord::Base
   belongs_to :user
   belongs_to :work
   has_many :ia_leaves
+  
+  before_create :truncate_title
+
+  def truncate_title
+    self.title = self.title.truncate(255, :omission => "...")
+  end
 
   def display_page
     # blank status of raw ocr before displaying -- if the user hits save, status will become default


### PR DESCRIPTION
Fix for #1055 