### PR TITLE
Adds Lat/Lon option to categories

### DIFF
--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -256,8 +256,11 @@ end
 def gis_truncated?(params, dec)
   unless params[:latitude] || params[:longitude] then return false end
 
-  lat_dec = params[:latitude].split('.').last.length
-  long_dec = params[:longitude].split('.').last.length
+  lat = params[:latitude].split('.')
+  lon = params[:longitude].split('.')
 
-  if lat_dec > dec || long_dec > dec then return true else return false end
+  if lat.length == 2 then lat_dec = lat.last.length else lat_dec = 0 end
+  if lon.length == 2 then lon_dec = lon.last.length else lon_dec = 0 end
+
+  if lat_dec > dec || lon_dec > dec then return true else return false end
 end

--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -49,13 +49,12 @@ class ArticleController < ApplicationController
         end
         record_deed
         flash[:notice] = "Subject has been successfully updated"
-        redirect_to :action => 'edit', :article_id => @article.id
       end
     elsif params['autolink']
       @article.source_text = autolink(@article.source_text)
       flash[:notice] = "Subjects auto linking process completed"
-      render :action => 'edit'
     end
+    render :action => 'edit'
   end
 
   def article_category

--- a/app/controllers/category_controller.rb
+++ b/app/controllers/category_controller.rb
@@ -47,14 +47,24 @@ class CategoryController < ApplicationController
     @category.update_attribute(:gis_enabled, true)
     @category.descendants.each {|d| d.update_attribute(:gis_enabled, true)}
     
-    flash[:notice] = "GIS Enabled for #{@category.title}"
+    notice = "GIS Enabled for #{@category.title}"
+    if @category.descendants.count > 0
+      notice << " and #{@category.descendants.count} child categories"
+    end
+    
+    flash[:notice] = notice
     ajax_redirect_to collection_subjects_path(@collection.owner, @collection, {:anchor => "category-#{@category.id }"})
   end
   def disable_gis
     @category.update_attribute(:gis_enabled, false)
     @category.descendants.each {|d| d.update_attribute(:gis_enabled, false)}
     
-    flash[:notice] = "GIS Disabled for #{@category.title}"
+    notice = "GIS Disabled for #{@category.title}"
+    if @category.descendants.count > 0
+      notice << " and #{@category.descendants.count} child categories"
+    end
+    
+    flash[:notice] = notice
     ajax_redirect_to collection_subjects_path(@collection.owner, @collection, {:anchor => "category-#{@category.id }"})
   end
 end

--- a/app/controllers/category_controller.rb
+++ b/app/controllers/category_controller.rb
@@ -39,5 +39,14 @@ class CategoryController < ApplicationController
     flash[:notice] = "Category has been deleted"
     redirect_to "#{request.env['HTTP_REFERER']}#{anchor}"
   end
-
+  def enable_gis
+    @category.update_attribute(:gis_enabled, true)
+    flash[:notice] = "GIS Enabled for #{@category.title}"
+    ajax_redirect_to "#{request.env['HTTP_REFERER']}#category-#{@category.id}"
+  end
+  def disable_gis
+    @category.update_attribute(:gis_enabled, false)
+    flash[:notice] = "GIS Disabled for #{@category.title}"
+    ajax_redirect_to "#{request.env['HTTP_REFERER']}#category-#{@category.id}"
+  end
 end

--- a/app/controllers/category_controller.rb
+++ b/app/controllers/category_controller.rb
@@ -19,7 +19,10 @@ class CategoryController < ApplicationController
 
   def add_new
     @new_category = Category.new({ :collection_id => @collection.id })
-    @new_category.parent = @category if @category.present?
+    if @category.present?
+      @new_category.parent = @category 
+      @new_category.gis_enabled = @category.gis_enabled
+    end
   end
 
   def create

--- a/app/controllers/category_controller.rb
+++ b/app/controllers/category_controller.rb
@@ -11,7 +11,7 @@ class CategoryController < ApplicationController
   def update
     if @category.update_attributes(params[:category])
       flash[:notice] = "Category has been updated"
-      ajax_redirect_to "#{request.env['HTTP_REFERER']}#category-#{@category.id}"
+      ajax_redirect_to collection_subjects_path(@collection.owner, @collection, {:anchor => "category-#{@category.id }"})
     else
       render :action => 'edit'
     end
@@ -30,31 +30,31 @@ class CategoryController < ApplicationController
     @new_category.parent = Category.find(params[:category][:parent_id]) if params[:category][:parent_id].present?
     if @new_category.save
       flash[:notice] = "Category has been created"
-      ajax_redirect_to "#{request.env['HTTP_REFERER']}#category-#{@new_category.id}"
+      ajax_redirect_to collection_subjects_path(@collection.owner, @collection, {:anchor => "category-#{@new_category.id }"})
     else
       render :action => 'add_new'
     end
   end
 
   def delete
-    anchor = @category.parent_id.present? ? "#category-#{@category.parent_id}" : nil
+    anchor = @category.parent_id.present? ? "category-#{@category.parent_id}" : nil
     @category.destroy #_but_attach_children_to_parent
     
     flash[:notice] = "Category has been deleted"
-    redirect_to "#{request.env['HTTP_REFERER']}#{anchor}"
+    ajax_redirect_to collection_subjects_path(@collection.owner, @collection, {:anchor => anchor})
   end
   def enable_gis
     @category.update_attribute(:gis_enabled, true)
     @category.descendants.each {|d| d.update_attribute(:gis_enabled, true)}
     
     flash[:notice] = "GIS Enabled for #{@category.title}"
-    ajax_redirect_to "#{request.env['HTTP_REFERER']}#category-#{@category.id}"
+    ajax_redirect_to collection_subjects_path(@collection.owner, @collection, {:anchor => "category-#{@category.id }"})
   end
   def disable_gis
     @category.update_attribute(:gis_enabled, false)
     @category.descendants.each {|d| d.update_attribute(:gis_enabled, false)}
     
     flash[:notice] = "GIS Disabled for #{@category.title}"
-    ajax_redirect_to "#{request.env['HTTP_REFERER']}#category-#{@category.id}"
+    ajax_redirect_to collection_subjects_path(@collection.owner, @collection, {:anchor => "category-#{@category.id }"})
   end
 end

--- a/app/controllers/category_controller.rb
+++ b/app/controllers/category_controller.rb
@@ -47,9 +47,10 @@ class CategoryController < ApplicationController
     @category.update_attribute(:gis_enabled, true)
     @category.descendants.each {|d| d.update_attribute(:gis_enabled, true)}
     
-    notice = "GIS Enabled for #{@category.title}"
-    if @category.descendants.count > 0
-      notice << " and #{@category.descendants.count} child categories"
+    notice = "GIS enabled for #{@category.title}"
+    count = @category.descendants.count
+    if count > 0
+      notice << " and #{count} child " << "category".pluralize(count)
     end
     
     flash[:notice] = notice
@@ -59,9 +60,10 @@ class CategoryController < ApplicationController
     @category.update_attribute(:gis_enabled, false)
     @category.descendants.each {|d| d.update_attribute(:gis_enabled, false)}
     
-    notice = "GIS Disabled for #{@category.title}"
-    if @category.descendants.count > 0
-      notice << " and #{@category.descendants.count} child categories"
+    notice = "GIS disabled for #{@category.title}"
+    count = @category.descendants.count
+    if count > 0
+      notice << " and #{count} child " << "category".pluralize(count)
     end
     
     flash[:notice] = notice

--- a/app/controllers/category_controller.rb
+++ b/app/controllers/category_controller.rb
@@ -39,16 +39,21 @@ class CategoryController < ApplicationController
   def delete
     anchor = @category.parent_id.present? ? "#category-#{@category.parent_id}" : nil
     @category.destroy #_but_attach_children_to_parent
+    
     flash[:notice] = "Category has been deleted"
     redirect_to "#{request.env['HTTP_REFERER']}#{anchor}"
   end
   def enable_gis
     @category.update_attribute(:gis_enabled, true)
+    @category.descendants.each {|d| d.update_attribute(:gis_enabled, true)}
+    
     flash[:notice] = "GIS Enabled for #{@category.title}"
     ajax_redirect_to "#{request.env['HTTP_REFERER']}#category-#{@category.id}"
   end
   def disable_gis
     @category.update_attribute(:gis_enabled, false)
+    @category.descendants.each {|d| d.update_attribute(:gis_enabled, false)}
+    
     flash[:notice] = "GIS Disabled for #{@category.title}"
     ajax_redirect_to "#{request.env['HTTP_REFERER']}#category-#{@category.id}"
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -14,6 +14,10 @@ class Article < ActiveRecord::Base
 
   validates_presence_of :title
 
+  validates :latitude, allow_blank: true, numericality: { less_than_or_equal_to: 90, greater_than_or_equal_to: -90}
+  validates :longitude, allow_blank: true, numericality: { less_than_or_equal_to: 180, greater_than_or_equal_to: -180}
+
+
   has_and_belongs_to_many :categories, -> { uniq }
   belongs_to :collection
   has_many(:target_article_links, { :foreign_key => "target_article_id", :class_name => 'ArticleArticleLink'})
@@ -33,7 +37,7 @@ class Article < ActiveRecord::Base
 
   after_save :create_version
 
-  attr_accessible :title
+  attr_accessible :title, :latitude, :longitude
   attr_accessible :source_text
 
   def link_list

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -71,7 +71,7 @@ class Article < ActiveRecord::Base
   end
   
   def gis_enabled?
-    self.categories.any? { |c| c.gis_enabled }
+    self.categories.where(:gis_enabled => true).present?
   end
 
   #######################

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -69,6 +69,10 @@ class Article < ActiveRecord::Base
   def related_article_ranks
 
   end
+  
+  def gis_enabled?
+    self.categories.any? { |c| c.gis_enabled }
+  end
 
   #######################
   # De-Dup Support

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -37,7 +37,7 @@ class Article < ActiveRecord::Base
 
   after_save :create_version
 
-  attr_accessible :title, :latitude, :longitude
+  attr_accessible :title, :latitude, :longitude, :uri
   attr_accessible :source_text
 
   def link_list

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -4,7 +4,7 @@ class Category < ActiveRecord::Base
   acts_as_tree :order => 'title'
   belongs_to :collection
   has_and_belongs_to_many :articles, -> { order('title').uniq }
-  attr_accessible :collection_id, :title
+  attr_accessible :collection_id, :title, :gis_enabled
 
   validates :title, presence: true, uniqueness: { scope: [:collection_id, :parent_id] }
 

--- a/app/views/article/edit.html.slim
+++ b/app/views/article/edit.html.slim
@@ -9,6 +9,9 @@
         tr.big
           th =f.label :title
           td.w100 =f.text_field :title
+        tr.big
+          th =f.label :uri, "URI"
+          td.w100 =f.text_field :uri
         tr
           td.voice-div(colspan="2")
             =f.label :source_text, 'Description', class: 'above'
@@ -18,6 +21,8 @@
                 span.voice-info.article-voice
                 
               =f.text_area :source_text, rows: 15
+        
+
       -if @article.gis_enabled?
         table.form
           tr

--- a/app/views/article/edit.html.slim
+++ b/app/views/article/edit.html.slim
@@ -18,6 +18,14 @@
                 span.voice-info.article-voice
                 
               =f.text_area :source_text, rows: 15
+      -if @article.gis_enabled?
+        table.form
+          tr
+            th =f.label :latitude
+            th =f.label :longitude
+          tr
+            td.w50 =f.text_field :latitude
+            td.w50 =f.text_field :longitude
 
       -update_article_url = url_for({ :controller => 'article', :action => 'article_category', :article_id => @article.id })
 

--- a/app/views/article/edit.html.slim
+++ b/app/views/article/edit.html.slim
@@ -29,8 +29,8 @@
             th =f.label :latitude
             th =f.label :longitude
           tr
-            td.w50 =f.text_field :latitude
-            td.w50 =f.text_field :longitude
+            td.w50 =f.text_field :latitude, :value => (number_with_precision(f.object.latitude, :precision => 5))
+            td.w50 =f.text_field :longitude, :value => (number_with_precision(f.object.longitude, :precision => 5))
 
       -update_article_url = url_for({ :controller => 'article', :action => 'article_category', :article_id => @article.id })
 

--- a/app/views/article/list.html.slim
+++ b/app/views/article/list.html.slim
@@ -31,7 +31,7 @@
                       span Actions
                       =svg_symbol '#big-menu', class: 'icon icon-big'
                     dd
-                      =link_to 'Rename Category', { :controller => 'category', :action => 'edit', :collection_id => @collection.id, :category_id => category.id }, 'data-litebox' => ''
+                      =link_to 'Edit Category', { :controller => 'category', :action => 'edit', :collection_id => @collection.id, :category_id => category.id }, 'data-litebox' => ''
                       =link_to 'Add Child Category', { :controller => 'category', :action => 'add_new', :collection_id => @collection.id, :category_id => category.id }, 'data-litebox' => ''
                       =link_to 'Add Root Category', { :controller => 'category', :action => 'add_new', :collection_id => @collection.id }, 'data-litebox' => ''
                       -if category.gis_enabled

--- a/app/views/article/list.html.slim
+++ b/app/views/article/list.html.slim
@@ -34,6 +34,10 @@
                       =link_to 'Rename Category', { :controller => 'category', :action => 'edit', :collection_id => @collection.id, :category_id => category.id }, 'data-litebox' => ''
                       =link_to 'Add Child Category', { :controller => 'category', :action => 'add_new', :collection_id => @collection.id, :category_id => category.id }, 'data-litebox' => ''
                       =link_to 'Add Root Category', { :controller => 'category', :action => 'add_new', :collection_id => @collection.id }, 'data-litebox' => ''
+                      -if category.gis_enabled
+                        =link_to 'Disable GIS for Category', { :controller => 'category', :action => 'disable_gis', :collection_id => @collection.id, :category_id => category.id }
+                      -else
+                        =link_to 'Enable GIS for Category', { :controller => 'category', :action => 'enable_gis', :collection_id => @collection.id, :category_id => category.id }
                       hr
                       =link_to 'Delete Category', { :controller => 'category', :action => 'delete', :collection_id => @collection.id, :category_id => category.id }, class: 'fgred', data: { :confirm => 'Are you sure you want to delete this category and all its subcategories? After deleting you won\'t be able to recover it!' }
           dd

--- a/app/views/category/add_new.html.slim
+++ b/app/views/category/add_new.html.slim
@@ -10,6 +10,9 @@
       tr.big
         th =f.label :title
         td.w100 =f.text_field :title
+      tr
+        th =f.label :gis_enabled, "Enable GIS"
+        td =f.check_box :gis_enabled
 
     .toolbar
       .toolbar_group.aright =f.button 'Create Category'

--- a/app/views/category/edit.html.slim
+++ b/app/views/category/edit.html.slim
@@ -8,6 +8,8 @@
       tr.big
         th =f.label :title
         td.w100 =f.text_field :title
-
+      tr
+        th =f.label :gis_enabled, "Enable GIS"
+        td =f.check_box :gis_enabled
     .toolbar
       .toolbar_group.aright =f.button 'Save Changes'

--- a/app/views/category/edit.html.slim
+++ b/app/views/category/edit.html.slim
@@ -1,5 +1,5 @@
 .litebox-embed(style="width:450px")
-  h1 Rename Category
+  h1 Edit Category
 
   =form_for(@category, :url => { :action => 'update' }) do |f|
     =hidden_field_tag(:category_id, @category.id)

--- a/app/views/category/edit.html.slim
+++ b/app/views/category/edit.html.slim
@@ -3,6 +3,8 @@
 
   =form_for(@category, :url => { :action => 'update' }) do |f|
     =hidden_field_tag(:category_id, @category.id)
+    =hidden_field_tag(:collection_id, @collection.id)
+    =f.hidden_field(:collection_id)
     =validation_summary @category.errors
     table.form
       tr.big

--- a/db/migrate/20180516132442_add_article_lat_long.rb
+++ b/db/migrate/20180516132442_add_article_lat_long.rb
@@ -1,6 +1,6 @@
 class AddArticleLatLong < ActiveRecord::Migration
   def change
-    add_column :articles, :latitude, :decimal, :precision => 10, :scale => 8, :default => nil
-    add_column :articles, :longitude, :decimal, :precision => 11, :scale => 8, :default => nil
+    add_column :articles, :latitude, :decimal, :precision => 7, :scale => 5, :default => nil
+    add_column :articles, :longitude, :decimal, :precision => 8, :scale => 5, :default => nil
   end
 end

--- a/db/migrate/20180516132442_add_article_lat_long.rb
+++ b/db/migrate/20180516132442_add_article_lat_long.rb
@@ -1,0 +1,6 @@
+class AddArticleLatLong < ActiveRecord::Migration
+  def change
+    add_column :articles, :latitude, :decimal, :precision => 10, :scale => 8, :default => nil
+    add_column :articles, :longitude, :decimal, :precision => 11, :scale => 8, :default => nil
+  end
+end

--- a/db/migrate/20180516133319_add_categories_gis_enabled.rb
+++ b/db/migrate/20180516133319_add_categories_gis_enabled.rb
@@ -1,0 +1,5 @@
+class AddCategoriesGisEnabled < ActiveRecord::Migration
+  def change
+    add_column :categories, :gis_enabled, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20180517150605_add_article_uri.rb
+++ b/db/migrate/20180517150605_add_article_uri.rb
@@ -1,0 +1,5 @@
+class AddArticleUri < ActiveRecord::Migration
+  def change
+    add_column :articles, :uri, :string
+  end
+end

--- a/spec/features/linking_spec.rb
+++ b/spec/features/linking_spec.rb
@@ -44,6 +44,23 @@ describe "subject linking" do
     expect(page).to have_content("This is the text about my article.")
   end
 
+  it "conditionally displays GIS fields on subject" do 
+    article = Article.first
+    category = article.categories.first
+    category_hash = "#category-" + "#{category.id}"
+    
+    visit "/article/show?article_id=#{article.id}"
+    page.find('.tabs').click_link('Settings')
+    expect(page).not_to have_content("Latitude")
+    
+    category.gis_enabled = true
+    category.save
+
+    visit "/article/show?article_id=#{article.id}"
+    page.find('.tabs').click_link('Settings')
+    expect(page).to have_content("Latitude")
+  end
+
   it "deletes a subject" do
     logout(:user)
     login_as(@owner, :scope => :user)

--- a/spec/features/owner_actions_spec.rb
+++ b/spec/features/owner_actions_spec.rb
@@ -122,10 +122,13 @@ describe "owner actions", :order => :defined do
   end
 
   it "enables GIS for subject category" do
-    cat = @collection.categories.find_by(title: "Places")
+    category = @collection.categories.find_by(title: "Places")
+    category.gis_enabled = false
+    category.save
+
     visit collection_path(@collection.owner, @collection)
     page.find('.tabs').click_link("Subjects")
-    @name = "#category-" + "#{cat.id}"
+    @name = "#category-" + "#{category.id}"
     page.find(@name).find('a', text: 'Enable GIS').click
     expect(page.find('.flash_message')).to have_content("GIS enabled for Places")
     page.find(@name).find('a', text: 'Add Child Category').click

--- a/spec/features/owner_actions_spec.rb
+++ b/spec/features/owner_actions_spec.rb
@@ -94,7 +94,7 @@ describe "owner actions", :order => :defined do
     Collection.last.destroy
   end
 
-  it "creates a subject" do
+  it "creates a subject category" do
     @count = @collection.categories.count
     cat = @collection.categories.find_by(title: "People")
     visit collection_path(@collection.owner, @collection)
@@ -108,7 +108,7 @@ describe "owner actions", :order => :defined do
     expect(page).to have_content("New Test Category")
   end
 
-  it "deletes a subject" do
+  it "deletes a subject category" do
     @count = @collection.categories.count
     cat = @collection.categories.find_by(title: "New Test Category")
     visit collection_path(@collection.owner, @collection)
@@ -119,6 +119,25 @@ describe "owner actions", :order => :defined do
     expect(@count - 1).to eq (@collection.categories.count)
     visit "/article/list?collection_id=#{@collection.id}"
     expect(page).not_to have_content("New Test Category")
+  end
+
+  it "enables GIS for subject category" do
+    cat = @collection.categories.find_by(title: "Places")
+    visit collection_path(@collection.owner, @collection)
+    page.find('.tabs').click_link("Subjects")
+    @name = "#category-" + "#{cat.id}"
+    page.find(@name).find('a', text: 'Enable GIS').click
+    expect(page.find('.flash_message')).to have_content("GIS enabled for Places")
+    page.find(@name).find('a', text: 'Add Child Category').click
+    fill_in 'category_title', with: 'Child GIS'
+    click_button('Create Category')
+    page.find(@name).find('a', text: 'Disable GIS').click
+    expect(page.find('.flash_message')).to have_content("GIS disabled for Places and 1 child category")
+    page.find(@name).find('a', text: 'Add Child Category').click
+    fill_in 'category_title', with: 'Child GIS-2'
+    click_button('Create Category')
+    page.find(@name).find('a', text: 'Enable GIS').click
+    expect(page.find('.flash_message')).to have_content("GIS enabled for Places and 2 child categories")
   end
 
   it "fails to create an empty work" do


### PR DESCRIPTION
Issue #1061
  * Adds Lat/Lon to subject/article table
    * `DECIMAL` type to allow for specific decimal precision
    * Lat: validates between -90/90; Lon validates to -180/180; null allowed
    * Includes `gis_enabled?` method to determine if any related categories are GIS enabled
    * Conditionally displays Lat/Lon fields on subject/edit view based on `gis_enabled?`
    * Fixed form validation error on subject/edit form
  * Adds `gis_enabled` to category
    * Defaults to `false`
    * Enabling/Disabling GIS through "actions" menu affects all descendant nodes in tree
    * Changed "rename category" to "edit category" and added "Enable GIS" setting
    * Added "Enable GIS" to create category form
  * Adds URI field to all subjects