### PR TITLE
Add context to `assign_categories` view

### DIFF
--- a/app/assets/stylesheets/base/global.scss
+++ b/app/assets/stylesheets/base/global.scss
@@ -129,6 +129,10 @@ code {
   box-shadow: inset 0 0 0 1px rgba(#000, 0.08);
 }
 
+mark {
+  font-weight: bold;
+  text-decoration: underline;
+}
 
 .tabular {
   table {

--- a/app/views/transcribe/assign_categories.html.slim
+++ b/app/views/transcribe/assign_categories.html.slim
@@ -13,6 +13,7 @@ p.big You have uncategorized subjects mentioned in the page transcription. Pleas
     -update_article_url = url_for({ :controller => 'article', :action => 'article_category', :article_id => article.id })
     .page-uncategorized
       h4.page-uncategorized_subject(data-prefix="Subject: " *language_attrs(@collection)) =="&ldquo;#{article.title}&rdquo;"
+      code= highlight(excerpt(@page.source_text, article.title, separator: ' ', radius: 6), article.title)
       select(data-assign-categories="#{update_article_url}" size="1" aria-label="Assign categories" multiple)
         -@collection.categories.walk_tree do |c, level|
           -selected = true if article.categories.include?(c)


### PR DESCRIPTION
#1073 
I wasn't expecting this one to be a one-liner! Here's what it looks like:

![image](https://user-images.githubusercontent.com/1544859/40436147-f75b5b64-5e77-11e8-8e65-c90a61a3c463.png)

A couple things:

- I feel like using the `page.source_text` content makes for a rather busy display (showing other sets of brackets, etc.), but because we are matching on the `article.title` we can't use `page.search_text`, since the titles don't always match the display text. Also, I suppose it actually is useful to include both the canonical subject title as well as the displayed text so the user can see what s/he is linking.
- Since the context goes forward and backward, I went ahead and put it on its own line. I tried to strike a balance between being able to quickly identify the word in the context (by highlighting it), and trying to keep it from dominating the page (mono-font, not too big, etc.)

If we aren't happy with this, an alternative to giving the context for each subject might be to show the whole page (like the "preview") off to the right, then on the front-end doing a hover/highlight to show the context. So, for example, show the whole page on the right (like in the preview) but, when you hover over each of the unique terms that we are categorizing on the left, the terms as they appear in the page would highlight. Does that make sense?