### PR TITLE
Internet Archive imported works now support IIIF API

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -212,6 +212,8 @@ class IiifController < ApplicationController
   def canvas
     if @page.sc_canvas
       render :text => canvas_from_iiif_page(@page).to_json(pretty: true), :content_type => "application/json"
+    elsif @page.ia_leaf
+      render :text => canvas_from_ia_page(@page).to_json(pretty: true), :content_type => "application/json"
     else
       render :text => canvas_from_page(@page).to_json(pretty: true), :content_type => "application/json"
     end
@@ -401,6 +403,8 @@ private
     pages.each do |page|
       if page.sc_canvas
         sequence.canvases << canvas_from_iiif_page(page)
+      elsif page.ia_leaf
+        sequence.canvases << canvas_from_ia_page(page)        
       else
         sequence.canvases << canvas_from_page(page)
       end
@@ -422,19 +426,17 @@ private
 
     if depth == true
       collection.works.each do |work|
-        unless work.ia_work
-          seed = {
-                    '@id' => url_for({:controller => 'iiif', :action => 'manifest', :id => work.id, :only_path => false}),
-                    'label' => work.title
-                }
-          manifest = IIIF::Presentation::Manifest.new(seed)
-          manifest.label = work.title
-          dc_source = dc_source_from_work(work)
-          manifest.metadata = [dc_source] if dc_source
-          manifest.service = status_service_for_manifest(work)
-        
-          iiif_collection.manifests << manifest            
-        end
+        seed = {
+                  '@id' => url_for({:controller => 'iiif', :action => 'manifest', :id => work.id, :only_path => false}),
+                  'label' => work.title
+              }
+        manifest = IIIF::Presentation::Manifest.new(seed)
+        manifest.label = work.title
+        dc_source = dc_source_from_work(work)
+        manifest.metadata = [dc_source] if dc_source
+        manifest.service = status_service_for_manifest(work)
+      
+        iiif_collection.manifests << manifest            
       end
     end
     iiif_collection
@@ -442,16 +444,18 @@ private
 
   def dc_source_from_work(work)
     dc_source = nil
-    if !work.identifier.blank? || work.sc_manifest
+    if !work.identifier.blank? || work.sc_manifest || work.ia_work
       dc_source = {"label" => "dc:source"}
-      if work.identifier && work.sc_manifest
-        dc_source["value"] = [work.identifier, work.sc_manifest.at_id]
+      value = []
+      value << work.identifier          if work.identifier
+      value << work.sc_manifest.at_id   if work.sc_manifest
+      value << work.ia_work.book_id     if work.ia_work
+      value << manifest_uri_from_ia(work.ia_work) if work.ia_work
+      
+      if value.length == 1
+        dc_source["value"] = value.first
       else
-        if work.sc_manifest
-          dc_source["value"] = work.sc_manifest.at_id
-        else
-          dc_source["value"] = work.identifier
-        end
+        dc_source["value"] = value
       end
     end
     dc_source
@@ -460,9 +464,15 @@ private
   def canvas_id_from_page(page)
     if page.sc_canvas
       page.sc_canvas.sc_canvas_id
+    elsif page.ia_leaf
+      "http://iiif.archivelab.org/iiif/#{page.work.ia_work.book_id}$#{page.ia_leaf.leaf_num}/canvas"
     else
       url_for({ :controller => 'iiif', :action => 'canvas', :page_id => page.id, :work_id => page.work.id, :only_path => false })
     end
+  end
+
+  def manifest_uri_from_ia(ia_work)
+    "http://iiif.archivelab.org/iiif/#{ia_work.book_id}/manifest.json"
   end
 
   def region_from_page(page)
@@ -502,7 +512,6 @@ private
   end
 
   def canvas_from_iiif_page(page)
-
     canvas = IIIF::Presentation::Canvas.new
     canvas.label = page.title
     canvas.width = page.sc_canvas.width
@@ -513,6 +522,41 @@ private
     annotation.resource = iiif_create_iiif_image_resource(page)
     annotation['on'] = canvas['@id']
     annotation['@id'] = page.sc_canvas.sc_service_id
+
+    canvas.images << annotation
+
+    add_related_to_canvas(canvas, page)
+    add_seeAlso_to_canvas(canvas, page)
+    add_services_to_canvas(canvas, page)
+    add_annotations_to_canvas(canvas, page)
+
+    canvas     
+  end
+
+  def canvas_from_ia_page(page)
+    id_base = "http://iiif.archivelab.org/iiif/#{page.work.ia_work.book_id}$#{page.ia_leaf.leaf_number}"
+
+    canvas = IIIF::Presentation::Canvas.new
+    canvas.label = page.title
+    canvas.width = page.base_width
+    canvas.height = page.base_height
+    canvas['@id'] = "#{id_base}/canvas"
+
+    image_resource = IIIF::Presentation::ImageResource.create_image_api_image_resource(
+      {
+        :service_id => id_base,
+        :resource_id => "#{id_base}/full/full/0/default.jpg",
+        :height => page.base_height,
+        :width => page.base_width,
+        :profile => 'http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2',
+       })
+
+    image_resource.service['@context'] = "http://iiif.io/api/image/2/context.json"
+
+    annotation = IIIF::Presentation::Annotation.new
+    annotation.resource = image_resource
+    annotation['on'] = canvas['@id']
+    annotation['@id'] = "#{id_base}/annotation"
 
     canvas.images << annotation
 


### PR DESCRIPTION
Since the IIIF server API was built before the Internet Archive supported IIIF
it did not expose any Internet Archive content.  Now it re-presents IIIF canvases
and works, so an IA work can be imported into FromThePage, transcribed, and
then viewed in IIIF clients like Mirador.