### PR TITLE
Hyphenation for #1090

### DIFF
--- a/app/helpers/abstract_xml_helper.rb
+++ b/app/helpers/abstract_xml_helper.rb
@@ -40,16 +40,21 @@ module AbstractXmlHelper
     doc.elements.delete_all("//table//lb")
     # convert line breaks to br or nothing, depending
     doc.elements.each("//lb") do |e|
+      lb = REXML::Element.new('span')
+      lb.add_text("")
+      lb.add_attribute('class', 'line-break')
+
       if preserve_lb
-        e.replace_with(REXML::Element.new('br'))
+        if e.attributes['break'] == "no"
+          lb.add_text('-')
+        end
+        lb.add_element(REXML::Element.new('br'))
       else
-        lb = REXML::Element.new('span')
         unless e.attributes['break']=="no"
           lb.add_text(' ')
         end
-        lb.add_attribute('class', 'line-break')
-        e.replace_with(lb)
       end
+      e.replace_with(lb)
     end
 
     doc.elements.each("//entryHeading") do |e|

--- a/app/models/xml_source_processor.rb
+++ b/app/models/xml_source_processor.rb
@@ -306,13 +306,13 @@ module XmlSourceProcessor
   # transformations converting source mode transcription to xml
   def process_line_breaks(text)
     text="<p>#{text}</p>"
-    text = text.gsub(/\n\s*\n/, "</p><p>")
-    text = text.gsub(/-\r\n/, '<lb break="no" />')
-    text = text.gsub(/\r\n/, "<lb/>")
-    text = text.gsub(/-\n/, '<lb break="no" />')
-    text = text.gsub(/\n/, "<lb/>")
-    text = text.gsub(/-\r/, '<lb break="no" />')
-    text = text.gsub(/\r/, "<lb/>")
+    text = text.gsub(/\s*\n\s*\n\s*/, "</p><p>")
+    text = text.gsub(/-\r\n\s*/, '<lb break="no" />')
+    text = text.gsub(/\r\n\s*/, "<lb/>")
+    text = text.gsub(/-\n\s*/, '<lb break="no" />')
+    text = text.gsub(/\n\s*/, "<lb/>")
+    text = text.gsub(/-\r\s*/, '<lb break="no" />')
+    text = text.gsub(/\r\s*/, "<lb/>")
     return text
   end
 


### PR DESCRIPTION
This fixes the hyphenation display problems described in #1090.

Adding the hyphen to views where the `lb` was significant was fairly straightforward, but I did end up changing the semantics of the outputted HTML. The original code used `Element.new('span')` and replaced the self-closing `<lb />` tags. for whatever reason, REXML replaced those line breaks with "self-closing `span`s" which, of course, aren't a thing. As a result, the browser was closing these tags automatically, which ended up making the new `span`s nested. Adding the text `''` to the span element forced the closing tag. More importantly, the hyphen itself is contained within `span.linebreak` as well as the `<br />`. Again, the semantics are a little weird, but I think this is an OK way of doing things. In the cases where linebreaks aren't significant, the `span.linebreak` still exists, but it's empty.

I also ended up having to tweak the `xml_source_processor` a bit. For whatever reason, there was extra whitespace after the `<lb>` elements, so I added `\s*` in a few places to try and strip them out.
