### PR TITLE
Update mysql2 gemspec to be ~> 0.3.0, update mysql2 gem to 0.3.21

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'capistrano-bundler', '~> 1.1.2'
 gem 'rvm1-capistrano3', require: false
 gem 'jquery-rails'
 gem 'savon', '~> 2.12.0'
-gem 'mysql2','0.3.16'
+gem 'mysql2', '~> 0.3.0'
 
 gem 'recaptcha', '0.3.6'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,7 +172,7 @@ GEM
     minitest (5.11.3)
     multi_json (1.13.1)
     multipart-post (2.0.0)
-    mysql2 (0.3.16)
+    mysql2 (0.3.21)
     net-http-persistent (2.9.4)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -372,7 +372,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   meta_request
-  mysql2 (= 0.3.16)
+  mysql2 (~> 0.3.0)
   nokogiri (~> 1.8.1)
   oai!
   omeka_client!
@@ -398,4 +398,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.12.5
+   1.16.2


### PR DESCRIPTION
Without this, I kept getting the fatal error `uninitialized constant Mysql2::Client::SECURE_CONNECTION (NameError)` on startup, regardless of whether I was using MySQL 5.6 or 5.7 (see https://github.com/brianmario/mysql2/issues/603).

See also #349. Previous PR #807 said the `mysql2` gem was updated but it doesn't appear to have been. I don't seem to need the `tzinfo-data` gem if I install/configure the Ubuntu `tzdata` package inside my Docker image.