### PR TITLE
Expanded subject categorization context to three lines

### DIFF
--- a/app/views/transcribe/assign_categories.html.slim
+++ b/app/views/transcribe/assign_categories.html.slim
@@ -13,7 +13,7 @@ p.big You have uncategorized subjects mentioned in the page transcription. Pleas
     -update_article_url = url_for({ :controller => 'article', :action => 'article_category', :article_id => article.id })
     .page-uncategorized
       h4.page-uncategorized_subject(data-prefix="Subject: " *language_attrs(@collection)) =="&ldquo;#{article.title}&rdquo;"
-      code= highlight(excerpt(@page.source_text, article.title, separator: ' ', radius: 6), article.title)
+      code= highlight(excerpt(@page.source_text.gsub("\n", "<br />"), article.title, separator: "<br />", radius: 3), article.title)
       select(data-assign-categories="#{update_article_url}" size="1" aria-label="Assign categories" multiple)
         -@collection.categories.walk_tree do |c, level|
           -selected = true if article.categories.include?(c)

--- a/gemfiles/Gemfile.mysql57
+++ b/gemfiles/Gemfile.mysql57
@@ -66,7 +66,7 @@ end
 gem 'sass-rails', '~> 5.0.0'
 
 # Use Autoprefixer for vendor prefixes
-gem 'autoprefixer-rails'
+gem 'autoprefixer-rails', '~>8'
 
 # Use Slim for templates
 gem 'slim', '~> 3.0.0'


### PR DESCRIPTION
Makes context three lines. See the discussion on #1073.

![image](https://user-images.githubusercontent.com/1544859/42824364-55bb966c-89a5-11e8-97e3-9f912a6227b3.png)

I had to replace `\n` with `<br />` because `.excerpt()` strips newlines.