### PR TITLE
Specified and fixed Gem versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'capistrano-bundler', '~> 1.1.2'
 gem 'rvm1-capistrano3', require: false
 gem 'jquery-rails'
 gem 'savon', '~> 2.12.0'
-gem 'mysql2','0.3.16'
+gem 'mysql2','0.3.21'
 
 gem 'recaptcha', '0.3.6'
 
@@ -66,7 +66,7 @@ end
 gem 'sass-rails', '~> 5.0.0'
 
 # Use Autoprefixer for vendor prefixes
-gem 'autoprefixer-rails'
+gem 'autoprefixer-rails', '~>8'
 
 # Use Slim for templates
 gem 'slim', '~> 3.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
       gyoku (>= 0.4.0)
       nokogiri
     arel (5.0.1.20140414130214)
-    autoprefixer-rails (8.0.0)
+    autoprefixer-rails (8.6.5)
       execjs
     bcrypt (3.1.11)
     browser (2.5.2)
@@ -172,7 +172,7 @@ GEM
     minitest (5.11.3)
     multi_json (1.13.1)
     multipart-post (2.0.0)
-    mysql2 (0.3.16)
+    mysql2 (0.3.21)
     net-http-persistent (2.9.4)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -354,7 +354,7 @@ DEPENDENCIES
   acts_as_list
   acts_as_tree
   ahoy_matey
-  autoprefixer-rails
+  autoprefixer-rails (~> 8)
   capistrano (~> 3.4.0)
   capistrano-bundler (~> 1.1.2)
   capistrano-rails (= 1.1.3)
@@ -372,7 +372,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   meta_request
-  mysql2 (= 0.3.16)
+  mysql2 (= 0.3.21)
   nokogiri (~> 1.8.1)
   oai!
   omeka_client!
@@ -398,4 +398,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.12.5
+   1.16.2

--- a/gemfiles/Gemfile.mysql57
+++ b/gemfiles/Gemfile.mysql57
@@ -66,7 +66,7 @@ end
 gem 'sass-rails', '~> 5.0.0'
 
 # Use Autoprefixer for vendor prefixes
-gem 'autoprefixer-rails'
+gem 'autoprefixer-rails', '~>8'
 
 # Use Slim for templates
 gem 'slim', '~> 3.0.0'


### PR DESCRIPTION
Specified `autoprefixer` to the latest 8-dot version in both the main `Gemfile` (and `.lock`) and the `mysql57` `Gemfile`.

I also updated the `mysql2` gem in the main `Gemfile`. Turns out, it had been updated in the other one. This should also take care of #1115 