### PR TITLE
Include host in IDs for related items in IIIF

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -135,12 +135,12 @@ class IiifController < ApplicationController
       {
         "format" => "text/html",
         "label" => "Read #{work.title}",
-        "@id" => collection_read_work_path(work.collection.owner, work.collection, work)
+        "@id" => collection_read_work_path(work.collection.owner, work.collection, work, :only_path => false)
       },
       {
         "format" => "text/html",
         "label" => "Table of Contents for #{work.title}",
-        "@id" => collection_work_contents_path(work.collection.owner, work.collection, work)
+        "@id" => collection_work_contents_path(work.collection.owner, work.collection, work, :only_path => false)
       }
     ]
     

--- a/gemfiles/Gemfile.mysql57
+++ b/gemfiles/Gemfile.mysql57
@@ -66,7 +66,7 @@ end
 gem 'sass-rails', '~> 5.0.0'
 
 # Use Autoprefixer for vendor prefixes
-gem 'autoprefixer-rails'
+gem 'autoprefixer-rails', '<= 8.6.5'
 
 # Use Slim for templates
 gem 'slim', '~> 3.0.0'


### PR DESCRIPTION
Following the logic in adding links to `seeAlso` for Manifests, I appended `, :only_path => false` to the calls for URLs for `related`. This should fix #1030.