### PR TITLE
Set oa:commenting as motivation for notes

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -335,7 +335,7 @@ class IiifController < ApplicationController
 
 private
   def iiif_page_note(page, noteid)
-    note = IIIF::Presentation::Annotation.new
+    note = IIIF::Presentation::Annotation.new({'motivation' => 'oa:commenting'})
     #note['@id'] = url_for({:controller => 'iiif', :action => 'note', :page_id => @page.id, :note_id => noteid, :only_path => false})
     note['on'] = region_from_page(@page)
     note.resource = IIIF::Presentation::Resource.new({'@id' => "note_#{noteid}_for_#{@page.id}", '@type' => "cnt:ContentAsText"})

--- a/gemfiles/Gemfile.mysql57
+++ b/gemfiles/Gemfile.mysql57
@@ -66,7 +66,7 @@ end
 gem 'sass-rails', '~> 5.0.0'
 
 # Use Autoprefixer for vendor prefixes
-gem 'autoprefixer-rails'
+gem 'autoprefixer-rails', '<= 8.6.5'
 
 # Use Slim for templates
 gem 'slim', '~> 3.0.0'


### PR DESCRIPTION
This fixes #1123 by giving `oa:commenting` as `motivation` to the Osullivan library when a new Annotation is created. (This overrides the default value `sc:painting`.)