### PR TITLE
Set default collection orientation

### DIFF
--- a/app/controllers/transcribe_controller.rb
+++ b/app/controllers/transcribe_controller.rb
@@ -19,8 +19,7 @@ class TranscribeController  < ApplicationController
   def display_page
     @collection = page.collection unless @collection
     @auto_fullscreen = cookies[:auto_fullscreen] || 'no';
-    default = @collection.field_based ? 'ttb' : 'ltr'
-    @layout_mode = cookies[:transcribe_layout_mode] || default;
+    @layout_mode = cookies[:transcribe_layout_mode] || @collection.default_orientation
     session[:col_id] = @collection.slug
   end
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -17,7 +17,7 @@ class Collection < ActiveRecord::Base
   belongs_to :owner, :class_name => 'User', :foreign_key => 'owner_user_id'
   has_and_belongs_to_many :owners, :class_name => 'User', :join_table => :collection_owners
   has_and_belongs_to_many :collaborators, :class_name => 'User', :join_table => :collection_collaborators
-  attr_accessible :title, :intro_block, :footer_block, :picture, :subjects_disabled, :transcription_conventions, :slug, :review_workflow, :hide_completed, :help, :link_help, :voice_recognition, :language, :text_language, :pct_completed
+  attr_accessible :title, :intro_block, :footer_block, :picture, :subjects_disabled, :transcription_conventions, :slug, :review_workflow, :hide_completed, :help, :link_help, :voice_recognition, :language, :text_language, :pct_completed, :default_orientation
 #  attr_accessor :picture
 
   validates :title, presence: true, length: { minimum: 3, maximum: 255 }
@@ -140,6 +140,16 @@ class Collection < ActiveRecord::Base
 
   def sections
     Section.where(work_id: self.works.ids)
+  end
+
+  def default_orientation
+    if !self[:default_orientation].nil?
+      self[:default_orientation]
+    elsif self[:field_based]
+      'ttb'
+    else
+      'ltr'
+    end
   end
 
   #constant

--- a/app/models/document_set.rb
+++ b/app/models/document_set.rb
@@ -126,5 +126,14 @@ class DocumentSet < ActiveRecord::Base
   def self.search(search)
     where("title LIKE ? OR slug LIKE ?", "%#{search}%", "%#{search}%")
   end
-
+  
+  def default_orientation
+    if !self[:default_orientation].nil?
+      self[:default_orientation]
+    elsif self[:field_based]
+      'ttb'
+    else
+      'ltr'
+    end
+  end
 end

--- a/app/views/collection/edit.html.slim
+++ b/app/views/collection/edit.html.slim
@@ -53,6 +53,11 @@
           td(colspan="2")
             =f.label :text_language, "Select the language of the transcription text", class: 'collection-label'
             =f.select :text_language, options_for_select(@text_languages, (@collection.text_language ? @collection.text_language : 'eng')), {}, {class: 'w50'}
+        
+        tr
+          td(colspan="2")
+            =f.label :default_orientation, "Select the default page transcription orientation"
+            =f.select :default_orientation, options_for_select([['Page on the Left','ltr'],['Page on the Right','rtl'],['Page on the Top','ttb'],['Page on the Bottom','btt']], @collection.default_orientation), {}, {class: 'w50'}
 
         -if @ssl && !@collection.field_based
           tr

--- a/db/migrate/20180826201612_add_default_orientation_to_collection.rb
+++ b/db/migrate/20180826201612_add_default_orientation_to_collection.rb
@@ -1,0 +1,5 @@
+class AddDefaultOrientationToCollection < ActiveRecord::Migration
+  def change
+    add_column :collections, :default_orientation, :string
+  end
+end

--- a/db/migrate/20180826214652_add_default_orientation_to_document_set.rb
+++ b/db/migrate/20180826214652_add_default_orientation_to_document_set.rb
@@ -1,0 +1,5 @@
+class AddDefaultOrientationToDocumentSet < ActiveRecord::Migration
+  def change
+    add_column :document_sets, :default_orientation, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180826201612) do
+ActiveRecord::Schema.define(version: 20180826214652) do
 
   create_table "ahoy_events", force: true do |t|
     t.integer  "visit_id"
@@ -37,11 +37,11 @@ ActiveRecord::Schema.define(version: 20180826201612) do
 
   create_table "article_versions", force: true do |t|
     t.string   "title"
-    t.text     "source_text", limit: 16777215
-    t.text     "xml_text",    limit: 16777215
+    t.text     "source_text"
+    t.text     "xml_text"
     t.integer  "user_id"
     t.integer  "article_id"
-    t.integer  "version",                      default: 0
+    t.integer  "version",     default: 0
     t.datetime "created_on"
   end
 
@@ -50,14 +50,14 @@ ActiveRecord::Schema.define(version: 20180826201612) do
 
   create_table "articles", force: true do |t|
     t.string   "title"
-    t.text     "source_text",   limit: 16777215
+    t.text     "source_text"
     t.datetime "created_on"
-    t.integer  "lock_version",                                           default: 0
-    t.text     "xml_text",      limit: 16777215
+    t.integer  "lock_version",                          default: 0
+    t.text     "xml_text"
     t.string   "graph_image"
     t.integer  "collection_id"
-    t.decimal  "latitude",                       precision: 7, scale: 5
-    t.decimal  "longitude",                      precision: 8, scale: 5
+    t.decimal  "latitude",      precision: 7, scale: 5
+    t.decimal  "longitude",     precision: 8, scale: 5
     t.string   "uri"
   end
 
@@ -112,42 +112,29 @@ ActiveRecord::Schema.define(version: 20180826201612) do
     t.string   "title"
     t.integer  "owner_user_id"
     t.datetime "created_on"
-    t.text     "intro_block",               limit: 16777215
-    t.text     "footer_block",              limit: 16777215
-    t.boolean  "restricted",                                 default: false
+    t.text     "intro_block"
+    t.string   "footer_block",              limit: 2000
+    t.boolean  "restricted",                             default: false
     t.string   "picture"
-    t.boolean  "supports_document_sets",                     default: false
-    t.boolean  "subjects_disabled",                          default: false
+    t.boolean  "supports_document_sets",                 default: false
+    t.boolean  "subjects_disabled",                      default: false
     t.text     "transcription_conventions"
     t.string   "slug"
-    t.boolean  "review_workflow",                            default: false
-    t.boolean  "hide_completed",                             default: true
+    t.boolean  "review_workflow",                        default: false
+    t.boolean  "hide_completed",                         default: true
     t.text     "help"
     t.text     "link_help"
-    t.boolean  "field_based",                                default: false
-    t.boolean  "voice_recognition",                          default: false
+    t.boolean  "field_based",                            default: false
+    t.boolean  "voice_recognition",                      default: false
     t.string   "language"
-    t.string   "text_language"
     t.string   "license_key"
+    t.string   "text_language"
     t.integer  "pct_completed"
     t.string   "default_orientation"
   end
 
   add_index "collections", ["owner_user_id"], name: "index_collections_on_owner_user_id", using: :btree
   add_index "collections", ["slug"], name: "index_collections_on_slug", unique: true, using: :btree
-
-  create_table "comments", force: true do |t|
-    t.integer  "parent_id"
-    t.integer  "user_id"
-    t.datetime "created_at",                                               null: false
-    t.integer  "commentable_id",                    default: 0,            null: false
-    t.string   "commentable_type",                  default: "",           null: false
-    t.integer  "depth"
-    t.string   "title"
-    t.text     "body",             limit: 16777215
-    t.string   "comment_type",     limit: 10,       default: "annotation"
-    t.string   "comment_status",   limit: 10
-  end
 
   create_table "deeds", force: true do |t|
     t.string   "deed_type",     limit: 10
@@ -186,6 +173,7 @@ ActiveRecord::Schema.define(version: 20180826201612) do
     t.datetime "updated_at"
     t.string   "slug"
     t.integer  "pct_completed"
+    t.string   "default_orientation"
   end
 
   add_index "document_sets", ["collection_id"], name: "index_document_sets_on_collection_id", using: :btree
@@ -266,7 +254,7 @@ ActiveRecord::Schema.define(version: 20180826201612) do
 
   create_table "notes", force: true do |t|
     t.string   "title"
-    t.text     "body",          limit: 16777215
+    t.text     "body"
     t.integer  "user_id"
     t.integer  "collection_id"
     t.integer  "work_id"
@@ -372,7 +360,7 @@ ActiveRecord::Schema.define(version: 20180826201612) do
     t.string   "view"
     t.string   "tag"
     t.string   "description"
-    t.text     "html",        limit: 16777215
+    t.text     "html"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -381,12 +369,12 @@ ActiveRecord::Schema.define(version: 20180826201612) do
 
   create_table "page_versions", force: true do |t|
     t.string   "title"
-    t.text     "transcription",      limit: 16777215
-    t.text     "xml_transcription",  limit: 16777215
+    t.text     "transcription"
+    t.text     "xml_transcription"
     t.integer  "user_id"
     t.integer  "page_id"
-    t.integer  "work_version",                        default: 0
-    t.integer  "page_version",                        default: 0
+    t.integer  "work_version",       default: 0
+    t.integer  "page_version",       default: 0
     t.datetime "created_on"
     t.text     "source_translation"
     t.text     "xml_translation"
@@ -397,7 +385,7 @@ ActiveRecord::Schema.define(version: 20180826201612) do
 
   create_table "pages", force: true do |t|
     t.string   "title"
-    t.text     "source_text",        limit: 16777215
+    t.text     "source_text"
     t.string   "base_image"
     t.integer  "base_width"
     t.integer  "base_height"
@@ -405,8 +393,8 @@ ActiveRecord::Schema.define(version: 20180826201612) do
     t.integer  "work_id"
     t.datetime "created_on"
     t.integer  "position"
-    t.integer  "lock_version",                        default: 0
-    t.text     "xml_text",           limit: 16777215
+    t.integer  "lock_version",       default: 0
+    t.text     "xml_text"
     t.integer  "page_version_id"
     t.string   "status"
     t.text     "source_translation"
@@ -426,11 +414,6 @@ ActiveRecord::Schema.define(version: 20180826201612) do
 
   add_index "pages_sections", ["page_id", "section_id"], name: "index_pages_sections_on_page_id_and_section_id", using: :btree
   add_index "pages_sections", ["section_id", "page_id"], name: "index_pages_sections_on_section_id_and_page_id", using: :btree
-
-  create_table "plugin_schema_info", id: false, force: true do |t|
-    t.string  "plugin_name"
-    t.integer "version"
-  end
 
   create_table "sc_canvases", force: true do |t|
     t.string   "sc_id"
@@ -490,8 +473,8 @@ ActiveRecord::Schema.define(version: 20180826201612) do
   add_index "sections", ["work_id"], name: "index_sections_on_work_id", using: :btree
 
   create_table "sessions", force: true do |t|
-    t.string   "session_id",                  default: "", null: false
-    t.text     "data",       limit: 16777215
+    t.string   "session_id", null: false
+    t.text     "data"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -634,22 +617,22 @@ ActiveRecord::Schema.define(version: 20180826201612) do
 
   create_table "works", force: true do |t|
     t.string   "title"
-    t.text     "description",               limit: 16777215
+    t.string   "description",               limit: 4000
     t.datetime "created_on"
     t.integer  "owner_user_id"
-    t.boolean  "restrict_scribes",                           default: false
-    t.integer  "transcription_version",                      default: 0
-    t.text     "physical_description",      limit: 16777215
-    t.text     "document_history",          limit: 16777215
-    t.text     "permission_description",    limit: 16777215
+    t.boolean  "restrict_scribes",                       default: false
+    t.integer  "transcription_version",                  default: 0
+    t.text     "physical_description"
+    t.text     "document_history"
+    t.text     "permission_description"
     t.string   "location_of_composition"
     t.string   "author"
-    t.text     "transcription_conventions", limit: 16777215
+    t.text     "transcription_conventions"
     t.integer  "collection_id"
-    t.boolean  "scribes_can_edit_titles",                    default: false
-    t.boolean  "supports_translation",                       default: false
+    t.boolean  "scribes_can_edit_titles",                default: false
+    t.boolean  "supports_translation",                   default: false
     t.text     "translation_instructions"
-    t.boolean  "pages_are_meaningful",                       default: true
+    t.boolean  "pages_are_meaningful",                   default: true
     t.boolean  "ocr_correction"
     t.string   "slug"
     t.string   "picture"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180525105752) do
+ActiveRecord::Schema.define(version: 20180826201612) do
 
   create_table "ahoy_events", force: true do |t|
     t.integer  "visit_id"
@@ -52,10 +52,13 @@ ActiveRecord::Schema.define(version: 20180525105752) do
     t.string   "title"
     t.text     "source_text",   limit: 16777215
     t.datetime "created_on"
-    t.integer  "lock_version",                   default: 0
+    t.integer  "lock_version",                                           default: 0
     t.text     "xml_text",      limit: 16777215
     t.string   "graph_image"
     t.integer  "collection_id"
+    t.decimal  "latitude",                       precision: 7, scale: 5
+    t.decimal  "longitude",                      precision: 8, scale: 5
+    t.string   "uri"
   end
 
   add_index "articles", ["collection_id"], name: "index_articles_on_collection_id", using: :btree
@@ -70,6 +73,7 @@ ActiveRecord::Schema.define(version: 20180525105752) do
     t.integer  "parent_id"
     t.integer  "collection_id"
     t.datetime "created_on"
+    t.boolean  "gis_enabled",   default: false, null: false
   end
 
   add_index "categories", ["collection_id"], name: "index_categories_on_collection_id", using: :btree
@@ -109,7 +113,7 @@ ActiveRecord::Schema.define(version: 20180525105752) do
     t.integer  "owner_user_id"
     t.datetime "created_on"
     t.text     "intro_block",               limit: 16777215
-    t.string   "footer_block",              limit: 2000
+    t.text     "footer_block",              limit: 16777215
     t.boolean  "restricted",                                 default: false
     t.string   "picture"
     t.boolean  "supports_document_sets",                     default: false
@@ -123,13 +127,27 @@ ActiveRecord::Schema.define(version: 20180525105752) do
     t.boolean  "field_based",                                default: false
     t.boolean  "voice_recognition",                          default: false
     t.string   "language"
-    t.string   "license_key"
     t.string   "text_language"
+    t.string   "license_key"
     t.integer  "pct_completed"
+    t.string   "default_orientation"
   end
 
   add_index "collections", ["owner_user_id"], name: "index_collections_on_owner_user_id", using: :btree
   add_index "collections", ["slug"], name: "index_collections_on_slug", unique: true, using: :btree
+
+  create_table "comments", force: true do |t|
+    t.integer  "parent_id"
+    t.integer  "user_id"
+    t.datetime "created_at",                                               null: false
+    t.integer  "commentable_id",                    default: 0,            null: false
+    t.string   "commentable_type",                  default: "",           null: false
+    t.integer  "depth"
+    t.string   "title"
+    t.text     "body",             limit: 16777215
+    t.string   "comment_type",     limit: 10,       default: "annotation"
+    t.string   "comment_status",   limit: 10
+  end
 
   create_table "deeds", force: true do |t|
     t.string   "deed_type",     limit: 10
@@ -409,6 +427,11 @@ ActiveRecord::Schema.define(version: 20180525105752) do
   add_index "pages_sections", ["page_id", "section_id"], name: "index_pages_sections_on_page_id_and_section_id", using: :btree
   add_index "pages_sections", ["section_id", "page_id"], name: "index_pages_sections_on_section_id_and_page_id", using: :btree
 
+  create_table "plugin_schema_info", id: false, force: true do |t|
+    t.string  "plugin_name"
+    t.integer "version"
+  end
+
   create_table "sc_canvases", force: true do |t|
     t.string   "sc_id"
     t.integer  "sc_manifest_id"
@@ -467,7 +490,7 @@ ActiveRecord::Schema.define(version: 20180525105752) do
   add_index "sections", ["work_id"], name: "index_sections_on_work_id", using: :btree
 
   create_table "sessions", force: true do |t|
-    t.string   "session_id",                  null: false
+    t.string   "session_id",                  default: "", null: false
     t.text     "data",       limit: 16777215
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -515,6 +538,7 @@ ActiveRecord::Schema.define(version: 20180525105752) do
     t.integer "line_number"
     t.integer "position"
     t.integer "percentage"
+    t.integer "page_number"
   end
 
   create_table "users", force: true do |t|
@@ -524,8 +548,8 @@ ActiveRecord::Schema.define(version: 20180525105752) do
     t.string   "email"
     t.boolean  "owner",                     default: false
     t.boolean  "admin",                     default: false
-    t.string   "encrypted_password",        default: "",    null: false
-    t.string   "password_salt",             default: "",    null: false
+    t.string   "encrypted_password",        default: "",      null: false
+    t.string   "password_salt",             default: "",      null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "remember_token"
@@ -536,7 +560,7 @@ ActiveRecord::Schema.define(version: 20180525105752) do
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",             default: 0,     null: false
+    t.integer  "sign_in_count",             default: 0,       null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
@@ -549,6 +573,8 @@ ActiveRecord::Schema.define(version: 20180525105752) do
     t.string   "provider"
     t.string   "uid"
     t.datetime "start_date"
+    t.string   "orcid"
+    t.string   "dictation_language",        default: "en-US"
   end
 
   add_index "users", ["login"], name: "index_users_on_login", using: :btree
@@ -608,7 +634,7 @@ ActiveRecord::Schema.define(version: 20180525105752) do
 
   create_table "works", force: true do |t|
     t.string   "title"
-    t.string   "description",               limit: 4000
+    t.text     "description",               limit: 16777215
     t.datetime "created_on"
     t.integer  "owner_user_id"
     t.boolean  "restrict_scribes",                           default: false


### PR DESCRIPTION
Closes #787

Allows collection owners to set the default orientation of their project.

The default is '"Page on the Left"
Unless it is a field-based project, in which case it defaults to "Page on the Top"
Unless the user has a cookie set, in which case it follows the user.