### PR TITLE
Disable pagination in transcription previews

### DIFF
--- a/app/controllers/transcribe_controller.rb
+++ b/app/controllers/transcribe_controller.rb
@@ -157,6 +157,7 @@ class TranscribeController  < ApplicationController
         # raise ex
       end
     elsif params['preview']
+      @display_context = 'preview'
       @preview_xml = @page.wiki_to_xml(@page.source_text, "transcription")
       display_page
 #      @preview_xml = @page.generate_preview("transcription")
@@ -274,6 +275,7 @@ class TranscribeController  < ApplicationController
         # raise ex
       end
     elsif params['preview']
+      @display_context = 'preview'
       @preview_xml = @page.wiki_to_xml(@page.source_translation, "translation")
       translate
       render :action => 'translate'

--- a/app/views/shared/_page_tabs.html.slim
+++ b/app/views/shared/_page_tabs.html.slim
@@ -59,25 +59,28 @@
 -content_for :page_title, selected == 1 ? "#{page_title}" : "#{selected_tab} - #{page_title}"
 -content_for :meta_description, "#{page_title} - #{tab_title}. #{strip_tags(description).truncate(150, separator: ' ')}"
 
+-@display_context ||= ''
+
 .headline
   h1.headline_title =@page.title
   .headline_aside
-    nav.page-nav
-      -if @page != @work.pages.first
-        -higher_item = @page.higher_item
-        =link_to({ :page_id => higher_item.id }, class: 'page-nav_prev', title: 'Previous page', 'aria-label' => 'Previous page', onclick: 'unsavedTranscription(event);')
-          =svg_symbol '#icon-arrow-left', class: 'icon', title: 'Previous page'
-      -else
-        span.page-nav_prev =svg_symbol '#icon-arrow-left', class: 'icon'
+    -unless @display_context == 'preview'
+      nav.page-nav
+        -if @page != @work.pages.first
+          -higher_item = @page.higher_item
+          =link_to({ :page_id => higher_item.id }, class: 'page-nav_prev', title: 'Previous page', 'aria-label' => 'Previous page', onclick: 'unsavedTranscription(event);')
+            =svg_symbol '#icon-arrow-left', class: 'icon', title: 'Previous page'
+        -else
+          span.page-nav_prev =svg_symbol '#icon-arrow-left', class: 'icon'
 
-      span.page-nav_info ="Page #{@page.position} of #{@work.pages.size}"
+        span.page-nav_info ="Page #{@page.position} of #{@work.pages.size}"
 
-      -if !@page.last?
-        -lower_item = @page.lower_item
-        =link_to({ :page_id => lower_item.id }, class: 'page-nav_next', title: 'Next page', 'aria-label' => 'Next page', onclick: 'unsavedTranscription(event);')
-          =svg_symbol '#icon-arrow-right', class: 'icon', title: 'Next page'
-      -else
-        span.page-nav_next =svg_symbol '#icon-arrow-right', class: 'icon'
+        -if !@page.last?
+          -lower_item = @page.lower_item
+          =link_to({ :page_id => lower_item.id }, class: 'page-nav_next', title: 'Next page', 'aria-label' => 'Next page', onclick: 'unsavedTranscription(event);')
+            =svg_symbol '#icon-arrow-right', class: 'icon', title: 'Next page'
+        -else
+          span.page-nav_next =svg_symbol '#icon-arrow-right', class: 'icon'
 
 .tabs
   -for tab in tabs


### PR DESCRIPTION
Closes #1084 

Hides the navigation buttons on both transcription and translation preview views by setting a `display_context` flag in the controller. All of these displays rely on a long-is set of `if-else` statements that branch based on parameters set in the `POST` req. This seemed like the cleanest way to operate within that paradigm.