### PR TITLE
Openseadragon `maxZoomPIxelRatio`

### DIFF
--- a/app/views/shared/_iiif_div.html.erb
+++ b/app/views/shared/_iiif_div.html.erb
@@ -57,6 +57,7 @@
 		        preserveViewport:   true,
 		        visibilityRatio:    1,
 		        minZoomLevel:       1,
+            maxZoomPixelRatio:  10,
 		        defaultZoomLevel:   1,
 		        sequenceMode:       false, //we want fromthepage to handle pages sequentially, rather than openseadragon
 		      	tileSources:   [


### PR DESCRIPTION
Closes #1193

Set it to `10` for no specific reason. I didn't notice a terribly adverse UX by using such a high number.

I suppose we could make this a setting in the `work` if it becomes distracting for higher-res images, but I doubt that'll be necessary.