### PR TITLE
1190 link to api documentation

### DIFF
--- a/app/views/export/index.html.slim
+++ b/app/views/export/index.html.slim
@@ -87,6 +87,11 @@ table.datagrid
 
 =render(:partial => 'shared/pagination', :locals => { :model => @works, :entries_info => true })
 
+h2 API
+p
+  'We also have an API for programmatically exporting transcripts for your collections. Learn more
+  =link_to('here', 'https://github.com/benwbrum/fromthepage/wiki/FromThePage-Support-for-the-IIIF-Presentation-API-and-Web-Annotations')
+  '.
 
 =render({ :partial => '/shared/collection_footer' })
 

--- a/app/views/export/index.html.slim
+++ b/app/views/export/index.html.slim
@@ -10,13 +10,13 @@
     span Click the button to export subject indexes from the entire collection in a single CSV file. Please note that the export process could take some time to complete, so please wait until you get the File Save dialog.
 
 h2 Export All Works
-p.big 
+p.big
   span.fright(style="margin-left: 30px")
 
     =link_to({ :controller => 'export', :action => 'export_all_works', :collection_id => @collection.id, format: :zip }, class: 'button btnExport', id: 'btnExportAll')
       =svg_symbol '#icon-export', class: 'icon'
       span Export All Works
-  
+
   span Click the button to export all works from the collection into a zip file containing each work as an XHTML file with transcripts, user comments, subject articles, and internal HREFs linking subjects and pages.
 
 -unless @table_export.blank?


### PR DESCRIPTION
Resolves #1190 

I've added the link to the API doc to the bottom of the `/export` page for issue #1190. In the process, I removed trailing whitespace from two lines in the `export/index.html.slim`, since my text editor does this automatically. I see that html.slim is whitespace-sensitive. I have not seen an issue with the removal of these particular trailing whitespaces on this page. Do you foresee this as a problem?

<img width="949" alt="screenshot 2018-09-17 15 47 26" src="https://user-images.githubusercontent.com/8680712/45649522-26df6900-ba91-11e8-9920-6bf548c7c0de.png">
