### PR TITLE
1195 show subject uri on overview

### DIFF
--- a/app/views/article/show.html.slim
+++ b/app/views/article/show.html.slim
@@ -9,7 +9,12 @@
     -else
       -if user_signed_in? && !current_user.guest
         i =link_to 'Edit the description in the settings tab.', collection_article_edit_path(@collection.owner, @collection, @article)
-      
+
+    -if @article.uri
+      p
+        | See also: 
+        a href="#{@article.uri}" target="_blank" #{@article.uri}
+
     h3 Related Subjects
     .article-graph
       =image_tag(file_to_url(@article.graph_image), :usemap => '#G', alt: "Related subjects")


### PR DESCRIPTION
Resolves #1195 

It displays this line only if an `article.uri` is present.

<img width="577" alt="screenshot 2018-10-10 09 54 13" src="https://user-images.githubusercontent.com/8680712/46745495-c6e47880-cc72-11e8-8d9d-7a14ca174f8b.png">
