### PR TITLE
HTML Annotations in IIIF Manifest

### DIFF
--- a/app/controllers/annotation_controller.rb
+++ b/app/controllers/annotation_controller.rb
@@ -1,0 +1,14 @@
+class AnnotationController < ApplicationController
+    include AbstractXmlHelper
+    
+    def page_transcription_html
+        render_xml_to_html @page.xml_text
+    end
+    def page_translation_html
+        render_xml_to_html @page.xml_translation
+    end
+    def render_xml_to_html(xml)
+        annotation = xml_to_html(xml)
+        render  :layout => false, :content_type => "text/html", :text => annotation
+    end
+end

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -350,14 +350,14 @@ private
     case type
     when 'transcription'
       annotation['on'] = region_from_page(@page)
-      annotation.resource = IIIF::Presentation::Resource.new({'@id' => "plaintext_export_for_#{@page.id}", '@type' => "cnt:ContentAsText"})
+      annotation.resource = IIIF::Presentation::Resource.new({'@id' => "#{collection_annotation_page_transcription_html_url(@work.owner, @collection, @work, @page)}", '@type' => "cnt:ContentAsText"})
       annotation.resource["format"] =  "text/html"
     when 'translation'
       unless page.source_translation.blank?
         #annotation = IIIF::Presentation::Annotation.new
         #page = Page.find page_id
         annotation['on'] = region_from_page(@page)
-        annotation.resource = IIIF::Presentation::Resource.new({'@id' => "translation_export_for_#{@page.id}", '@type' => "cnt:ContentAsText"})
+        annotation.resource = IIIF::Presentation::Resource.new({'@id' => "#{collection_annotation_page_translation_html_url(@work.owner, @collection, @work, @page)}", '@type' => "cnt:ContentAsText"})
         annotation.resource["format"] =  "text/html"
       end
     when 'facsimile'

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -352,11 +352,6 @@ private
       annotation['on'] = region_from_page(@page)
       annotation.resource = IIIF::Presentation::Resource.new({'@id' => "plaintext_export_for_#{@page.id}", '@type' => "cnt:ContentAsText"})
       annotation.resource["format"] =  "text/html"
-
-      doc = Nokogiri::XML(@page.xml_text.gsub(/<\/p>/, "</p>\n\n").gsub("<lb/>", "\n"))
-      no_tags = doc.text
-
-      annotation.resource["chars"] = no_tags
     when 'translation'
       unless page.source_translation.blank?
         #annotation = IIIF::Presentation::Annotation.new
@@ -364,11 +359,6 @@ private
         annotation['on'] = region_from_page(@page)
         annotation.resource = IIIF::Presentation::Resource.new({'@id' => "translation_export_for_#{@page.id}", '@type' => "cnt:ContentAsText"})
         annotation.resource["format"] =  "text/html"
-
-        doc = Nokogiri::XML(@page.xml_translation.gsub(/<\/p>/, "</p>\n\n").gsub("<lb/>", "\n"))
-        no_tags = doc.text
-
-        annotation.resource["chars"] = no_tags
       end
     when 'facsimile'
       #annotation = IIIF::Presentation::Annotation.new

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -351,7 +351,7 @@ private
     when 'transcription'
       annotation['on'] = region_from_page(@page)
       annotation.resource = IIIF::Presentation::Resource.new({'@id' => "plaintext_export_for_#{@page.id}", '@type' => "cnt:ContentAsText"})
-      annotation.resource["format"] =  "text/plain"
+      annotation.resource["format"] =  "text/html"
 
       doc = Nokogiri::XML(@page.xml_text.gsub(/<\/p>/, "</p>\n\n").gsub("<lb/>", "\n"))
       no_tags = doc.text
@@ -363,7 +363,7 @@ private
         #page = Page.find page_id
         annotation['on'] = region_from_page(@page)
         annotation.resource = IIIF::Presentation::Resource.new({'@id' => "translation_export_for_#{@page.id}", '@type' => "cnt:ContentAsText"})
-        annotation.resource["format"] =  "text/plain"
+        annotation.resource["format"] =  "text/html"
 
         doc = Nokogiri::XML(@page.xml_translation.gsub(/<\/p>/, "</p>\n\n").gsub("<lb/>", "\n"))
         no_tags = doc.text

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,10 @@ Fromthepage::Application.routes.draw do
       get 'export/page_plaintext_emended', path: ':work_id/export/:page_id/plaintext/emended', as: 'page_export_plaintext_emended', to: 'export#page_plaintext_emended'
       get 'export/page_plaintext_translation_emended', path: ':work_id/export/:page_id/plaintext/translation/emended', as: 'page_export_plaintext_translation_emended', to: 'export#page_plaintext_translation_emended'
 
+      # Page Annotations
+      get 'annotation/page_transcription_html', path: ':work_id/annotation/:page_id/html/transcription', to: 'annotation#page_transcription_html'
+      get 'annotation/page_translation_html', path: ':work_id/annotation/:page_id/html/translation', to: 'annotation#page_translation_html'
+
       #article related routes
       match 'article/show', path: '/article/:article_id', to: 'article#show', via: [:get, :post]
       get 'article/edit', path: 'article/:article_id/edit', to: 'article#edit'

--- a/spec/features/iiif_annotations_spec.rb
+++ b/spec/features/iiif_annotations_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe "IIIF Annotations API" do
+
+  before :all do
+    @owner = User.find_by(login: OWNER)
+    @collection = @owner.all_owner_collections.first
+    @work = @collection.works.last
+    @page = @work.pages.first
+  end
+
+  it "should return OK for transcription" do
+    visit collection_annotation_page_transcription_html_path(@owner, @collection, @work, @page)
+  end
+  it "should return OK for translation" do
+    visit collection_annotation_page_translation_html_path(@owner, @collection, @work, @page)
+  end
+end


### PR DESCRIPTION
Closes #1189 

- [x] Add URIs for transcriptions and translations as annotations in
- [x] Assign URIs to `@id` in annotations
- [x] Remove `chars` field in favor of URI in `@id`
- [x] Update contentType to `text/html`