### PR TITLE
Create deeds when marking as blank

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -404,4 +404,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.16.3
+   1.16.5

--- a/app/assets/stylesheets/sections/deed.scss.erb
+++ b/app/assets/stylesheets/sections/deed.scss.erb
@@ -19,7 +19,7 @@
   $color: #B30;
   $opacity: 0.4;
   $rotate: 0deg;
-  @each $type in page_edit, page_trans, page_index, art_edit, note_add, pg_xlat, pg_xlat_ed {
+  @each $type in <%= DeedType.all_types %> {
     &-#{$type} { background: rgba(adjust-hue($color, $rotate), $opacity); }
     $rotate: $rotate - 30deg;
   }

--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -206,7 +206,7 @@ class ArticleController < ApplicationController
   def record_deed
     deed = Deed.new
     deed.article = @article
-    deed.deed_type = Deed::ARTICLE_EDIT
+    deed.deed_type = DeedType::ARTICLE_EDIT
     deed.collection = @article.collection
     deed.user = current_user
     deed.save!

--- a/app/controllers/collection_controller.rb
+++ b/app/controllers/collection_controller.rb
@@ -293,15 +293,15 @@ class CollectionController < ApplicationController
 
       id_data = [user.display_name, user.email]
       time_data = [time_total, time_proportional]
-      
+
       user_deeds = @collection_deeds.select { |d| d.user_id == user.id }
 
       user_stats = [
-        user_deeds.count { |d| d.deed_type == 'page_trans' },
-        user_deeds.count { |d| d.deed_type == 'page_edit' },
-        user_deeds.count { |d| d.deed_type == 'pg_xlat' },
-        user_deeds.count { |d| d.deed_type == 'ocr_corr' },
-        user_deeds.count { |d| d.deed_type == 'note_add' }
+        user_deeds.count { |d| d.deed_type == DeedType::PAGE_TRANSCRIPTION },
+        user_deeds.count { |d| d.deed_type == DeedType::PAGE_EDIT },
+        user_deeds.count { |d| d.deed_type == DeedType::PAGE_TRANSLATED },
+        user_deeds.count { |d| d.deed_type == DeedType::OCR_CORRECTED },
+        user_deeds.count { |d| d.deed_type == DeedType::NOTE_ADDED }
       ]
 
       id_data + time_data + user_stats

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -71,20 +71,20 @@ class IiifController < ApplicationController
     if sc_canvas = ScCanvas.where(:sc_canvas_id => at_id).last
       redirect_to :controller => 'iiif', :action => 'canvas', :page_id => sc_canvas.page_id
       return
-    end    
+    end
 
-    if at_id.match(/http/)   
+    if at_id.match(/http/)
       render :status => 404, :text => "No items that correspond to #{at_id} have been imported into the FromThePage server.  For a full list of public IIIF resources, see #{url_for(:controller => 'iiif', :action => 'collections')}"
     else
       collection_for_domain(at_id)
     end
   end
-  
+
   def collection_for_domain(domain, terminus_a_quo = nil, terminus_ad_quem = nil)
     if terminus_a_quo && terminus_ad_quem
-      works = Work.joins(:deeds, :sc_manifest).where("sc_manifests.at_id LIKE ?", "%#{domain}%").where(:deeds => { :created_at => terminus_a_quo..terminus_ad_quem, :deed_type => Deed::CONTRIBUTOR_DEED_TYPES}).distinct
+      works = Work.joins(:deeds, :sc_manifest).where("sc_manifests.at_id LIKE ?", "%#{domain}%").where(:deeds => { :created_at => terminus_a_quo..terminus_ad_quem, :deed_type => DeedType.contributor_types}).distinct
     elsif terminus_a_quo
-      works = Work.joins(:deeds, :sc_manifest).where("sc_manifests.at_id LIKE ? AND deeds.created_at >= ? AND deeds.deed_type != '#{Deed::WORK_ADDED}'", "%#{domain}%", terminus_a_quo).distinct      
+      works = Work.joins(:deeds, :sc_manifest).where("sc_manifests.at_id LIKE ? AND deeds.created_at >= ? AND deeds.deed_type != '#{DeedType::WORK_ADDED}'", "%#{domain}%", terminus_a_quo).distinct
     else
       works = Work.joins(:sc_manifest).where("at_id LIKE ?", "%#{domain}%")
     end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -70,7 +70,7 @@ class NotesController < ApplicationController
       deed.collection = @collection.collection
     end
 
-    deed.deed_type = Deed::NOTE_ADDED
+    deed.deed_type = DeedType::NOTE_ADDED
     deed.user = current_user
     deed.save!
   end

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -7,9 +7,9 @@ class StatisticsController < ApplicationController
   #  @works.sort { |w1, w2| w2.work_statistic.pct_transcribed <=> w1.work_statistic.pct_transcribed }
 
     @users = User.all
-    @all_transcribers = build_user_array(Deed::PAGE_TRANSCRIPTION)
-    @all_editors      = build_user_array(Deed::PAGE_EDIT)
-    @all_indexers     = build_user_array(Deed::PAGE_INDEXED)
+    @all_transcribers = build_user_array(DeedType::PAGE_TRANSCRIPTION)
+    @all_editors      = build_user_array(DeedType::PAGE_EDIT)
+    @all_indexers     = build_user_array(DeedType::PAGE_INDEXED)
   end
 
   private

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -90,7 +90,7 @@ class UserController < ApplicationController
     deed.page = @page
     deed.work = @work
     deed.collection = @collection
-    deed.deed_type = Deed::NOTE_ADDED
+    deed.deed_type = DeedType::NOTE_ADDED
     deed.user = current_user
     deed.save!
   end

--- a/app/controllers/work_controller.rb
+++ b/app/controllers/work_controller.rb
@@ -239,7 +239,7 @@ class WorkController < ApplicationController
   def record_deed(work)
     deed = Deed.new
     deed.work = work
-    deed.deed_type = Deed::WORK_ADDED
+    deed.deed_type = DeedType::WORK_ADDED
     deed.collection = work.collection
     deed.user = work.owner
     deed.save!

--- a/app/helpers/add_work_helper.rb
+++ b/app/helpers/add_work_helper.rb
@@ -69,7 +69,7 @@ module AddWorkHelper
   def record_deed
     deed = Deed.new
     deed.work = @work
-    deed.deed_type = Deed::WORK_ADDED
+    deed.deed_type = DeedType::WORK_ADDED
     deed.collection = @work.collection
     deed.user = current_user
     deed.save!

--- a/app/models/collection_statistic.rb
+++ b/app/models/collection_statistic.rb
@@ -20,47 +20,48 @@ module CollectionStatistic
   end
 
   def comment_count(last_days=nil)
-    Collection.count_by_sql("SELECT COUNT(*) FROM deeds WHERE collection_id = #{self.id} AND deed_type = \"#{Deed::NOTE_ADDED}\" #{last_days_clause(last_days)}")
+    Collection.count_by_sql("SELECT COUNT(*) FROM deeds WHERE collection_id = #{self.id} AND deed_type = \"#{DeedType::NOTE_ADDED}\" #{last_days_clause(last_days)}")
   end
 
   def transcription_count(last_days=nil)
-    Collection.count_by_sql("SELECT COUNT(*) FROM deeds WHERE collection_id = #{self.id} AND deed_type = \"#{Deed::PAGE_TRANSCRIPTION}\" #{last_days_clause(last_days)}")
+    Collection.count_by_sql("SELECT COUNT(*) FROM deeds WHERE collection_id = #{self.id} AND deed_type = \"#{DeedType::PAGE_TRANSCRIPTION}\" #{last_days_clause(last_days)}")
   end
 
   def edit_count(last_days=nil)
-    Collection.count_by_sql("SELECT COUNT(*) FROM deeds WHERE collection_id = #{self.id} AND deed_type = \"#{Deed::PAGE_EDIT}\" #{last_days_clause(last_days)}")
+    Collection.count_by_sql("SELECT COUNT(*) FROM deeds WHERE collection_id = #{self.id} AND deed_type = \"#{DeedType::PAGE_EDIT}\" #{last_days_clause(last_days)}")
   end
 
   def index_count(last_days=nil)
-    Collection.count_by_sql("SELECT COUNT(*) FROM deeds WHERE collection_id = #{self.id} AND deed_type = \"#{Deed::PAGE_INDEXED}\" #{last_days_clause(last_days)}")
+    Collection.count_by_sql("SELECT COUNT(*) FROM deeds WHERE collection_id = #{self.id} AND deed_type = \"#{DeedType::PAGE_INDEXED}\" #{last_days_clause(last_days)}")
   end
 
   def translation_count(last_days=nil)
-    Collection.count_by_sql("SELECT COUNT(*) FROM deeds WHERE collection_id = #{self.id} AND deed_type = \"#{Deed::PAGE_TRANSLATED}\" #{last_days_clause(last_days)}")
+    Collection.count_by_sql("SELECT COUNT(*) FROM deeds WHERE collection_id = #{self.id} AND deed_type = \"#{DeedType::PAGE_TRANSLATED}\" #{last_days_clause(last_days)}")
   end
 
   def ocr_count(last_days=nil)
-    Collection.count_by_sql("SELECT COUNT(*) FROM deeds WHERE collection_id = #{self.id} AND deed_type = \"#{Deed::OCR_CORRECTED}\" #{last_days_clause(last_days)}")
+    Collection.count_by_sql("SELECT COUNT(*) FROM deeds WHERE collection_id = #{self.id} AND deed_type = \"#{DeedType::OCR_CORRECTED}\" #{last_days_clause(last_days)}")
   end
 
   def get_stats_hash(start_date=nil, end_date=nil)
     deeds = {
-      Deed::ARTICLE_EDIT => 0,
-      Deed::PAGE_TRANSCRIPTION => 0,
-      Deed::PAGE_EDIT => 0,
-      Deed::PAGE_INDEXED => 0,
-      Deed::NOTE_ADDED => 0,
-      Deed::PAGE_TRANSLATED => 0,
-      Deed::PAGE_TRANSLATION_EDIT => 0,
-      Deed::OCR_CORRECTED => 0,
-      Deed::NEEDS_REVIEW => 0,
-      Deed::TRANSLATION_REVIEW => 0,
-      Deed::TRANSLATION_INDEXED => 0,
-      Deed::WORK_ADDED => 0,
+      DeedType::ARTICLE_EDIT => 0,
+      DeedType::PAGE_TRANSCRIPTION => 0,
+      DeedType::PAGE_EDIT => 0,
+      DeedType::PAGE_INDEXED => 0,
+      DeedType::PAGE_MARKED_BLANK => 0,
+      DeedType::NOTE_ADDED => 0,
+      DeedType::PAGE_TRANSLATED => 0,
+      DeedType::PAGE_TRANSLATION_EDIT => 0,
+      DeedType::OCR_CORRECTED => 0,
+      DeedType::NEEDS_REVIEW => 0,
+      DeedType::TRANSLATION_REVIEW => 0,
+      DeedType::TRANSLATION_INDEXED => 0,
+      DeedType::WORK_ADDED => 0,
     }
     deeds.merge!(self.deeds.where(timeframe(start_date, end_date)).group('deed_type').count)
-    
-    stats = 
+
+    stats =
     {
       :works        => self.works.count,
       :pages        => self.works.joins(:pages).where(timeframe(start_date, end_date, 'pages.created_on')).count,

--- a/app/models/deed.rb
+++ b/app/models/deed.rb
@@ -1,34 +1,4 @@
 class Deed < ActiveRecord::Base
-  # constants
-  PAGE_TRANSCRIPTION = 'page_trans'
-  PAGE_EDIT = 'page_edit'
-  PAGE_INDEXED = 'page_index'
-  ARTICLE_EDIT = 'art_edit'
-  NOTE_ADDED = 'note_add'
-  PAGE_TRANSLATED = 'pg_xlat'
-  PAGE_TRANSLATION_EDIT = 'pg_xlat_ed'
-  OCR_CORRECTED = 'ocr_corr'
-  NEEDS_REVIEW = 'review'
-  TRANSLATION_REVIEW = 'xlat_rev'
-  TRANSLATION_INDEXED = 'xlat_index'
-  WORK_ADDED = 'work_add'
-
-  CONTRIBUTOR_DEED_TYPES = [
-    PAGE_TRANSCRIPTION,
-    PAGE_EDIT,
-    PAGE_INDEXED,
-    ARTICLE_EDIT,
-    NOTE_ADDED,
-    PAGE_TRANSLATED,
-    PAGE_TRANSLATION_EDIT,
-    OCR_CORRECTED,
-    NEEDS_REVIEW,
-    TRANSLATION_REVIEW,
-    TRANSLATION_INDEXED
-  ]
-
-
-  # associations
   belongs_to :article
   belongs_to :collection
   belongs_to :note
@@ -36,7 +6,7 @@ class Deed < ActiveRecord::Base
   belongs_to :user
   belongs_to :work
 
-  validates_inclusion_of :deed_type, :in => [ PAGE_TRANSCRIPTION, PAGE_EDIT, PAGE_INDEXED, ARTICLE_EDIT, NOTE_ADDED, PAGE_TRANSLATED, PAGE_TRANSLATION_EDIT, OCR_CORRECTED, NEEDS_REVIEW, TRANSLATION_REVIEW, TRANSLATION_INDEXED, WORK_ADDED ]
+  validates_inclusion_of :deed_type, in: DeedType.all_types
   scope :order_by_recent_activity, -> { order('created_at DESC') }
   scope :active, -> { joins(:user).where(users: {deleted: false}) }
   scope :past_day, -> {where('created_at >= ?', 1.day.ago)}
@@ -44,32 +14,6 @@ class Deed < ActiveRecord::Base
   visitable # ahoy integration
 
   def deed_type_name
-    return case self.deed_type
-    when PAGE_TRANSCRIPTION
-      'Page Transcribed'
-    when PAGE_EDIT
-      'Page Edited'
-    when PAGE_INDEXED
-      'Page Indexed'
-    when ARTICLE_EDIT
-      'Article Edited'
-    when NOTE_ADDED
-      'Note Added'
-    when PAGE_TRANSLATED
-      'Page Translated'
-    when PAGE_TRANSLATION_EDIT
-      'Translation Page Edited'
-    when OCR_CORRECTED
-      'Page OCR Corrected'
-    when NEEDS_REVIEW
-      'Page Needs Review'
-    when  TRANSLATION_REVIEW
-      'Translation Page Needs Review'
-    when TRANSLATION_INDEXED
-      'Translation Page Indexed'
-    when WORK_ADDED
-      'Work Added'
-    end
+    DeedType.name(self.deed_type)
   end
-
 end

--- a/app/models/deed_type.rb
+++ b/app/models/deed_type.rb
@@ -1,0 +1,53 @@
+class DeedType
+  PAGE_TRANSCRIPTION = 'page_trans'
+  PAGE_EDIT = 'page_edit'
+  PAGE_INDEXED = 'page_index'
+  PAGE_MARKED_BLANK = 'markd_blnk'
+  ARTICLE_EDIT = 'art_edit'
+  NOTE_ADDED = 'note_add'
+  PAGE_TRANSLATED = 'pg_xlat'
+  PAGE_TRANSLATION_EDIT = 'pg_xlat_ed'
+  OCR_CORRECTED = 'ocr_corr'
+  NEEDS_REVIEW = 'review'
+  TRANSLATION_REVIEW = 'xlat_rev'
+  TRANSLATION_INDEXED = 'xlat_index'
+  WORK_ADDED = 'work_add'
+
+  TYPES = {
+    "#{PAGE_TRANSCRIPTION}" => 'Page Transcribed',
+    "#{PAGE_EDIT}" => 'Page Edited',
+    "#{PAGE_INDEXED}" => 'Page Indexed',
+    "#{PAGE_MARKED_BLANK}" => 'Page Marked Blank',
+    "#{ARTICLE_EDIT}" => 'Article Edited',
+    "#{NOTE_ADDED}" => 'Note Added',
+    "#{PAGE_TRANSLATED}" => 'Page Translated',
+    "#{PAGE_TRANSLATION_EDIT}" => 'Translation Page Edited',
+    "#{OCR_CORRECTED}" => 'Page OCR Corrected',
+    "#{NEEDS_REVIEW}" => 'Page Needs Review',
+    "#{TRANSLATION_REVIEW}" => 'Translation Page Needs Review',
+    "#{TRANSLATION_INDEXED}" => 'Translation Page Indexed',
+    "#{WORK_ADDED}" => 'Work Added'
+  }
+
+  class << self
+    def all_types
+      TYPES.keys
+    end
+
+    def contributor_types
+      TYPES.clone.except!(WORK_ADDED).keys
+    end
+
+    def collection_edits
+      [PAGE_TRANSCRIPTION, PAGE_EDIT, PAGE_MARKED_BLANK, ARTICLE_EDIT, OCR_CORRECTED, NEEDS_REVIEW, TRANSLATION_REVIEW]
+    end
+
+    def document_set_edits
+      [PAGE_TRANSCRIPTION, PAGE_EDIT, PAGE_MARKED_BLANK, ARTICLE_EDIT]
+    end
+
+    def name(deed_type)
+      TYPES[deed_type]
+    end
+  end
+end

--- a/app/models/document_set_statistic.rb
+++ b/app/models/document_set_statistic.rb
@@ -70,22 +70,23 @@ module DocumentSetStatistic
   end
   def get_stats_hash(start_date=nil, end_date=nil)
     deeds = {
-      Deed::ARTICLE_EDIT => 0,
-      Deed::PAGE_TRANSCRIPTION => 0,
-      Deed::PAGE_EDIT => 0,
-      Deed::PAGE_INDEXED => 0,
-      Deed::NOTE_ADDED => 0,
-      Deed::PAGE_TRANSLATED => 0,
-      Deed::PAGE_TRANSLATION_EDIT => 0,
-      Deed::OCR_CORRECTED => 0,
-      Deed::NEEDS_REVIEW => 0,
-      Deed::TRANSLATION_REVIEW => 0,
-      Deed::TRANSLATION_INDEXED => 0,
-      Deed::WORK_ADDED => 0,
+      DeedType::ARTICLE_EDIT => 0,
+      DeedType::PAGE_TRANSCRIPTION => 0,
+      DeedType::PAGE_EDIT => 0,
+      DeedType::PAGE_INDEXED => 0,
+      DeedType::PAGE_MARKED_BLANK => 0,
+      DeedType::NOTE_ADDED => 0,
+      DeedType::PAGE_TRANSLATED => 0,
+      DeedType::PAGE_TRANSLATION_EDIT => 0,
+      DeedType::OCR_CORRECTED => 0,
+      DeedType::NEEDS_REVIEW => 0,
+      DeedType::TRANSLATION_REVIEW => 0,
+      DeedType::TRANSLATION_INDEXED => 0,
+      DeedType::WORK_ADDED => 0,
     }
     deeds.merge!(self.deeds.where(timeframe(start_date, end_date)).group('deed_type').count)
-    
-    stats = 
+
+    stats =
     {
       :works        => self.works.count,
       :pages        => self.works.joins(:pages).where(timeframe(start_date, end_date, 'pages.created_on')).count,

--- a/app/models/ia_work.rb
+++ b/app/models/ia_work.rb
@@ -309,7 +309,7 @@ private
   def record_deed(work)
     deed = Deed.new
     deed.work = work
-    deed.deed_type = Deed::WORK_ADDED
+    deed.deed_type = DeedType::WORK_ADDED
     deed.collection = work.collection
     deed.user = work.owner
     deed.save!

--- a/app/models/omeka_item.rb
+++ b/app/models/omeka_item.rb
@@ -153,7 +153,7 @@ protected
   def record_deed(work)
     deed = Deed.new
     deed.work = work
-    deed.deed_type = Deed::WORK_ADDED
+    deed.deed_type = DeedType::WORK_ADDED
     deed.collection = work.collection
     deed.user = work.owner
     deed.save!

--- a/app/models/sc_manifest.rb
+++ b/app/models/sc_manifest.rb
@@ -145,7 +145,7 @@ protected
   def record_deed(work)
     deed = Deed.new
     deed.work = work
-    deed.deed_type = Deed::WORK_ADDED
+    deed.deed_type = DeedType::WORK_ADDED
     deed.collection = work.collection
     deed.user = work.owner
     deed.save!

--- a/app/views/collection/show.html.slim
+++ b/app/views/collection/show.html.slim
@@ -93,7 +93,6 @@
       =link_to 'Show More', { :controller => 'deed', :action => 'list', :collection_id => @collection.id }, class: 'button outline round'
 
     h3 Recent Edits
-    =deeds_for({ :collection => @collection, :limit => 10, :types => [Deed::PAGE_TRANSCRIPTION, Deed::PAGE_EDIT, Deed::ARTICLE_EDIT, Deed::OCR_CORRECTED, Deed::NEEDS_REVIEW, Deed::TRANSLATION_REVIEW], :long_view => true })
+    =deeds_for({ :collection => @collection, :limit => 20, :types => DeedType.collection_edits, :long_view => true })
 
 =render({ :partial => '/shared/collection_footer' })
-

--- a/app/views/deed/_deed.html.slim
+++ b/app/views/deed/_deed.html.slim
@@ -15,40 +15,43 @@
 -output = "#{user} "
 
 -case deed.deed_type
--when 'page_trans'
+-when DeedType::PAGE_TRANSCRIPTION
   -output += "transcribed page #{page}"
 
--when 'page_edit'
+-when DeedType::PAGE_EDIT
   -output += "edited page #{page}"
 
--when 'page_index'
+-when DeedType::PAGE_INDEXED
   -output += "indexed page #{page}"
+  
+-when DeedType::PAGE_MARKED_BLANK
+  -output += "marked page #{page} as blank"
 
--when 'art_edit'
+-when DeedType::ARTICLE_EDIT
   -output += "edited #{article} article"
 
--when 'note_add'
+-when DeedType::NOTE_ADDED
   -output += "added a note to page #{page}"
 
--when 'pg_xlat'
+-when DeedType::PAGE_TRANSLATED
   -output += "translated page #{page}"
 
--when 'pg_xlat_ed'
+-when DeedType::PAGE_TRANSLATION_EDIT
   -output += "edited the translation of page #{page}"
 
--when 'ocr_corr'
+-when DeedType::OCR_CORRECTED
   -output += "corrected page #{page}"
 
--when 'review'
+-when DeedType::NEEDS_REVIEW
   -output += "marked page #{page} as needing review"
 
--when 'xlat_index'
+-when DeedType::TRANSLATION_INDEXED
   -output += "indexed the translation of page #{page}"
 
--when 'xlat_rev'
+-when DeedType::TRANSLATION_REVIEW
   -output += "marked translation page #{page} as needing review"
 
--when 'work_add'
+-when DeedType::WORK_ADDED
   -output += "added #{work}"
 
 -if(long_view && !deed.work.nil?)
@@ -62,7 +65,7 @@
   -collection = link_to(deed.collection.title, collection_path(deed.collection.owner, deed.collection), only_path: false )
   -output += " in #{collection} collection"
 
--if(long_view && deed.deed_type == 'note_add' && !deed.note.nil?)
+-if(long_view && deed.deed_type == DeedType::NOTE_ADDED && !deed.note.nil?)
   -output += ", saying &ldquo;#{deed.note.title}&rdquo;"
 
 ==output

--- a/app/views/document_sets/show.html.slim
+++ b/app/views/document_sets/show.html.slim
@@ -53,6 +53,6 @@
       =link_to 'Show More', { :controller => 'deed', :action => 'list', :collection_id => @collection.id }, class: 'button outline round'
 
     h3 Recent Edits
-    =deeds_for({ :collection => true, :limit => 10, :types => [Deed::PAGE_TRANSCRIPTION, Deed::PAGE_EDIT, Deed::ARTICLE_EDIT] })
+    =deeds_for({ :collection => true, :limit => 10, :types => DeedType.document_set_edits })
 
 =render({ :partial => '/shared/collection_footer' })

--- a/app/views/statistics/_collection_statistics.html.slim
+++ b/app/views/statistics/_collection_statistics.html.slim
@@ -2,15 +2,15 @@
     .collection-stats_counters
       .counter(data-prefix="#{number_with_delimiter stats[:works]}") #{'Work'.pluralize(stats[:works])}
       .counter(data-prefix="#{number_with_delimiter stats[:pages]}") #{'Page'.pluralize(stats[:pages])}
-      .counter(data-prefix="#{number_with_delimiter stats[Deed::NOTE_ADDED]}") #{'Note'.pluralize(stats[Deed::NOTE_ADDED])}
+      .counter(data-prefix="#{number_with_delimiter stats[DeedType::NOTE_ADDED]}") #{'Note'.pluralize(stats[DeedType::NOTE_ADDED])}
       -unless subjects_disabled
         .counter(data-prefix="#{number_with_delimiter stats[:subjects]}") #{'Subject'.pluralize(stats[:subjects])}
         .counter(data-prefix="#{number_with_delimiter stats[:mentions]}") #{'Reference'.pluralize(stats[:mentions])}
       .counter(data-prefix="#{number_with_delimiter stats[:contributors]}") #{'Collaborator'.pluralize(stats[:contributors])}
     .collection-stats_counters
-      .counter(data-prefix="#{number_with_delimiter stats[Deed::PAGE_TRANSCRIPTION]}") #{'Page'.pluralize(stats[Deed::PAGE_TRANSCRIPTION])} transcribed
-      .counter(data-prefix="#{number_with_delimiter stats[Deed::PAGE_EDIT]}") Page edits
+      .counter(data-prefix="#{number_with_delimiter stats[DeedType::PAGE_TRANSCRIPTION]}") #{'Page'.pluralize(stats[DeedType::PAGE_TRANSCRIPTION])} transcribed
+      .counter(data-prefix="#{number_with_delimiter stats[DeedType::PAGE_EDIT]}") Page edits
       -unless subjects_disabled
-        .counter(data-prefix="#{number_with_delimiter stats[Deed::PAGE_INDEXED]}") #{'Page'.pluralize(stats[Deed::PAGE_INDEXED])} indexed
-      .counter(data-prefix="#{number_with_delimiter stats[Deed::PAGE_TRANSLATED]}") #{'Page'.pluralize(stats[Deed::PAGE_TRANSLATED])} translated
-      .counter(data-prefix="#{number_with_delimiter stats[Deed::OCR_CORRECTED]}") OCR #{'Correction'.pluralize(stats[Deed::OCR_CORRECTED])}
+        .counter(data-prefix="#{number_with_delimiter stats[DeedType::PAGE_INDEXED]}") #{'Page'.pluralize(stats[DeedType::PAGE_INDEXED])} indexed
+      .counter(data-prefix="#{number_with_delimiter stats[DeedType::PAGE_TRANSLATED]}") #{'Page'.pluralize(stats[DeedType::PAGE_TRANSLATED])} translated
+      .counter(data-prefix="#{number_with_delimiter stats[DeedType::OCR_CORRECTED]}") OCR #{'Correction'.pluralize(stats[DeedType::OCR_CORRECTED])}

--- a/app/views/statistics/_recent_statistics.html.slim
+++ b/app/views/statistics/_recent_statistics.html.slim
@@ -1,11 +1,11 @@
 section.collection-stats_recent
     .counter(data-prefix="#{number_with_delimiter stats[:contributors]}") #{'Collaborator'.pluralize(stats[:contributors])}
-    .counter(data-prefix="#{number_with_delimiter stats[Deed::PAGE_TRANSCRIPTION]}") #{'Page'.pluralize(stats[Deed::PAGE_TRANSCRIPTION])} transcribed
-    .counter(data-prefix="#{number_with_delimiter stats[Deed::PAGE_EDIT]}") Page #{'edit'.pluralize(stats[Deed::PAGE_EDIT])}
+    .counter(data-prefix="#{number_with_delimiter stats[DeedType::PAGE_TRANSCRIPTION]}") #{'Page'.pluralize(stats[DeedType::PAGE_TRANSCRIPTION])} transcribed
+    .counter(data-prefix="#{number_with_delimiter stats[DeedType::PAGE_EDIT]}") Page #{'edit'.pluralize(stats[DeedType::PAGE_EDIT])}
     -unless subjects_disabled
-      .counter(data-prefix="#{number_with_delimiter stats[Deed::PAGE_INDEXED]}") #{'Page'.pluralize(stats[Deed::PAGE_INDEXED])} indexed
+      .counter(data-prefix="#{number_with_delimiter stats[DeedType::PAGE_INDEXED]}") #{'Page'.pluralize(stats[DeedType::PAGE_INDEXED])} indexed
       .counter(data-prefix="#{number_with_delimiter stats[:mentions]}") #{'Reference'.pluralize(stats[:mentions])}
       .counter(data-prefix="#{number_with_delimiter stats[:subjects]}") New #{'subject'.pluralize(stats[:subjects])}
-    .counter(data-prefix="#{number_with_delimiter stats[Deed::NOTE_ADDED]}") #{'Note'.pluralize(stats[Deed::NOTE_ADDED])}
-    .counter(data-prefix="#{number_with_delimiter stats[Deed::PAGE_TRANSLATED]}") #{'Page'.pluralize(stats[Deed::PAGE_TRANSLATED])} translated
-    .counter(data-prefix="#{number_with_delimiter stats[Deed::OCR_CORRECTED]}") OCR #{'Correction'.pluralize(stats[Deed::OCR_CORRECTED])}
+    .counter(data-prefix="#{number_with_delimiter stats[DeedType::NOTE_ADDED]}") #{'Note'.pluralize(stats[DeedType::NOTE_ADDED])}
+    .counter(data-prefix="#{number_with_delimiter stats[DeedType::PAGE_TRANSLATED]}") #{'Page'.pluralize(stats[DeedType::PAGE_TRANSLATED])} translated
+    .counter(data-prefix="#{number_with_delimiter stats[DeedType::OCR_CORRECTED]}") OCR #{'Correction'.pluralize(stats[DeedType::OCR_CORRECTED])}

--- a/db/migrate/032_create_deeds.rb
+++ b/db/migrate/032_create_deeds.rb
@@ -17,14 +17,14 @@ class CreateDeeds < ActiveRecord::Migration
     transcriptions = PageVersion.where('page_version=1').all
     transcriptions.each do |pv|
       deed = self.deed_from_version(pv)
-      deed.deed_type = Deed::PAGE_TRANSCRIPTION
+      deed.deed_type = DeedType::PAGE_TRANSCRIPTION
       deed.save!
     end
 
     edits = PageVersion.where('page_version>1').all
     edits.each do |pv|
       deed = self.deed_from_version(pv)
-      deed.deed_type = Deed::PAGE_EDIT
+      deed.deed_type = DeedType::PAGE_EDIT
       deed.save!
     end
 

--- a/lib/tasks/ingestor.rake
+++ b/lib/tasks/ingestor.rake
@@ -269,25 +269,25 @@ namespace :fromthepage do
       page.base_width = image.columns
       image = nil
       GC.start
-      work.pages << page      
+      work.pages << page
        print "\t\tconvert_to_work added #{image_fn} to work as page #{page.title}, id=#{page.id}\n"
     end
     work.save!
     record_deed(work)
-    
+
     document_sets.each do |ds|
       print "\t\tconvert_to-work adding #{work.title} to document set #{ds.title}"
       ds.works << work
-      ds.save!      
+      ds.save!
     end
-    
+
     print "convert_to_work succeeded for #{work.title}\n"
   end
 
   def record_deed(work)
     deed = Deed.new
     deed.work = work
-    deed.deed_type = Deed::WORK_ADDED
+    deed.deed_type = DeedType::WORK_ADDED
     deed.collection = work.collection
     deed.user = work.owner
     deed.save!

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :collection do
+    sequence(:title) { |n| "collection title #{n}"}
 
     trait :with_links do
       works { build_stubbed_list :work_with_links, 2 }
@@ -48,6 +49,16 @@ FactoryBot.define do
 end
 
 FactoryBot.define do
-  factory :user
+  # You will need to declare a `deed_type` within the spec
+  factory :deed
 end
 
+FactoryBot.define do
+  factory :user do
+    sequence(:display_name) { |n| "User #{n} Display Name" }
+    sequence(:login) { |n| "user_#{n}_login" }
+    sequence(:email) { |n| "user_#{n}@sample.com" }
+    password { 'password' }
+    password_confirmation { 'password' }
+  end
+end

--- a/spec/features/display_marked_as_blank_spec.rb
+++ b/spec/features/display_marked_as_blank_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+describe "display marked as blank" do
+  let(:deed_type) { DeedType::PAGE_MARKED_BLANK }
+
+  it 'shows pages marked blank in main Activity Feed page' do
+    # Build out factories
+    user = create(:user)
+    collection = create(:collection, owner_user_id: user.id)
+    work = create(:work, owner_user_id: user.id, collection_id: collection.id)
+    page1 = create(:page, work_id: work.id)
+    deed = create(:deed, {
+      deed_type: deed_type,
+      page_id: page1.id,
+      work_id: work.id,
+      collection_id: collection.id,
+      user_id: user.id
+      })
+
+    # Visit page
+    visit 'deed/list'
+    expect(page).to have_content('Page Marked Blank')
+
+    # Tear down Factories
+    Deed.destroy(deed.id)
+    Page.destroy(page1.id)
+    Work.destroy(work.id)
+    Collection.destroy(collection.id)
+    User.destroy(user.id)
+  end
+
+  it 'shows pages marked blank in collection Recent Activity sidebar feed' do
+    # Build out factories
+    user = create(:user)
+    collection = create(:collection, owner_user_id: user.id)
+    work = create(:work, owner_user_id: user.id, collection_id: collection.id)
+    page1 = create(:page, work_id: work.id)
+    deed = create(:deed, {
+      deed_type: deed_type,
+      page_id: page1.id,
+      work_id: work.id,
+      collection_id: collection.id,
+      user_id: user.id
+      })
+
+    # Visit page
+    visit 'collections'
+    expect(page.find('.sidecol')).to have_content("#{user.display_name} marked page #{page1.title} as blank")
+
+    # Tear down Factories
+    Deed.destroy(deed.id)
+    Page.destroy(page1.id)
+    Work.destroy(work.id)
+    Collection.destroy(collection.id)
+    User.destroy(user.id)
+  end
+
+  it 'shows pages marked blank in collection Recent Edits sidebar feed' do
+    # Build out factories
+    user = create(:user)
+    collection = create(:collection, owner_user_id: user.id)
+    work = create(:work, owner_user_id: user.id, collection_id: collection.id)
+    page1 = create(:page, work_id: work.id)
+    deed = create(:deed, {
+      deed_type: deed_type,
+      page_id: page1.id,
+      work_id: work.id,
+      collection_id: collection.id,
+      user_id: user.id
+      })
+
+    # Visit page
+    visit "#{user.login}/#{collection.slug}"
+    expect(page).to have_content('Recent Edits')
+    expect(page.find('.sidecol')).to have_content("#{user.display_name} marked page #{page1.title} as blank")
+
+    # Tear down Factories
+    Deed.destroy(deed.id)
+    Page.destroy(page1.id)
+    Work.destroy(work.id)
+    Collection.destroy(collection.id)
+    User.destroy(user.id)
+  end
+end

--- a/spec/features/needs_review_spec.rb
+++ b/spec/features/needs_review_spec.rb
@@ -69,7 +69,7 @@ describe "needs review", :order => :defined do
     expect(@page4.status).to be_nil
     expect(@page5.status).to be_nil
     expect(page).to have_content(@collection.title)
-    click_link @work.title
+    page.find('.maincol').click_link @work.title
     page.find('.work-page_title', text: @page4.title).click_link(@page4.title)
     page.fill_in 'page_source_text', with: "Review Text"
     page.check('page_needs_review')

--- a/spec/models/deed_spec.rb
+++ b/spec/models/deed_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+RSpec.describe Deed, type: :model do
+  context "associations" do
+    it { should belong_to(:article) }
+    it { should belong_to(:collection) }
+    it { should belong_to(:note) }
+    it { should belong_to(:page) }
+    it { should belong_to(:user) }
+    it { should belong_to(:work) }
+  end
+
+  context "validations" do
+    it { should validate_inclusion_of(:deed_type).in_array(DeedType.all_types) }
+  end
+
+  describe '.order_by_recent_activity' do
+    let(:deed_type) { DeedType.all_types.first }
+
+    it 'lists deeds in order by most recently created' do
+      first_deed = create(:deed, deed_type: deed_type)
+      sleep(1)
+      second_deed = create(:deed, deed_type: deed_type)
+
+      expect(Deed.order_by_recent_activity.first).to eq(second_deed)
+
+      # Tear down factories
+      Deed.destroy(first_deed.id)
+      Deed.destroy(second_deed.id)
+    end
+  end
+
+  describe '.active' do
+    let(:deed_type) { DeedType.all_types.first }
+
+    it 'returns deeds by all active users' do
+      inactive_user = create(:user, deleted: true)
+      inactive_user_deed = create(:deed, deed_type: deed_type, user_id: inactive_user.id)
+      active_user = create(:user)
+      active_user_deed = create(:deed, deed_type: deed_type, user_id: active_user.id)
+
+      expect(Deed.active).to include(active_user_deed)
+      expect(Deed.active).to_not include(inactive_user_deed)
+
+      # Tear down factories
+      Deed.destroy(inactive_user_deed.id)
+      Deed.destroy(active_user_deed.id)
+      User.destroy(inactive_user.id)
+      User.destroy(active_user.id)
+    end
+  end
+
+  describe '.past_day' do
+    let(:old_date) { 2.day.ago }
+    let(:deed_type) { DeedType.all_types.first }
+
+    it 'returns deeds created within the past day' do
+      old_deed = create(:deed, deed_type: deed_type, created_at: old_date)
+      deed_from_today = create(:deed, deed_type: deed_type)
+
+      expect(Deed.past_day).to include(deed_from_today)
+      expect(Deed.past_day).to_not include(old_deed)
+
+      # Tear down factories
+      Deed.destroy(old_deed.id)
+      Deed.destroy(deed_from_today.id)
+    end
+  end
+
+  describe '#deed_type_name' do
+    let(:deed_type) { DeedType.all_types.first }
+
+    it 'returns the human-readable name for the deed type' do
+      deed = create(:deed, deed_type: deed_type)
+      human_readable_name = DeedType::TYPES[deed_type]
+
+      expect(deed.deed_type_name).to eq(human_readable_name)
+
+      # Tear down factories
+      Deed.destroy(deed.id)
+    end
+  end
+end

--- a/spec/models/deed_type_spec.rb
+++ b/spec/models/deed_type_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+RSpec.describe DeedType, type: :model do
+
+  describe 'TYPES' do
+    it 'has all 13 DeedTypes' do
+      expect(DeedType::TYPES.length).to eq(13)
+    end
+  end
+  
+  describe '.all_types' do
+    it 'returns the machine-readable types' do
+      type = DeedType::PAGE_TRANSCRIPTION
+      expect(DeedType.all_types).to include(type)
+    end
+
+    it 'does not return the full pair machine-readable and human-readable names' do
+      pair = DeedType::TYPES.first
+      expect(DeedType.all_types).to_not include(pair)
+    end
+  end
+
+  describe '.contributor_types' do
+    it 'returns an array of machine-readable type names' do
+      type = DeedType::PAGE_TRANSCRIPTION
+      expect(DeedType.contributor_types).to include(type)
+      expect(DeedType.contributor_types).to be_a_kind_of(Array)
+    end
+
+    it 'excludes the "Work Added" type' do
+      type = DeedType::WORK_ADDED
+      expect(DeedType.contributor_types).to_not include(type)
+    end
+  end
+
+  describe '.name' do
+    it 'returns the human-readable name for a type' do
+      type = DeedType::PAGE_TRANSCRIPTION
+      human_readable = DeedType::TYPES[type]
+
+      expect(DeedType.name(type)).to eq(human_readable)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,6 +75,13 @@ Capybara.configure do |config|
   config.asset_host = "http://localhost:3000"
 end
 
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
+
 INACTIVE = "ron"
 REST_USER = "george"
 USER = "eleanor"

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
Closes #1214 

Previously, deeds were not being recorded when a user marked a page as blank while on the `Transcribe` tab. Now they are being recorded and they're displayed in:

The main Activity Stream:
(url: 'deed/list')
<img width="943" alt="screenshot 2018-10-17 08 19 28" src="https://user-images.githubusercontent.com/8680712/47180416-2cc1a780-d2e6-11e8-83d2-c3fe86612599.png">

In the collections sidebar under Recent Activity:
(url: 'collections')
<img width="347" alt="screenshot 2018-10-17 08 19 21" src="https://user-images.githubusercontent.com/8680712/47180415-2cc1a780-d2e6-11e8-906b-42b0a1538f8b.png">

In a collection's sidebar under Recent Edits:
(url:  "#{user.login}/#{collection.slug}")
<img width="332" alt="screenshot 2018-10-17 08 28 54" src="https://user-images.githubusercontent.com/8680712/47180417-2cc1a780-d2e6-11e8-966b-6f6d0ef83fb2.png">

## Bonus Wins
Business logic around how to define a deed's type is now in a class called `DeedType`. Some specific wins are:
1. Calling groups of `deed_types` by one method instead of a hand-coded array:
```
# Before
validates_inclusion_of :deed_type, :in => [ PAGE_TRANSCRIPTION, PAGE_EDIT, PAGE_INDEXED, ARTICLE_EDIT, NOTE_ADDED, PAGE_TRANSLATED, PAGE_TRANSLATION_EDIT, OCR_CORRECTED, NEEDS_REVIEW, TRANSLATION_REVIEW, TRANSLATION_INDEXED, WORK_ADDED ]

# After
a) validates_inclusion_of :deed_type, in: DeedType.all_types

b) =deeds_for({ :collection => @collection, :limit => 20, :types => DeedType.collection_edits, :long_view => true })

c) works = Work.joins(:deeds, :sc_manifest).where("sc_manifests.at_id LIKE ?", "%#{domain}%").where(:deeds => { :created_at => terminus_a_quo..terminus_ad_quem, :deed_type => DeedType.contributor_types}).distinct

d) .deed-type {
  $color: #B30;
  $opacity: 0.4;
  $rotate: 0deg;
  @each $type in <%= DeedType.all_types %> { 
    &-#{$type} { background: rgba(adjust-hue($color, $rotate), $opacity); }
    $rotate: $rotate - 30deg;
  }
}
```
2. We can replace large case statements with a single method
```
# Before
def deed_type_name
    return case self.deed_type
    when PAGE_TRANSCRIPTION
      'Page Transcribed'
    when PAGE_EDIT
      'Page Edited'
    when PAGE_INDEXED
      'Page Indexed'
    when ARTICLE_EDIT
      'Article Edited'
    when NOTE_ADDED
      'Note Added'
    when PAGE_TRANSLATED
      'Page Translated'
    when PAGE_TRANSLATION_EDIT
      'Translation Page Edited'
    when OCR_CORRECTED
      'Page OCR Corrected'
    when NEEDS_REVIEW
      'Page Needs Review'
    when  TRANSLATION_REVIEW
      'Translation Page Needs Review'
    when TRANSLATION_INDEXED
      'Translation Page Indexed'
    when WORK_ADDED
      'Work Added'
    end
  end

# After
def deed_type_name
  DeedType.name(self.deed_type)
end
```
3. Any decisions about `DeedType`s will be in one, predictable location

### Caveat
Moving 12 constants from the `Deed` model to the `DeedType` model means changing instances of `Deed::PAGE_TRANSCRIPTION` to `DeedType::PAGE_TRANSCRIPTION` (etc) across several files. So a lot of files have been modified in this PR. 
