### PR TITLE
Admin dashboard performance improvment

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -15,14 +15,18 @@ class AdminController < ApplicationController
   end
 
   def index
-    @collections = Collection.all
-    @articles = Article.all
-    @works = Work.all
-    @ia_works = IaWork.all
-    @pages = Page.all
-
     @users = User.all
-    @owners = @users.select {|i| i.owner == true}
+    @owners = User.where(owner: true)
+
+    # Count stats for dashboard
+    @collections_count  = Collection.all.count
+    @articles_count     = Article.all.count
+    @works_count        = Work.all.count
+    @ia_works_count     = IaWork.all.count
+    @pages_count        = Page.all.count
+    @users_count        = User.all.count
+    @owners_count       = User.where(owner: true).count
+
     @version = ActiveRecord::Migrator.current_version
 =begin
     sql_online =

--- a/app/views/admin/index.html.slim
+++ b/app/views/admin/index.html.slim
@@ -2,15 +2,15 @@
 
 section.admin-counters
   =link_to ({ :controller => 'admin', :action => 'collection_list' }) do
-    .counter.link(data-prefix="#{number_with_delimiter @collections.length}") #{'Collection'.pluralize(@collections.length)}
+    .counter.link(data-prefix="#{number_with_delimiter @collections_count}") #{'Collection'.pluralize(@collections_count)}
   =link_to ({ :controller => 'admin', :action => 'work_list'}) do
-    .counter.link(data-prefix="#{number_with_delimiter @works.length}") #{'Work'.pluralize(@works.length)}
-  .counter(data-prefix="#{number_with_delimiter @articles.length}") #{'Article'.pluralize(@articles.length)}
-  .counter(data-prefix="#{number_with_delimiter @pages.length}") #{'Page'.pluralize(@pages.length)}
+    .counter.link(data-prefix="#{number_with_delimiter @works_count}") #{'Work'.pluralize(@works_count)}
+  .counter(data-prefix="#{number_with_delimiter @articles_count}") #{'Article'.pluralize(@articles_count)}
+  .counter(data-prefix="#{number_with_delimiter @pages_count}") #{'Page'.pluralize(@pages_count)}
   =link_to ({ :controller => 'admin', :action => 'owner_list'}) do
-    .counter.link(data-prefix="#{number_with_delimiter @owners.length}") #{'Owner'.pluralize(@owners.length)}
+    .counter.link(data-prefix="#{number_with_delimiter @owners_count}") #{'Owner'.pluralize(@owners_count)}
   =link_to ({ :controller => 'admin', :action => 'user_list'}) do
-    .counter.link(data-prefix="#{number_with_delimiter @users.length}") #{'Registered user'.pluralize(@users.length)}
+    .counter.link(data-prefix="#{number_with_delimiter @users_count}") #{'Registered user'.pluralize(@users_count)}
 
 -unless Deed.last.nil?
  h4.acenter="Last deed logged #{time_ago_in_words Deed.last.created_at} ago by #{Deed.last.user.display_name}"


### PR DESCRIPTION
Closes #1249 

This PR changes a number of `Model.all` queries (which were only used for their `.length` property to `Model.all.count`.

Additionally, it gives the `@owners` variable its own query using `.where` rather than filtering `User.all`. This should help leverage ActiveRecord's caching and lazy querying where possible (e.g., pagination).