### PR TITLE
Remove MySQL 5.7 Tests from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,10 @@ jobs:
     - stage: test
       env: DB=mysql
       gemfile: Gemfile
-    - env: DB=mysql
-      gemfile: gemfiles/Gemfile.mysql57
-    - env: DB=mysql57
-      gemfile: gemfiles/Gemfile.mysql57
     - addons:
         mariadb: '10.0'
       env: DB=mariadb
       gemfile: Gemfile
-    - addons:
-        mariadb: '10.0'
-      env: DB=mariadb
-      gemfile: gemfiles/Gemfile.mysql57
 
 before_install:
   - sudo apt-get -qq update

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ jobs:
     - stage: test
       env: DB=mysql
       gemfile: Gemfile
+    - env: DB=mysql57
+      gemfile: Gemfile
     - addons:
         mariadb: '10.0'
       env: DB=mariadb

--- a/travis/.travis_mysql57.sh
+++ b/travis/.travis_mysql57.sh
@@ -6,7 +6,7 @@ apt-get purge -qq '^mysql*' '^libmysql*'
 rm -fr /etc/mysql
 rm -fr /var/lib/mysql
 add-apt-repository 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7'
-apt-key adv --keyserver pgp.mit.edu --recv-keys 5072E1F5
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8C718D3B5072E1F5
 apt-get update -qq
 apt-get install -qq mysql-server libmysqlclient-dev
 

--- a/travis/.travis_mysql57.sh
+++ b/travis/.travis_mysql57.sh
@@ -6,6 +6,7 @@ apt-get purge -qq '^mysql*' '^libmysql*'
 rm -fr /etc/mysql
 rm -fr /var/lib/mysql
 add-apt-repository 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7'
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8C718D3B5072E1F5
 apt-get update -qq
 apt-get install -qq mysql-server libmysqlclient-dev
 

--- a/travis/.travis_mysql57.sh
+++ b/travis/.travis_mysql57.sh
@@ -5,8 +5,8 @@ set -eux
 apt-get purge -qq '^mysql*' '^libmysql*'
 rm -fr /etc/mysql
 rm -fr /var/lib/mysql
-apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 5072E1F5
 add-apt-repository 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7'
+sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 5072E1F5
 apt-get update -qq
 apt-get install -qq mysql-server libmysqlclient-dev
 

--- a/travis/.travis_mysql57.sh
+++ b/travis/.travis_mysql57.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eux
+
+apt-get purge -qq '^mysql*' '^libmysql*'
+rm -fr /etc/mysql
+rm -fr /var/lib/mysql
+add-apt-repository 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7'
+apt-get update -qq
+apt-get install -qq mysql-server libmysqlclient-dev
+
+# https://www.percona.com/blog/2016/03/16/change-user-password-in-mysql-5-7-with-plugin-auth_socket/
+mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY ''"

--- a/travis/.travis_mysql57.sh
+++ b/travis/.travis_mysql57.sh
@@ -6,7 +6,7 @@ apt-get purge -qq '^mysql*' '^libmysql*'
 rm -fr /etc/mysql
 rm -fr /var/lib/mysql
 add-apt-repository 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7'
-sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 5072E1F5
+apt-key adv --keyserver pgp.mit.edu --recv-keys 5072E1F5
 apt-get update -qq
 apt-get install -qq mysql-server libmysqlclient-dev
 

--- a/travis/.travis_mysql57.sh
+++ b/travis/.travis_mysql57.sh
@@ -6,7 +6,7 @@ apt-get purge -qq '^mysql*' '^libmysql*'
 rm -fr /etc/mysql
 rm -fr /var/lib/mysql
 add-apt-repository 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7'
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8C718D3B5072E1F5
+sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 5072E1F5
 apt-get update -qq
 apt-get install -qq mysql-server libmysqlclient-dev
 

--- a/travis/.travis_mysql57.sh
+++ b/travis/.travis_mysql57.sh
@@ -5,8 +5,8 @@ set -eux
 apt-get purge -qq '^mysql*' '^libmysql*'
 rm -fr /etc/mysql
 rm -fr /var/lib/mysql
+apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 5072E1F5
 add-apt-repository 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7'
-sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 5072E1F5
 apt-get update -qq
 apt-get install -qq mysql-server libmysqlclient-dev
 


### PR DESCRIPTION
Closes #1287

I was getting test failures on all the Travis environments that needed the `mysql57.gemfile`. I was pleasantly surprised to realize these failures were because we removed support for MySQL 5.7 and had deleted the old gemfile. 

So, I removed any environment that was looking for the old gemfile (since it's not tehre any more). Perhaps there was a reason why this hadn't been done... I figured it was a 5min fix for me either way.