### PR TITLE
Export Collaborator Activity Stream

### DIFF
--- a/app/controllers/collection_controller.rb
+++ b/app/controllers/collection_controller.rb
@@ -349,9 +349,9 @@ class CollectionController < ApplicationController
         d.user.email,
         d.deed_type,
         d.page.title,
-        collection_transcribe_page_path(d.page.collection.owner, d.page.collection, d.page.work, d.page),
+        collection_transcribe_page_url(d.page.collection.owner, d.page.collection, d.page.work, d.page),
         d.work.title,
-        collection_read_work_path(d.work.collection.owner, d.work.collection, d.work)
+        collection_read_work_url(d.work.collection.owner, d.work.collection, d.work)
       ]
     }
 

--- a/app/controllers/collection_controller.rb
+++ b/app/controllers/collection_controller.rb
@@ -330,6 +330,7 @@ class CollectionController < ApplicationController
     end_date = end_date.to_datetime.end_of_day
 
     recent_activity = @collection.deeds.where({created_at: start_date...end_date})
+        .where(deed_type: DeedType.contributor_types)
 
     headers = [
       :date,
@@ -344,7 +345,7 @@ class CollectionController < ApplicationController
     ]
 
     rows = recent_activity.map {|d|
-    
+
     note = ''
     note += d.note.title if d.deed_type == DeedType::NOTE_ADDED && !d.note.nil?
       

--- a/app/controllers/collection_controller.rb
+++ b/app/controllers/collection_controller.rb
@@ -329,7 +329,7 @@ class CollectionController < ApplicationController
     start_date = start_date.to_datetime.beginning_of_day
     end_date = end_date.to_datetime.end_of_day
 
-    recent_activity = @collection.deeds.where({created_at: start_date..end_date})
+    recent_activity = @collection.deeds.where({created_at: start_date...end_date})
 
     headers = [
       :date,
@@ -339,10 +339,15 @@ class CollectionController < ApplicationController
       :page_title,
       :page_url,
       :work_title,
-      :work_url
+      :work_url,
+      :comment
     ]
 
     rows = recent_activity.map {|d|
+    
+    note = ''
+    note += d.note.title if d.deed_type == DeedType::NOTE_ADDED && !d.note.nil?
+      
       [
         d.created_at,
         d.user.display_name,
@@ -351,7 +356,8 @@ class CollectionController < ApplicationController
         d.page.title,
         collection_transcribe_page_url(d.page.collection.owner, d.page.collection, d.page.work, d.page),
         d.work.title,
-        collection_read_work_url(d.work.collection.owner, d.work.collection, d.work)
+        collection_read_work_url(d.work.collection.owner, d.work.collection, d.work),
+        note
       ]
     }
 

--- a/app/controllers/collection_controller.rb
+++ b/app/controllers/collection_controller.rb
@@ -322,6 +322,54 @@ class CollectionController < ApplicationController
       
   end
 
+  def activity_download
+    start_date = params[:start_date]
+    end_date = params[:end_date]
+
+    start_date = start_date.to_datetime.beginning_of_day
+    end_date = end_date.to_datetime.end_of_day
+
+    recent_activity = @collection.deeds.where({created_at: start_date..end_date})
+
+    headers = [
+      :date,
+      :user,
+      :user_email,
+      :deed_type,
+      :page_title,
+      :page_url,
+      :work_title,
+      :work_url
+    ]
+
+    rows = recent_activity.map {|d|
+      [
+        d.created_at,
+        d.user.display_name,
+        d.user.email,
+        d.deed_type,
+        d.page.title,
+        collection_transcribe_page_path(d.page.collection.owner, d.page.collection, d.page.work, d.page),
+        d.work.title,
+        collection_read_work_path(d.work.collection.owner, d.work.collection, d.work)
+      ]
+    }
+
+    csv = CSV.generate(:headers => true) do |records|
+      records << headers
+      rows.each do |row|
+          records << row
+      end
+    end
+
+    send_data( csv, 
+      :filename => "#{start_date.strftime('%Y-%m%b-%d')}-#{end_date.strftime('%Y-%m%b-%d')}_#{@collection.slug}_activity.csv",
+      :type => "application/csv")
+
+    cookies['download_finished'] = 'true'
+
+  end
+
   def blank_collection
     collection = Collection.find_by(id: params[:collection_id])
     collection.blank_out_collection

--- a/app/controllers/collection_controller.rb
+++ b/app/controllers/collection_controller.rb
@@ -341,7 +341,9 @@ class CollectionController < ApplicationController
       :page_url,
       :work_title,
       :work_url,
-      :comment
+      :comment,
+      :subject_title,
+      :subject_url
     ]
 
     rows = recent_activity.map {|d|
@@ -349,17 +351,31 @@ class CollectionController < ApplicationController
     note = ''
     note += d.note.title if d.deed_type == DeedType::NOTE_ADDED && !d.note.nil?
       
-      [
+      record = [
         d.created_at,
         d.user.display_name,
         d.user.email,
-        d.deed_type,
-        d.page.title,
-        collection_transcribe_page_url(d.page.collection.owner, d.page.collection, d.page.work, d.page),
-        d.work.title,
-        collection_read_work_url(d.work.collection.owner, d.work.collection, d.work),
-        note
+        d.deed_type
       ]
+
+      if d.deed_type == DeedType::ARTICLE_EDIT
+        record += ['','','','','',]
+        record += [
+          d.article.title, 
+          collection_article_show_url(d.collection.owner, d.collection, d.article)
+        ]
+      else
+        pagedeeds = [
+          d.page.title,
+          collection_transcribe_page_url(d.page.collection.owner, d.page.collection, d.page.work, d.page),
+          d.work.title,
+          collection_read_work_url(d.work.collection.owner, d.work.collection, d.work),
+          note,
+        ] 
+        record += pagedeeds
+        record += ['','']
+      end
+      record
     }
 
     csv = CSV.generate(:headers => true) do |records|

--- a/app/views/collection/_contributors_body.html.slim
+++ b/app/views/collection/_contributors_body.html.slim
@@ -14,28 +14,36 @@
   h4.legend.fglight Collaborator Stats #{@start_deed} through #{@end_deed}
   =render({ :partial => 'statistics/recent_statistics', 
             :locals => { :stats => @stats, :subjects_disabled => @collection.subjects_disabled }})
-  =link_to 'Details', { :controller => 'deed', :action => 'list',
-    :collection_id => @collection.id, :start_date => @start_deed, :end_date => @end_deed }
-
+  
+  =link_to('View Activity ', { :controller => 'deed', :action => 'list',
+    :collection_id => @collection.id, :start_date => @start_deed, :end_date => @end_deed },  :class => 'button btnExport')
+  | &nbsp;
+  =link_to({:controller => 'collection', :action => 'activity_download',
+          :collection_id => @collection.id, :start_date => @start_deed, :end_date => @end_deed}, :class => 'button btnExport')
+          =svg_symbol '#icon-export', class: 'icon'
+          span Export Activity as CSV
+    
 -else
   h3 No activity in this time frame
 
 .contributor-users
     h3 Active Collaborators
+    
     -unless @active_transcribers.empty?
+      p
       -@active_transcribers.each do |user|
-        p
           =link_to user.display_name, { :controller => 'user', :action => 'profile', :user_id => user.id, only_path: false }
           =" (Collection: #{(@user_time_proportional[user.id] / 60 + 1).floor} minutes | Total: #{(@user_time[user.id] / 60 + 1).floor} minutes)" if @user_time[user.id]  
-
+          | <br>
       p
         -total_minutes = (@user_time.values.sum / 60).floor + 1
         ="Total time: #{(total_minutes / 60)} hours, #{(total_minutes % 60)} minutes."
-      p
+        | <br />
+        
         =link_to({:controller => 'collection', :action => 'contributors_download',
-          :collection_id => @collection.id, :start_date => @start_deed, :end_date => @end_deed,},  class: 'button btnExport')
-          =svg_symbol '#icon-export', class: 'icon'
-          span Export as CSV
+            :collection_id => @collection.id, :start_date => @start_deed, :end_date => @end_deed,})
+            =svg_symbol '#icon-export', class: 'icon'
+            span 'Export as CSV
     -else
       h3 Collaborators
       p No Collaborators

--- a/app/views/collection/_contributors_body.html.slim
+++ b/app/views/collection/_contributors_body.html.slim
@@ -38,10 +38,9 @@
       p
         -total_minutes = (@user_time.values.sum / 60).floor + 1
         ="Total time: #{(total_minutes / 60)} hours, #{(total_minutes % 60)} minutes."
-        | <br />
-        
+      p  
         =link_to({:controller => 'collection', :action => 'contributors_download',
-            :collection_id => @collection.id, :start_date => @start_deed, :end_date => @end_deed,})
+            :collection_id => @collection.id, :start_date => @start_deed, :end_date => @end_deed}, :class => 'button btnExport')
             =svg_symbol '#icon-export', class: 'icon'
             span 'Export as CSV
     -else

--- a/app/views/collection/_contributors_body.html.slim
+++ b/app/views/collection/_contributors_body.html.slim
@@ -42,7 +42,7 @@
         =link_to({:controller => 'collection', :action => 'contributors_download',
             :collection_id => @collection.id, :start_date => @start_deed, :end_date => @end_deed}, :class => 'button btnExport')
             =svg_symbol '#icon-export', class: 'icon'
-            span 'Export as CSV
+            span Export as CSV
     -else
       h3 Collaborators
       p No Collaborators


### PR DESCRIPTION
Closes #1280 

TODO:
- [x] Add comment/note text to export
- [x] Provide example export file
- [x] Test against new DB with two-year timeframe, (JBD and LVa)
- [x] Add subject title and url to export

This PR adds the ability for collection owners to export collaborator activity, scoped to a particular date range.

![image](https://user-images.githubusercontent.com/1544859/53688288-9677a680-3d07-11e9-8b66-5c6359f41c82.png)
The generated CSV file includes the following for each `Deed`:
1. A timestamp
2. User `display_name`
3. User `email`
4. Deed Type
5. Page Title
6. Page URL
7. Work Title
8. Work URL

In addition, this PR makes some minor adjustments to the layout of the old "veiw activity" link and standardizes the long lists of Users to use `<br />` rather than `<p>` in the interest of density.

OLD:
![image](https://user-images.githubusercontent.com/1544859/53688428-5adddc00-3d09-11e9-8955-da7448c35489.png)

NEW:
![image](https://user-images.githubusercontent.com/1544859/53688391-d4c19580-3d08-11e9-9214-f4046a0ce1b3.png)

OLD: 
![image](https://user-images.githubusercontent.com/1544859/53688426-4c8fc000-3d09-11e9-9af7-c46290f82d76.png)

NEW:
![image](https://user-images.githubusercontent.com/1544859/53688441-a85a4900-3d09-11e9-942a-c3d836ef2682.png)