### PR TITLE
Export formatting for works with indexeing disabled

### DIFF
--- a/app/controllers/transcribe_controller.rb
+++ b/app/controllers/transcribe_controller.rb
@@ -167,9 +167,8 @@ class TranscribeController  < ApplicationController
       end
     elsif params['preview']
       @display_context = 'preview'
-      @preview_xml = @page.wiki_to_xml(@page.source_text, "transcription")
+      @preview_xml = @page.wiki_to_xml(@page, Page::TEXT_TYPE::TRANSCRIPTION)
       display_page
-#      @preview_xml = @page.generate_preview("transcription")
       render :action => 'display_page'
     elsif params['edit']
       display_page
@@ -286,7 +285,7 @@ class TranscribeController  < ApplicationController
       end
     elsif params['preview']
       @display_context = 'preview'
-      @preview_xml = @page.wiki_to_xml(@page.source_translation, "translation")
+      @preview_xml = @page.wiki_to_xml(@page, Page::TEXT_TYPE::TRANSLATION)
       translate
       render :action => 'translate'
     elsif params['edit']

--- a/app/models/xml_source_processor.rb
+++ b/app/models/xml_source_processor.rb
@@ -91,15 +91,15 @@ module XmlSourceProcessor
     end
   end
 
-  def wiki_to_xml(wiki, text_type)
+  def wiki_to_xml(wiki, text_type, subjects_disabled=false)
     xml_string = String.new(wiki || "")
     xml_string = process_latex_snippets(xml_string)
     xml_string = clean_bad_braces(xml_string)
-    xml_string = process_square_braces(xml_string)
+    xml_string = process_square_braces(xml_string) unless subjects_disabled
     xml_string = process_linewise_markup(xml_string)
     xml_string = process_line_breaks(xml_string)
     xml_string = valid_xml_from_source(xml_string)
-    xml_string = update_links_and_xml(xml_string, false, text_type)
+    xml_string = update_links_and_xml(xml_string, false, text_type) 
     postprocess_sections
     xml_string    
   end

--- a/app/models/xml_source_processor.rb
+++ b/app/models/xml_source_processor.rb
@@ -83,16 +83,28 @@ module XmlSourceProcessor
   ##############################################
   def process_source
     if @text_dirty
-      self.xml_text = wiki_to_xml(self.source_text, Page::TEXT_TYPE::TRANSCRIPTION)
+      self.xml_text = wiki_to_xml(self, Page::TEXT_TYPE::TRANSCRIPTION)
     end
 
     if @translation_dirty
-      self.xml_translation = wiki_to_xml(self.source_translation, Page::TEXT_TYPE::TRANSLATION)      
+      self.xml_translation = wiki_to_xml(self, Page::TEXT_TYPE::TRANSLATION)      
     end
   end
 
-  def wiki_to_xml(wiki, text_type, subjects_disabled=false)
-    xml_string = String.new(wiki || "")
+  def wiki_to_xml(page, text_type)
+
+    subjects_disabled = page.collection.subjects_disabled
+    
+    source_text = case text_type
+    when Page::TEXT_TYPE::TRANSCRIPTION
+      page.source_text
+    when Page::TEXT_TYPE::TRANSLATION
+      page.source_translation
+    else
+      ""
+    end
+
+    xml_string = String.new(source_text)
     xml_string = process_latex_snippets(xml_string)
     xml_string = clean_bad_braces(xml_string)
     xml_string = process_square_braces(xml_string) unless subjects_disabled
@@ -102,12 +114,6 @@ module XmlSourceProcessor
     xml_string = update_links_and_xml(xml_string, false, text_type) 
     postprocess_sections
     xml_string    
-  end
-
-  def generate_preview(text_type)
-    xml_string = wiki_to_xml(self.source_text, text_type)
-    xml_string = update_links_and_xml(xml_string, true, text_type)
-    return xml_string
   end
 
   BAD_SHIFT_REGEX = /\[\[([[[:alpha:]][[:blank:]]|,\(\)\-[[:digit:]]]+)\}\}/

--- a/spec/features/disable_subjects_spec.rb
+++ b/spec/features/disable_subjects_spec.rb
@@ -63,7 +63,6 @@ describe "disable subject linking", :order => :defined do
     page.find('.tabs').click_link("Contents")
     expect(page).to have_content("Actions")
     expect(page).not_to have_content("Annotate")
-
   end
 
   it "checks page level subject items" do
@@ -71,14 +70,21 @@ describe "disable subject linking", :order => :defined do
     page.find('.work-page_title', text: @title).click_link(@title)
     expect(page).not_to have_content("Autolink")
     expect(page).to have_content("A single newline")
-    page.fill_in 'page_source_text', with: "[[Texas]]"
+    page.fill_in 'page_source_text', with: "[[Canonical Subject|display subject]] [[Short Subject]]"
     find('#save_button_top').click
-    expect(page).to have_content("Texas")
+    expect(page).to have_content("[[Canonical Subject|display subject]] [[Short Subject]]")
     expect(page).to have_content("Transcription")
-    expect(page).not_to have_selector('a', text: 'Texas')
+    expect(page).not_to have_selector('a', text: 'display subject')
+    expect(page).not_to have_selector('a', text: 'Short Subject')
     page.find('.tabs').click_link("Translate")
     expect(page).not_to have_content("Autolink")
+  end
 
+  it "checks export formatting" do
+    visit "/export/show?work_id=#{@work.id}"
+    expect(page).to have_content("[[Canonical Subject|display subject]] [[Short Subject]]")
+    expect(page).not_to have_selector('a', text: 'display subject')
+    expect(page).not_to have_selector('a', text: 'Short Subject')
   end
 
   it "enables subject indexing" do
@@ -97,9 +103,23 @@ describe "disable subject linking", :order => :defined do
     expect(page).to have_content(@collection.title)
     expect(page).to have_content(@work.title)
     page.find('.work-page_title', text: @title).click_link(@title)
-    expect(page).to have_content("Transcription")
-    expect(page).to have_selector('a', text: 'Texas')
-    
-  end
+    page.find('.tabs').click_link("Transcribe")
+    find('#save_button_top').click
 
+    # Categories
+    expect(page).to have_content("Canonical Subject")
+    expect(page).to have_content("Short Subject")
+    click_link("Continue")
+
+    # Return to read page
+    page.find('.tabs').click_link("Overview")
+    expect(page).to have_selector('a', text: 'display subject')
+    expect(page).to have_selector('a', text: 'Short Subject')
+    expect(page).not_to have_content('Canonical Subject')
+  end
+  it "checks export formatting" do
+    visit "/export/show?work_id=#{@work.id}"
+    expect(page).to have_selector('a', text: 'display subject')
+    expect(page).to have_selector('a', text: 'Short Subject')
+  end
 end

--- a/spec/models/xml_source_processor_spec.rb
+++ b/spec/models/xml_source_processor_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe XmlSourceProcessor, type: :model do
 
   let(:collection){ build_stubbed(:collection ) }
   let(:work)      { build_stubbed(:work, collection: collection) }
-  let(:page)      { build_stubbed(:page, work: work)}
+  let(:page)      { build_stubbed(:page, work: work, source_text: SOURCE_TEXT)}
   let(:old_link)  { build_stubbed(:article, title: 'Old Subject', collection: collection ) }
     
     context 'subject linking not disabled (default)' do
       it 'builds the xml document' do
         expect(work.collection).to eq(collection)
-        xml = page.wiki_to_xml(SOURCE_TEXT, Page::TEXT_TYPE::TRANSCRIPTION)
+        xml = page.wiki_to_xml(page, Page::TEXT_TYPE::TRANSCRIPTION)
         expect(Article.all.count).to eq(3)
         expect(PageArticleLink.all.count).to eq(4)
         expect(xml).to eq(EXPECTED_XML)
@@ -38,8 +38,9 @@ RSpec.describe XmlSourceProcessor, type: :model do
     end
     context 'subject linking disabled' do
       it 'builds the xml document' do
-        expect(work.collection).to eq(collection)
-        xml = page.wiki_to_xml(SOURCE_TEXT, Page::TEXT_TYPE::TRANSCRIPTION, true)
+        collection.subjects_disabled = true
+
+        xml = page.wiki_to_xml(page, Page::TEXT_TYPE::TRANSCRIPTION)
         expect(xml).to eq(EXPECTED_XML_DISABLED)
         expect(Article.all.count).to eq(0)
         expect(PageArticleLink.all.count).to eq(0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,9 @@ require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'factory_bot'
 require 'webmock/rspec'
+require 'database_cleaner'
+
+DatabaseCleaner.strategy = :transaction
 
 WebMock.allow_net_connect!
 


### PR DESCRIPTION
Closes #1277 

I was able to accomplish this without completely refactoring the `wiki_to_xml` method into two. In fact, the final solution turned out to be quite simple. I was really hesitant to make any significant changes to this section because of how core this functionality is; we didn't have any tests, so I couldn't feel confident I wasn't regressing.

But, we have some tests now. One minor change I made was to change the method signature to accept the whole page object rather than only the wiki text. This allowed a more clean way to reference the page's collection object in order to determine if subject linking was disabled.

The Unit tests are simple; they basically just test that the XML output is what we expect. I had to assume that the former functionality was correct, but this will help prevent regressions, anyway.

The integration tests test both the display (reading) view of the page as well as the HTML export view.