### PR TITLE
Fix Ahoy duplicate entry errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -265,7 +265,6 @@ end
 
 
   def track_action
-    ahoy.track_visit
     extras = {}
     extras[:collection_id] = @collection.id if @collection
     extras[:collection_title] = @collection.title if @collection


### PR DESCRIPTION
Closes #1314 

Per the issue note, I was able to remove the explicit call to track the visit in the application controller. I tested this on my machine and it seems to work. There still seems to be an ahoy visit being logged (I think?)