### PR TITLE
Delete old anonymous ahoy records

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -56,7 +56,7 @@ class AdminController < ApplicationController
 
   def visit_actions
     @visit = Visit.find(params[:visit_id])
-    @actions = @visit.ahoy_events.order(time: :desc).paginate :page => params[:page], :per_page => PAGES_PER_SCREEN
+    @actions = @visit.ahoy_events.order(time: :asc).paginate :page => params[:page], :per_page => 500
   end
 
   def visit_deeds

--- a/lib/tasks/clean_anonymous_ahoy.rake
+++ b/lib/tasks/clean_anonymous_ahoy.rake
@@ -1,0 +1,8 @@
+namespace :fromthepage do
+  desc "Clean anonymous ahoy tables"
+  task clean_anonymous_ahoy: :environment do
+  	Visit.where(:user_id => nil).delete_all
+  	Ahoy::Event.where(:user_id => nil).delete_all
+  end
+
+end


### PR DESCRIPTION
On deploying this, we need to set up a cron job that does the following:
`rake fromthepage:clean_anonymous_ahoy`