### PR TITLE
Accessibility Compliance

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -77,6 +77,7 @@ $.fn.dropdown = function(s) {
     $trigger.on('mousedown.DropDown', function() {
       $element.toggleClass(cfg.openclass);
     });
+    //Open on focus
     $trigger.on('focusin.DropDown', function() {
       $element.addClass(cfg.openclass);
     });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -74,8 +74,11 @@ $.fn.dropdown = function(s) {
     var $trigger = $(cfg.trigger, this);
 
     // Open/close when clicked on the trigger
-    $trigger.on('click.DropDown', function() {
+    $trigger.on('mousedown.DropDown', function() {
       $element.toggleClass(cfg.openclass);
+    });
+    $trigger.on('focusin.DropDown', function() {
+      $element.addClass(cfg.openclass);
     });
 
     // Close when clicked on an item
@@ -88,6 +91,12 @@ $.fn.dropdown = function(s) {
 
     // Close if clicked outside
     $(document).on('click.DropDown', function(e) {
+      if($(e.target).closest($element).length === 0) {
+        $element.removeClass(cfg.openclass);
+      }
+    });
+    // Close if focus leaves
+    $(document).on('focusin.DropDown', function(e) {
       if($(e.target).closest($element).length === 0) {
         $element.removeClass(cfg.openclass);
       }

--- a/app/assets/javascripts/plugins/jquery.litebox.js
+++ b/app/assets/javascripts/plugins/jquery.litebox.js
@@ -82,7 +82,8 @@
       } else {
         // Create elements
         this.$wrapper = $('<section>').addClass('litebox').addClass(this.options.cssclass);
-        this.$closebutton = $('<a>').addClass('litebox_close').text('×');
+        this.$closebutton = $('<a>').addClass('litebox_close')
+          .attr('aria-label', 'close').text('×');
         this.$container = $('<div>').addClass('litebox_container');
         this.$content = $('<div>').addClass('litebox_content');
 

--- a/app/assets/stylesheets/base/customer_color_scheme.scss
+++ b/app/assets/stylesheets/base/customer_color_scheme.scss
@@ -69,7 +69,7 @@ $headerBg:                  $themeLight;
 
 
 //the color of lettering on the footer
-$footerFg:                  mix(#FFF, $themeDark, 50);
+$footerFg:                  mix(#FFF, $themeDark, 75);
 
 //footer background color
 $footerBg:                  $themeDark;

--- a/app/assets/stylesheets/base/customer_color_scheme.scss
+++ b/app/assets/stylesheets/base/customer_color_scheme.scss
@@ -52,9 +52,8 @@ $bodyFg:                    #200;
 
 //the background color of the app
 $bodyBg:                    mix(#FFF, $themeLight, 70);
-
-$bodyFgFaded:               mix($bodyFg, $bodyBg, 60);
-$bodyFgLight:               mix($bodyFg, $bodyBg, 50);
+$bodyFgFaded:               mix($bodyFg, $bodyBg, 80);
+$bodyFgLight:               mix($bodyFg, $bodyBg, 70);
 $borderColor:               mix(#000, $bodyBg, 15);
 
 //HEADER INFO

--- a/app/assets/stylesheets/base/ftp_color_scheme.scss
+++ b/app/assets/stylesheets/base/ftp_color_scheme.scss
@@ -43,8 +43,8 @@ $themeDark:                 #433;
 
 $bodyFg:                    #200;
 $bodyBg:                    mix(#FFF, $themeLight, 70);
-$bodyFgFaded:               mix($bodyFg, $bodyBg, 60);
-$bodyFgLight:               mix($bodyFg, $bodyBg, 50);
+$bodyFgFaded:               mix($bodyFg, $bodyBg, 80);
+$bodyFgLight:               mix($bodyFg, $bodyBg, 70);
 $bodyFgDark:                #342b2b;
 $borderColor:               mix(#000, $bodyBg, 15);
 

--- a/app/assets/stylesheets/base/ftp_color_scheme.scss
+++ b/app/assets/stylesheets/base/ftp_color_scheme.scss
@@ -52,8 +52,8 @@ $headerHeight:              80px;
 $headerFg:                  $themeDark;
 $headerBg:                  $themeLight;
 
-$footerHeight:              172px;
-$footerFg:                  mix(#FFF, $themeDark, 50);
+$footerHeight:              220px;
+$footerFg:                  mix(#FFF, $themeDark, 75);
 $footerBg:                  $themeDark;
 
 // Highlight box background color

--- a/app/assets/stylesheets/base/global.scss
+++ b/app/assets/stylesheets/base/global.scss
@@ -125,7 +125,7 @@ code {
   border-radius: 3px;
   line-height: 1.8333;
   display: inline-block;
-  background: rgba(#000, 0.03);
+  background: mix(#000, $bodyBg, 3);
   box-shadow: inset 0 0 0 1px rgba(#000, 0.08);
 }
 

--- a/app/assets/stylesheets/base/global.scss
+++ b/app/assets/stylesheets/base/global.scss
@@ -98,7 +98,6 @@ a {
   text-decoration: underline;
   transition: color 0.15s, background-color 0.15s;
   &:hover { color: $fgHover; }
-  &:focus { outline: none; }
 }
 
 hr {

--- a/app/assets/stylesheets/base/helpers.scss
+++ b/app/assets/stylesheets/base/helpers.scss
@@ -88,7 +88,7 @@ $step: 5;
   text-decoration: none !important;
 }
 .a50 {
-  opacity: 0.5;
+  opacity: 0.6;
 }
 
 // Prefix & suffix using pseudo-elements

--- a/app/assets/stylesheets/components/buttons.scss
+++ b/app/assets/stylesheets/components/buttons.scss
@@ -107,10 +107,10 @@ button, .button, input[type="submit"], input[type="reset"], input[type="button"]
     box-shadow: none;
     color: $bodyFgFaded;
     background-image: none;
-    background-color: rgba(#FFF, 0.35);
+    background-color: mix(#FFF, $bodyBg, 25);
     &:hover, &:focus {
       color: $bodyFg;
-      background-color: #FFF;
+      background-color: mix(#FFF, $bodyBg, 80);
       border-color: rgba(#000, 0.25);
     }
     &:active, &.pressed { @include button-state(active); }

--- a/app/assets/stylesheets/components/layout.scss
+++ b/app/assets/stylesheets/components/layout.scss
@@ -70,6 +70,7 @@
     width: 200px;
     float: right;
     a {
+      text-decoration: none !important;
       display: block;
       font-size: $fontSizeBig;
       line-height: 30px;
@@ -77,7 +78,7 @@
   }
   a {
     color: inherit;
-    text-decoration: none;
+    text-decoration: underline;
     &:hover { color: lighten($footerFg, 20); }
   }
 }

--- a/app/assets/stylesheets/components/litebox.scss
+++ b/app/assets/stylesheets/components/litebox.scss
@@ -103,7 +103,7 @@ $svg-litebox-error: '<path fill="#FC3" d="M46.61,32.66L31.03,4.78C29.33,1.74,26.
     right: 3px;
     width: 1em;
     height: 1em;
-    color: #999;
+    color: #777;
     cursor: pointer;
     position: absolute;
     text-align: center;

--- a/app/assets/stylesheets/components/shared.scss
+++ b/app/assets/stylesheets/components/shared.scss
@@ -549,7 +549,7 @@ button, .button, .dropdown dd a {
   line-height: 1.25;
   border-collapse: separate;
   border-bottom: 1px solid rgba(#000, 0.08);
-  th {
+  th, thead td {
     font-weight: bold;
     padding: 15px 10px;
     //white-space: nowrap;

--- a/app/assets/stylesheets/components/shared.scss
+++ b/app/assets/stylesheets/components/shared.scss
@@ -466,7 +466,7 @@ button, .button, .dropdown dd a {
     text-decoration: none;
     font-size: $fontSizeBig;
     border-radius: 3px 3px 0 0;
-    color: rgba($textColor, 0.5);
+    color: rgba($textColor, 0.65);
     border: 1px solid transparent;
     border-width: 1px 1px 0 1px;
     &:hover { color: $textColor; }

--- a/app/assets/stylesheets/sections/deed.scss.erb
+++ b/app/assets/stylesheets/sections/deed.scss.erb
@@ -17,10 +17,10 @@
 
 .deed-type {
   $color: #B30;
-  $opacity: 0.4;
+  $opacity: 0.1;
   $rotate: 0deg;
   @each $type in <%= DeedType.all_types %> {
-    &-#{$type} { background: rgba(adjust-hue($color, $rotate), $opacity); }
+    &-#{$type} { background: rgba(adjust-hue($color, $rotate), $opacity); color: $bodyFgLight;}
     $rotate: $rotate - 30deg;
   }
 }

--- a/app/assets/stylesheets/sections/home.scss
+++ b/app/assets/stylesheets/sections/home.scss
@@ -41,7 +41,7 @@ a.button.big.learn-more {
     line-height: normal;
     display: inline-block;
     vertical-align: middle;
-    background: rgba(#100, 0.5);
+    background: rgba(#100, 0.6);
     margin: 0 auto;
     padding: 60px;
 

--- a/app/assets/stylesheets/sections/page.scss
+++ b/app/assets/stylesheets/sections/page.scss
@@ -17,7 +17,7 @@
     border-radius: 1.2em;
     text-decoration: none;
     font-size: $fontSizeSmall;
-    background: rgba(#FFF, 0.35);
+    background: mix(#FFF, $bodyBg, 25);
     background-clip: padding-box;
     border: 1px solid $borderColor;
   }
@@ -40,7 +40,7 @@
     color: inherit;
     &:hover {
       color: $bodyFg;
-      background-color: #FFF;
+      background-color: mix(#FFF, $bodyBg, 80);
     }
     &:active { @include button-state(active); }
   }
@@ -159,14 +159,14 @@
     right: 6px;
     position: absolute;
     button, .button {
-      border: 0;
+      border-color: mix(#fff, $bodyFgLight, 50);
       box-shadow: none;
-      color: rgba(#FFF, 0.8);
+      color: $bodyFg;
       font-size: $fontSizeSmall;
-      background: rgba(#433, 0.35);
+      background: mix( white, $bodyFgLight, 95);
       &:hover, &:active {
-        color: #FFF;
-        background: rgba(#433, 0.5);
+        color: $bodyFg;
+        background: mix( white, $bodyFgLight, 85);
       }
     }
   }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -130,8 +130,21 @@ module ApplicationHelper
 
   def language_attrs(collection)
     direction = Rtl.rtl?(collection.text_language) ? 'rtl' : 'ltr'
-    language = !collection.text_language.nil? ? collection.text_language : nil
-    attrs = {'lang'=>"#{language}", 'dir'=>"#{direction}", 'class'=>"#{direction}"}
+    
+    language = ISO_639.find_by_code(collection.text_language)
+    language = ISO_639.find_by_code('en') if language.nil?
+
+    display_language = if language.alpha2.empty?
+      language.alpha3
+    else
+      language.alpha2
+    end
+
+    attrs = {
+      'lang'=>"#{display_language}", 
+      'dir'=>"#{direction}", 
+      'class'=>"#{direction}"
+    }
     return attrs
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -134,11 +134,7 @@ module ApplicationHelper
     language = ISO_639.find_by_code(collection.text_language)
     language = ISO_639.find_by_code('en') if language.nil?
 
-    display_language = if language.alpha2.empty?
-      language.alpha3
-    else
-      language.alpha2
-    end
+    display_language = language.alpha2
 
     attrs = {
       'lang'=>"#{display_language}", 

--- a/app/views/admin/uploads.html.slim
+++ b/app/views/admin/uploads.html.slim
@@ -30,7 +30,7 @@ table.admin-grid.datagrid.striped
           small.label(class="upload-status-#{document.status}") =document.status.titleize
         td.nowrap
           dl.dropdown.right
-            dt
+            dt tabindex=0
               span Actions
               =svg_symbol '#icon-list', class: 'icon'
             dd

--- a/app/views/admin/user_list.html.slim
+++ b/app/views/admin/user_list.html.slim
@@ -1,7 +1,5 @@
 =render(:partial => 'header', :locals => { :selected => 2 })
 
-=label_tag :search, "Search users", class: "hidden"
-
 =form_tag({:controller => 'admin', :action => 'user_list'}, method: :get, enforce_utf8: false, class: 'collection-search') do
   =search_field_tag :search, params[:search], placeholder: 'Search Users...'
   =button_tag 'Search', :name => nil

--- a/app/views/article/list.html.slim
+++ b/app/views/article/list.html.slim
@@ -27,7 +27,7 @@
               -if user_signed_in? && current_user.like_owner?(@collection)
                 .headline_aside
                   dl.dropdown.right
-                    dt.h5
+                    dt.h5 tabindex=0
                       span Actions
                       =svg_symbol '#big-menu', class: 'icon icon-big'
                     dd

--- a/app/views/article/list.html.slim
+++ b/app/views/article/list.html.slim
@@ -52,7 +52,8 @@
           dt: h3 Uncategorized subjects
           dd
             -@uncategorized_articles.each do |article|
-              =link_to article.title, collection_article_show_path(@collection.owner, @collection, article.id)
+              p[*language_attrs(@collection)]
+                =link_to article.title, collection_article_show_path(@collection.owner, @collection, article.id)
 -else
   -add_category = link_to 'Create the first category', { :controller => 'category', :action => 'add_new', :collection_id => @collection.slug }, 'data-litebox' => ''
   .nodata

--- a/app/views/collection/edit.html.slim
+++ b/app/views/collection/edit.html.slim
@@ -81,9 +81,8 @@
     =form_for :collection, url: { action: 'update' }, html: { multipart: true, class: 'image-form' } do |f|
       =hidden_field_tag(:collection_id, @collection.id)
       label(data-empty="No Image" data-hover="Upload Image" aria-label="Upload Image" title="Upload Image")
-        =f.file_field :picture, tabindex: '-1', accept: 'image/*'
-        -unless @collection.picture.blank?
-          =image_tag(@collection.picture_url(:thumb), alt: @collection.title)
+        =f.file_field :picture, accept: 'image/*'
+        =image_tag(@collection.picture_url(:thumb), alt: @collection.title)
     p.fglight A picture to be used to illustrate the collection description.
 
     h3 Collection Link

--- a/app/views/dashboard/_new_work.html.slim
+++ b/app/views/dashboard/_new_work.html.slim
@@ -48,9 +48,10 @@
                 =link_to 'Edit Site', edit_omeka_site_path(omeka_site), :data => { litebox: { hash: "edit-connection-#{omeka_site.id}" } }
                 hr
                 =link_to 'Delete Site', omeka_site, method: :delete, data: { confirm: 'Are you sure? You will need to re-create the site confiuration to import from this site again!' }, class: 'fgred'
-    =link_to 'Add Source', { :controller => 'omeka_sites', :action => 'new' }, :data => { litebox: { hash: 'create-connection' } }, class: 'button outline'
+    =link_to 'Add Source', { :controller => 'omeka_sites', :action => 'new' }, :data => { litebox: { hash: 'create-connection' } }, class: 'button'
     h3 Import from CONTENTdm URL
-    p.fgfaded Paste in the URL of a compound object on your CONTENTdm site.
+    p
+    =label_tag :cdm_url, "Paste in the URL of a compound object on your CONTENTdm site."
     =form_tag({ controller: 'sc_collections', action: 'import_cdm' }) do |f|
       table.form
           td

--- a/app/views/dashboard/_owner_header.html.slim
+++ b/app/views/dashboard/_owner_header.html.slim
@@ -25,7 +25,7 @@
   h1.headline_title Owner Dashboard
   .headline_aside
     dl.dropdown.right
-      dt.h5
+      dt.h5 tabindex=0
         span Actions
         =svg_symbol '#big-menu', class: 'icon icon-big'
       dd

--- a/app/views/dashboard/landing_page.html.slim
+++ b/app/views/dashboard/landing_page.html.slim
@@ -1,8 +1,8 @@
 -unless params[:search]
   .carousel
-    button.prev
+    button.prev aria-label="Previous image"
       =svg_symbol '#icon-arrow-left', class: 'icon', title: 'Previous image'
-    button.next
+    button.next aria-label="Next image"
       =svg_symbol '#icon-arrow-right', class: 'icon', title: 'Next image'
 
     ul

--- a/app/views/dashboard/omeka.html.slim
+++ b/app/views/dashboard/omeka.html.slim
@@ -24,7 +24,7 @@
               small.fglight =omeka_item.omeka_url
             td.aright
               dl.dropdown.right
-                dt
+                dt tabindex=0
                   span Actions
                   =svg_symbol '#icon-list', class: 'icon'
                 dd

--- a/app/views/document_sets/_set_works.html.slim
+++ b/app/views/document_sets/_set_works.html.slim
@@ -12,6 +12,6 @@
             span =link_to w.title, collection_read_work_path(w.collection.owner, w.collection, w)
             span ="#{pluralize(w.work_statistic.total_pages, 'page')}: #{@wording}"
             span =w.restrict_scribes  ? 'Restricted' : 'Unrestricted'
-            span =check_box_tag "work[#{w.id}]"
+            span =check_box_tag("work[#{w.id}]", "work[#{w.id}]", false,{"title"=>"Remove #{w.title} from Document Set"})
       br
       .aright =button_tag 'Remove works'

--- a/app/views/document_sets/index.html.slim
+++ b/app/views/document_sets/index.html.slim
@@ -56,7 +56,7 @@ br
             -ids = work.document_sets.ids
             -@collection.document_sets.each do |document_set|
               td
-                =check_box_tag("work_assignment[#{document_set.id}][#{work.id}]", "true", ids.include?(document_set.id))
+                =check_box_tag("work_assignment[#{document_set.id}][#{work.id}]", "true", ids.include?(document_set.id), {"title"=>"Toggle #{work.title} in Document Set #{document_set.title}"})
     br
     =submit_tag "Save"
 

--- a/app/views/document_sets/index.html.slim
+++ b/app/views/document_sets/index.html.slim
@@ -16,7 +16,7 @@ ul
         th Title
         th Privacy
         th Actions
-        th
+        td
     tbody#sets
       -@collection.document_sets.each do |document_set|
         tr

--- a/app/views/document_sets/settings.html.slim
+++ b/app/views/document_sets/settings.html.slim
@@ -38,7 +38,7 @@
                 i
                   =work.restrict_scribes  ? 'Restricted' : 'Unrestricted'
               td.document_set
-                =check_box_tag("work[#{work.id}]")
+                =check_box_tag("work[#{work.id}]", "work[#{work.id}]", false, {"title"=>"Add #{work.title} to Document Set"})
       br
       .aright
         =submit_tag "Save"

--- a/app/views/document_sets/settings.html.slim
+++ b/app/views/document_sets/settings.html.slim
@@ -50,9 +50,8 @@
     =form_for  @document_set, url: document_set_path(@document_set), html: { multipart: true, class: 'image-form' } do |f|
       =hidden_field_tag(:collection_id, @document_set.id)
       label(data-empty="No Image" data-hover="Upload Image" aria-label="Upload Image" title="Upload Image")
-        =f.file_field :picture, tabindex: '-1', accept: 'image/*'
-        -unless @document_set.picture_url.nil?
-          =image_tag(@document_set.picture_url(:thumb), alt: @document_set.title)
+        =f.file_field :picture, accept: 'image/*'
+        =image_tag(@document_set.picture_url(:thumb), alt: @document_set.title)
     p.fglight A picture to be used to illustrate the document set description.
 
     h3 Document Set Privacy

--- a/app/views/ia/manage.html.slim
+++ b/app/views/ia/manage.html.slim
@@ -12,7 +12,7 @@ h1 Manage Archive.org Import
         -page_index = index_offset + i + 1
         .ia-import_headline
           dl.dropdown.right
-            dt
+            dt tabindex=0
               span Actions
               =svg_symbol '#icon-list', class: 'icon'
             dd

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -55,7 +55,7 @@ html lang="en-US"
 
           -if user_signed_in?
             dl.dropdown.right
-              dt.header_link.header_user
+              dt.header_link.header_user tabindex=0
                 span
                   big =current_user.guest ? "Create An Account" : "Signed In As"
                   small =current_user.display_name

--- a/app/views/user/_owner_profile.html.slim
+++ b/app/views/user/_owner_profile.html.slim
@@ -24,9 +24,9 @@ section.user-profile
 
 -unless carousel_collections.blank?
   .carousel
-    button.prev
+    button.prev aria-label="Previous image"
       =svg_symbol '#icon-arrow-left', class: 'icon', title: 'Previous image'
-    button.next
+    button.next aria-label="Next image"
       =svg_symbol '#icon-arrow-right', class: 'icon', title: 'Next image'
     ul
       -carousel_collections.each do |c|

--- a/app/views/work/edit.html.slim
+++ b/app/views/work/edit.html.slim
@@ -99,9 +99,8 @@
     =form_for(@work, url: update_collection_work_path(@collection.owner, @collection, @work), html: { multipart: true, class: 'image-form' }) do |f|
       =hidden_field_tag(:work_id, @work.id)
       label(data-empty="No Image" data-hover="Upload Image" aria-label="Upload Image")
-        =f.file_field :picture, tabindex: '-1', accept: 'image/*'
-        -unless @work.picture.blank?
-          =image_tag(@work.picture_url(:thumb))
+        =f.file_field :picture, accept: 'image/*'
+        =image_tag(@work.picture_url(:thumb))
     p.fglight A picture to be used to illustrate the work.  If no picture is uploaded, a page image will be used.
 
     hr


### PR DESCRIPTION
Closes #1346 

The email about accessibility compliance lists three things for us to look at. Contrast, Form Labels, and Language attributes.

I worked hard on this, but without the ability to run it through the (paid) linter that they used, I was stuck clicking around the site looking for errors. So, perhaps after merging this, we may ask UT to run it again? 

# Changes

## Contrast
I tried to be as light-handed as possible making these edits. Where I had to be more aggressive, I tried to maintain the look and feel of the site as best as I could. The two "major" changes I made (viz. more than just tweaking the text-color to be a bit darker) were to the Deed label coloring and to the transcription preview/autolink buttons.


## Form Labels
I *think* I've got a good label for all form elements. I confess, I'm not sure that I looked at every form, but I've looked at most of them and linted them with an a11y tool.

## Aria Labels
I was only able to find two places that needed aria labels, the close "X" link used in the Litebox plugin (most other symbols have text, which negate the need for aria labels, as I understand it), and the prev/next navigation buttons.

## Tab Indexing
This one wasn't on the a11y note, but I noticed it while I was working. Basically, we should be able to navigate around the site using the keyboard and that wasn't really possible before. One of the main problems was that all the `focus` state visual cues had been overridden in our stylesheet to be invisible. I added some subtle outlining for the `focus` state.

This also required that I make some additions to the JavaScript that toggled the menus. Since the event listener was only set on `click` tabbing into the menus wasn't possible (both the main `login/logout` menu as well as the `Actions` menus). So I was able to add event listeners for `focusin` that open and close the menus at the appropriate times. Because the menus were made with Definition Lists, they additionally needed to be explicitly marked as tabbable with `tabindex=0`.

## Lang Attributes
After we got that email back, I was able to go look for what the gentleman was talking about. The problem was that we use the `ISO-639-2` style (three-letter) codes and these a11y linters only like the two-letter versions (`ISO-639-1`).

Since our database is full of three-letter codes, I thought it best to only change how we display the codes. We already had the `ISO-639` library installed, so, I was able to use that to make the changes. The problem with this approach is that `ISO-639-1` has many fewer languages in its standard (the reason, I suspect, we opted for the three-letter version!). Since many of these excluded languages seem to be the dead variety, I figured we'd still need them, so, in cases where there is no two-letter code, the three-letter version is used instead. I thought this was better than leaving off the `lang` attribute altogether and no worse than `lang=""`.

** UPDATE**
This is all wrong. There is a new standard, it seems, laid out in BCP 47 that provides even more information than either of the ISO639 standards. The list of codes can be found here. This standard seems to have the comprehensive coverage of the standard we are using, but uses many two-letter codes that look like the older standard.

To make things more complicated, it seems that the Library of Congress uses the newer ISO standard, so there is, perhaps, good reason for us to retain that standard in our database (especially).

But, for displaying HTML, it seems the official answer is that we should be converting these ISO639-2 codes into IANA subtags.

## Other
I noticed a couple minor CSS/HTML errors, too, which I fixed. One being the extra white bar on the bottom of the footer where the "contact us" link is (on all pages!). Another was that empty `<th>` tags make the a11y linter complain, so I changed it to a `<td>` and added a little CSS to fix the appearance.