### PR TITLE
Fix deed_spec issues

### DIFF
--- a/spec/models/deed_spec.rb
+++ b/spec/models/deed_spec.rb
@@ -14,59 +14,63 @@ RSpec.describe Deed, type: :model do
     it { should validate_inclusion_of(:deed_type).in_array(DeedType.all_types) }
   end
 
-  # describe '.order_by_recent_activity' do
-    # let(:deed_type) { DeedType.all_types.first }
-# 
-    # it 'lists deeds in order by most recently created' do
-      # binding.pry
-      # first_deed = create(:deed, deed_type: deed_type)
-      # sleep(1)
-      # second_deed = create(:deed, deed_type: deed_type)
-# 
-      # expect(Deed.order_by_recent_activity.first).to eq(second_deed)
-# 
-      # # Tear down factories
-      # Deed.destroy(first_deed.id)
-      # Deed.destroy(second_deed.id)
-    # end
-  # end
-# 
-  # describe '.active' do
-    # let(:deed_type) { DeedType.all_types.first }
-# 
-    # it 'returns deeds by all active users' do
-      # inactive_user = create(:user, deleted: true)
-      # inactive_user_deed = create(:deed, deed_type: deed_type, user_id: inactive_user.id)
-      # active_user = create(:user)
-      # active_user_deed = create(:deed, deed_type: deed_type, user_id: active_user.id)
-# 
-      # expect(Deed.active).to include(active_user_deed)
-      # expect(Deed.active).to_not include(inactive_user_deed)
-# 
-      # # Tear down factories
-      # Deed.destroy(inactive_user_deed.id)
-      # Deed.destroy(active_user_deed.id)
-      # User.destroy(inactive_user.id)
-      # User.destroy(active_user.id)
-    # end
-  # end
+  describe '.order_by_recent_activity' do
+    let(:deed_type) { DeedType.all_types.first }
 
-  # describe '.past_day' do
-    # let(:old_date) { 2.day.ago }
-    # let(:deed_type) { DeedType.all_types.first }
-# 
-    # it 'returns deeds created within the past day' do
-      # old_deed = create(:deed, deed_type: deed_type, created_at: old_date)
-      # deed_from_today = create(:deed, deed_type: deed_type)
-# 
-      # expect(Deed.past_day).to include(deed_from_today)
-      # expect(Deed.past_day).to_not include(old_deed)
-# 
-      # # Tear down factories
-      # Deed.destroy(old_deed.id)
-      # Deed.destroy(deed_from_today.id)
-    # end
-  # end
+    it 'lists deeds in order by most recently created' do
+      allow_any_instance_of(Deed).to receive(:calculate_prerender)
+      allow_any_instance_of(Deed).to receive(:calculate_prerender_mailer)
+
+      first_deed = create(:deed, deed_type: deed_type)
+      second_deed = create(:deed, deed_type: deed_type)
+
+      expect(Deed.order_by_recent_activity.first).to eq(second_deed)
+
+      # Tear down factories
+      Deed.destroy(first_deed.id)
+      Deed.destroy(second_deed.id)
+    end
+  end
+
+  describe '.active' do
+    let(:deed_type) { DeedType.all_types.first }
+
+    it 'returns deeds by all active users' do
+      inactive_user = create(:user, deleted: true)
+      inactive_user_deed = create(:deed, deed_type: deed_type, user_id: inactive_user.id)
+      active_user = create(:user)
+      active_user_deed = create(:deed, deed_type: deed_type, user_id: active_user.id)
+
+      expect(Deed.active).to include(active_user_deed)
+      expect(Deed.active).to_not include(inactive_user_deed)
+
+      # Tear down factories
+      Deed.destroy(inactive_user_deed.id)
+      Deed.destroy(active_user_deed.id)
+      User.destroy(inactive_user.id)
+      User.destroy(active_user.id)
+    end
+  end
+
+  describe '.past_day' do
+    let(:old_date) { 2.day.ago }
+    let(:deed_type) { DeedType.all_types.first }
+
+    it 'returns deeds created within the past day' do
+      allow_any_instance_of(Deed).to receive(:calculate_prerender)
+      allow_any_instance_of(Deed).to receive(:calculate_prerender_mailer)
+
+      old_deed = create(:deed, deed_type: deed_type, created_at: old_date)
+      deed_from_today = create(:deed, deed_type: deed_type)
+
+      expect(Deed.past_day).to include(deed_from_today)
+      expect(Deed.past_day).to_not include(old_deed)
+
+      # Tear down factories
+      Deed.destroy(old_deed.id)
+      Deed.destroy(deed_from_today.id)
+    end
+  end
 
   describe '#deed_type_name' do
     let(:deed_type) { DeedType.all_types.first }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -94,6 +94,8 @@ OWNER = "margaret"
 NEW_OWNER = "harry"
 ADMIN = "julia"
 
-#set this for mailer tests
-SMTP_ENABLED = true
+# Set this for mailer tests
+silence_warnings do
+  SMTP_ENABLED = true
+end
 ActionMailer::Base.perform_deliveries = true


### PR DESCRIPTION
Closes #1363 
The problem was that the factories that we are using to stub the deeds were (intentionally) having to be saved to the database, which triggered the `before_save` hooks. Because we are prerendering deeds, the application was trying to prerender the stubbed deeds, which lacked the necessary properties for the partial.

The solution was simply to mock the class methods in the tests, like so:

    allow_any_instance_of(Deed).to receive(:calculate_prerender)
    allow_any_instance_of(Deed).to receive(:calculate_prerender_mailer)

and that solved the problem.

I've also silenced the `reassigning constant` warning that we always get in the tests (because the SMTP settings are by default set to `false`.