### PR TITLE
Allow multiline notes

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,5 +1,5 @@
 class NotesController < ApplicationController
-
+  include ActionView::Helpers::TextHelper
   def create
     @note = Note.new(params[:note])
     # truncate the body for the title
@@ -32,7 +32,9 @@ class NotesController < ApplicationController
     @note = Note.find(params[:id])
     respond_to do |format|
       if @note.update_attributes(params[:note])
-        format.json { head :no_content }
+        note_body = sanitize(@note.body, tags: %w(strong b em i a), attributes: %w(href))
+        
+        format.json { render json: { html: simple_format(note_body) }, status: :ok }
         format.html { redirect_to :back, notice: "Note has been updated" }
       else
         format.json { render json: @note.errors.full_messages, status: :unprocessable_entity }

--- a/app/views/notes/_note.html.slim
+++ b/app/views/notes/_note.html.slim
@@ -4,7 +4,7 @@
   .user-bubble_content
     -if note.user == current_user
       .user-bubble_actions
-        a(data-note-edit)
+        a(data-note-edit=note.id title='Edit')
           =svg_symbol '#icon-edit', class: 'icon'
         =link_to(note, method: :delete, remote: true, data: { "note-delete" => note.id, :confirm => 'Are you sure you want to delete this note?' }, title: 'Delete')
           =svg_symbol '#icon-remove-sign', class: 'icon', title: 'Delete'
@@ -15,7 +15,7 @@
     =time_tag note.created_at
       =link_to note.user.display_name, { :controller => 'user', :action => 'profile', :user_id => note.user.id }
       =" #{time_ago_in_words note.created_at} ago"
-    p ==sanitize(note.body, tags: %w(strong b em i a), attributes: %w(href))
+    .user-bubble_note ==simple_format(sanitize(note.body, tags: %w(strong b em i a), attributes: %w(href)))
 
   -if note.user == current_user
     =form_for note, remote: true, :html => { class: 'user-bubble_form' } do |f|
@@ -26,5 +26,5 @@
         -if @collection.voice_recognition
           span.voice-info.voice
           =image_submit_tag 'mic-icon.png', height: '40', alt: 'Microphone', class: 'voice', id: 'start_img_update', onclick: 'startButton(event);'
-        a(data-note-edit) Cancel
+        a(data-note-edit=note.id title='Edit') Cancel
         =f.button 'Update'

--- a/app/views/notes/_notes.html.slim
+++ b/app/views/notes/_notes.html.slim
@@ -45,11 +45,11 @@
             $(content).hide().insertBefore($container).fadeIn();
             $('[data-note-empty]').hide();
             this.reset();
-          } else if(xhr.status === 204) {
+          } else if(xhr.status === 200) {
             // Note updated
-            var content = $('textarea', this).val();
+            var content = xhr.responseJSON.html;
             $container.removeClass('edit');
-            $('.user-bubble_content > p', $container).text(content);
+            $('.user-bubble_note', $container).html(content);
           } else {
             // Error occurred
             var message = xhr.responseJSON.join('. ');


### PR DESCRIPTION
Closes #1375 

This PR allows users to submit multiline notes. It uses the `simple_format` rails helper in conjunction with the `sanitize` helper. It does not change how the notes are saved in the DB; this only affects how the note is displayed.

![image](https://user-images.githubusercontent.com/1544859/60680672-d2f01600-9e51-11e9-922d-17ed708ed32c.png)

The one problem I had was that the `update` function was only handled on the client, which made it so edited notes  wouldn't be processed by these same functions. The old update function simply returned a `204` code and left it to the client to render the change. In the new version. the server returns a success code and a re-rendered partial of the note, which then replaces the old version of the note.