### PR TITLE
Collection stats not updating

### DIFF
--- a/app/models/work_statistic.rb
+++ b/app/models/work_statistic.rb
@@ -111,6 +111,8 @@ class WorkStatistic < ActiveRecord::Base
     self[:complete] = self.pct_completed
     self[:translation_complete] = self.pct_translation_completed
     save!
+
+    recalculate_parent_statistics
   end
 
 

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -249,3 +249,45 @@ describe "collection settings js tasks", :order => :defined do
   end
 
 end
+
+describe "collection spec (isolated)" do
+  before :all do
+    @factory_owner = create(:user, owner: true)
+  end
+
+  it 'updates collection statistics', :js => true do
+      login_as(@factory_owner, :scope => :user)
+      visit dashboard_owner_path(@factory_owner)
+      expect(page).to have_content('Start A Project')
+      page.find('.tabs').click_link('Start A Project')
+
+      select('Add New Collection', :from => 'work_collection_id')
+      page.find('#new_collection').fill_in('collection_title', with: 'Stats Test Collection')
+      click_button('Create Collection')
+      expect(page).to have_content('Collection has been created')
+
+      fill_in('work_title', with: 'Stats Test Work')
+      click_button('Create Work')
+      page.find('#new_page')
+      click_button('Save & New Work')
+
+      visit dashboard_owner_path
+
+      page.find('.collections').click_link('Stats Test Work')
+      page.find('.tabs').click_link('Read')
+      page.find('.maincol h4').click_link('Page 1')
+      fill_in('page_source_text', with: 'Transcription')
+      page.find('#save_button_top').click
+      expect(page).to have_content('Saved')
+
+      page.find('.breadcrumbs').click_link('Stats Test Collection')
+      expect(page).to have_content("All works are fully transcribed.")
+  end
+
+  after :all do
+    @factory_owner.collections.each do |c|
+        c.destroy
+    end
+    @factory_owner.destroy
+  end
+end


### PR DESCRIPTION
Closes #1351 
As far as I was able to tell, at no point did the `Work` ever call an update function on the `Collection`. That said, there already existed a function that seemed to be intended for this purpose (`recalculate_parent_statistics`), which was (as far as I could tell) never invoked in our code.

So, I put a call to that function (which updates both parent collections and document sets) whenever the work stats are updated. Since the work stats seem to be working fine, this seemed like a solid place to put this code.

My one reservation with this PR is that I was running into a situation where it seemed like perhaps I was dealing with a DB race in the test. I'd query the DB and ask for the `ptc_completed` and it would always give me `0` (rather than `100`). But, when I'd go into the console immediately after, it read as `100`. Right now, rather than querying the DB in the test, I look for `All works fully transcribed` which is conditionally displayed only if `ptc_completed == 100`.