### PR TITLE
dashboard: fix collections_list performance

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -46,9 +46,7 @@ class DashboardController < ApplicationController
   end
 
   def collections_list
-    collections = Collection.includes(:owner).distinct
-    document_sets = DocumentSet.includes(:owner).distinct
-    @collections_and_document_sets = (collections + document_sets).sort { |a,b| a.title <=> b.title }
+    @collections = Collection.all
   end
 
   #Owner Dashboard - start project

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -49,7 +49,7 @@ class DashboardController < ApplicationController
     if user_signed_in?
       @collections = Collection.by_user(current_user) + DocumentSet.by_user(current_user)
     else
-      @collections = Collection.where(restricted: false) + DocumentSet.where(restricted: false)
+      @collections = Collection.where(restricted: false) + DocumentSet.where(is_public: true)
     end
   end
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -46,7 +46,11 @@ class DashboardController < ApplicationController
   end
 
   def collections_list
-    @collections = Collection.all
+    if user_signed_in?
+      @collections = Collection.by_user(current_user) + DocumentSet.by_user(current_user)
+    else
+      @collections = Collection.where(restricted: false)
+    end
   end
 
   #Owner Dashboard - start project

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -49,7 +49,7 @@ class DashboardController < ApplicationController
     if user_signed_in?
       @collections = Collection.by_user(current_user) + DocumentSet.by_user(current_user)
     else
-      @collections = Collection.where(restricted: false)
+      @collections = Collection.where(restricted: false) + DocumentSet.where(restricted: false)
     end
   end
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -66,6 +66,10 @@ class Collection < ActiveRecord::Base
     (!self.restricted && self.works.present?) || (user && user.like_owner?(self)) || (user && user.collaborator?(self))
   end
 
+  def self.by_user(user)
+    Collection.includes(:owners).where(owner_user_id: user.id).joins(:collaborators)
+  end
+
   def create_categories
     #create two default categories
     category1 = Category.new(collection_id: self.id, title: "People")

--- a/app/models/document_set.rb
+++ b/app/models/document_set.rb
@@ -21,6 +21,10 @@ class DocumentSet < ActiveRecord::Base
   def show_to?(user)
     self.is_public? || (user && user.collaborator?(self)) || self.collection.show_to?(user)
   end
+
+  def self.by_user(user)
+    DocumentSet.includes(:owner).where(owner_user_id: user.id).joins(:collaborators)
+  end
   
   def intro_block
     self.description

--- a/app/views/dashboard/_alphabetical_collections_and_document_sets.html.slim
+++ b/app/views/dashboard/_alphabetical_collections_and_document_sets.html.slim
@@ -1,19 +1,13 @@
-
-    .collections
-      -collections_and_document_sets.each do |cds|
-        -if cds.show_to?(current_user)
-          -snippet = truncate(strip_tags(cds.intro_block), length: 300, separator: ' ') || ''
-          -owner_link = link_to cds.owner.display_name, user_profile_path(cds.owner)
-          .collection
-            -unless cds.picture.blank?
-              .collection_image
-                =image_tag(cds.picture_url(:thumb), alt: cds.title)
-            .collection_details
-              h4.collection_title =link_to cds.title, collection_path(cds.owner, cds)
-              -if cds.has_untranscribed_pages?
-                p
-                  =link_to "Start Transcribing", collection_start_transcribing_path(cds.owner, cds), class: 'button'
-              -unless snippet.empty?
-                p.collection_snippet =snippet
-              .collection_summary
-                span =="Owned by #{owner_link}"
+.collections
+  -snippet = truncate(strip_tags(collection.intro_block), length: 300, separator: ' ') || ''
+  -owner_link = link_to collection.owner.display_name, user_profile_path(collection.owner) unless collection.owner.nil?
+  .collection
+    -unless collection.picture.blank?
+      .collection_image
+        =image_tag(collection.picture_url(:thumb), alt: collection.title)
+    .collection_details
+      h4.collection_title =link_to collection.title, collection_path(collection.owner, collection) unless collection.owner.nil?
+      -unless snippet.empty?
+        p.collection_snippet =snippet
+      .collection_summary
+        span =="Owned by #{owner_link}"

--- a/app/views/dashboard/collections_list.html.slim
+++ b/app/views/dashboard/collections_list.html.slim
@@ -4,7 +4,7 @@
 h1 Collections
 .columns
   article.maincol
-    =render partial: 'alphabetical_collections_and_document_sets', locals: { collections_and_document_sets: @collections_and_document_sets }
+    =render partial: 'alphabetical_collections_and_document_sets', collection: @collections, as: :collection
   aside.sidecol
     h2 Recent Activity
     =deeds_for()

--- a/app/views/user/_owner_profile.html.slim
+++ b/app/views/user/_owner_profile.html.slim
@@ -43,7 +43,7 @@ section.user-profile
     -if any_public_collections_with_document_sets?(collections_and_document_sets)
       =render partial: '/dashboard/hierarchical_collections_and_document_sets', locals: {collections_and_document_sets: collections_and_document_sets}
     -else
-      =render partial: '/dashboard/alphabetical_collections_and_document_sets', locals: {collections_and_document_sets: collections_and_document_sets}
+      =render partial: '/dashboard/alphabetical_collections_and_document_sets', collection: @collections_and_document_sets, as: :collection
     
   aside.sidecol
     h2 Recent Activity


### PR DESCRIPTION
By not calling Collection.show_to? and #has_untranscribed_pages? inside
a each loop (mariadb is flooded with lots of queries, thus creating a
bottleneck).

Fixes: #1175.