### PR TITLE
Apply langauge attrs to the page view

### DIFF
--- a/app/views/display/_pages_view.html.slim
+++ b/app/views/display/_pages_view.html.slim
@@ -25,7 +25,7 @@
             -if page.work.pages_are_meaningful
               h4.work-page_title =link_to page.title, page_params(page)
 
-            .work-page_text
+            .work-page_text[*language_attrs(@collection)]
               -transcription = xml_to_html(page.xml_text, false)
               -if current_user
                 -action = page_params(page)


### PR DESCRIPTION
Closes #1379

As we do in the page#read,transcribe and preview views. This is important for displaying RTL languages properly in the work-page view. Note the RTL justification in the latter image.

**Before**
![image](https://user-images.githubusercontent.com/1544859/62330831-751a1280-b47f-11e9-9f71-4295ab083ef2.png)

**After**
![image](https://user-images.githubusercontent.com/1544859/62330817-65023300-b47f-11e9-9592-f8d0d8f6ff2d.png)
