### PR TITLE
dashboard: remove the call to show_to? from collections view

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -48,8 +48,8 @@ class DashboardController < ApplicationController
   def collections_list
     collections_and_document_sets = []
 
-    collections = Collection.includes(:owner).distinct
-    document_sets = DocumentSet.includes(:owner).distinct
+    collections = Collection.includes(:owner).preload(:owner).distinct
+    document_sets = DocumentSet.includes(:owner).preload(:owner).distinct
 
     if user_signed_in?
       (collections + document_sets).each do |collection|
@@ -58,7 +58,7 @@ class DashboardController < ApplicationController
         collections_and_document_sets << collection if current_user.collaborator?(collection)
       end
     else
-      collections_and_document_sets = Collection.where(restricted: false) + DocumentSet.where(is_public: true)
+      collections_and_document_sets = Collection.joins(:owner).preload(:owner).where(restricted: false) + DocumentSet.joins(:owner).preload(:owner).where(is_public: true)
     end
 
     @collections_and_document_sets = collections_and_document_sets.sort { |a,b| a.title <=> b.title }

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -46,9 +46,22 @@ class DashboardController < ApplicationController
   end
 
   def collections_list
+    collections_and_document_sets = []
+
     collections = Collection.includes(:owner).distinct
     document_sets = DocumentSet.includes(:owner).distinct
-    @collections_and_document_sets = (collections + document_sets).sort { |a,b| a.title <=> b.title }
+
+    if user_signed_in?
+      (collections + document_sets).each do |collection|
+        collections_and_document_sets << collection if !collection.restricted && collection.works.present?
+        collections_and_document_sets << collection if current_user.like_owner?(collection)
+        collections_and_document_sets << collection if current_user.collaborator?(collection)
+      end
+    else
+      collections_and_document_sets = Collection.where(restricted: false) + DocumentSet.where(is_public: true)
+    end
+
+    @collections_and_document_sets = collections_and_document_sets.sort { |a,b| a.title <=> b.title }
   end
 
   #Owner Dashboard - start project

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -159,7 +159,7 @@ class Collection < ActiveRecord::Base
   end
 
   def has_untranscribed_pages?
-    self.works.any? { |w| w.has_untranscribed_pages? }
+    self.works.joins(:work_statistic).where('work_statistics.total_pages > work_statistics.transcribed_pages').exists?
   end
 
   #constant

--- a/app/models/document_set.rb
+++ b/app/models/document_set.rb
@@ -103,7 +103,7 @@ class DocumentSet < ActiveRecord::Base
   end
   
   def has_untranscribed_pages?
-    self.works.any? { |w| w.has_untranscribed_pages? }
+    self.works.joins(:work_statistic).where('work_statistics.total_pages > work_statistics.transcribed_pages').exists?
   end
 
   def slug_candidates

--- a/app/models/document_set.rb
+++ b/app/models/document_set.rb
@@ -21,7 +21,7 @@ class DocumentSet < ActiveRecord::Base
   def show_to?(user)
     self.is_public? || (user && user.collaborator?(self)) || self.collection.show_to?(user)
   end
-  
+
   def intro_block
     self.description
   end

--- a/app/views/dashboard/_alphabetical_collections_and_document_sets.html.slim
+++ b/app/views/dashboard/_alphabetical_collections_and_document_sets.html.slim
@@ -1,19 +1,17 @@
 
     .collections
-      -collections_and_document_sets.each do |cds|
-        -if cds.show_to?(current_user)
-          -snippet = truncate(strip_tags(cds.intro_block), length: 300, separator: ' ') || ''
-          -owner_link = link_to cds.owner.display_name, user_profile_path(cds.owner)
-          .collection
-            -unless cds.picture.blank?
-              .collection_image
-                =image_tag(cds.picture_url(:thumb), alt: cds.title)
-            .collection_details
-              h4.collection_title =link_to cds.title, collection_path(cds.owner, cds)
-              -if cds.has_untranscribed_pages?
-                p
-                  =link_to "Start Transcribing", collection_start_transcribing_path(cds.owner, cds), class: 'button'
-              -unless snippet.empty?
-                p.collection_snippet =snippet
-              .collection_summary
-                span =="Owned by #{owner_link}"
+      -snippet = truncate(strip_tags(cds.intro_block), length: 300, separator: ' ') || ''
+      -owner_link = link_to cds.owner.display_name, user_profile_path(cds.owner) unless cds.owner.nil?
+      .collection
+        -unless cds.picture.blank?
+          .collection_image
+            =image_tag(cds.picture_url(:thumb), alt: cds.title)
+        .collection_details
+          h4.collection_title =link_to cds.title, collection_path(cds.owner, cds) unless cds.owner.nil?
+          -if cds.has_untranscribed_pages?
+            p
+              =link_to "Start Transcribing", collection_start_transcribing_path(cds.owner, cds), class: 'button'
+          -unless snippet.empty?
+            p.collection_snippet =snippet
+          .collection_summary
+            span =="Owned by #{owner_link}"

--- a/app/views/dashboard/collections_list.html.slim
+++ b/app/views/dashboard/collections_list.html.slim
@@ -4,7 +4,7 @@
 h1 Collections
 .columns
   article.maincol
-    =render partial: 'alphabetical_collections_and_document_sets', locals: { collections_and_document_sets: @collections_and_document_sets }
+    =render partial: 'alphabetical_collections_and_document_sets', collection: @collections_and_document_sets, as: :cds
   aside.sidecol
     h2 Recent Activity
     =deeds_for()

--- a/app/views/user/_owner_profile.html.slim
+++ b/app/views/user/_owner_profile.html.slim
@@ -43,7 +43,7 @@ section.user-profile
     -if any_public_collections_with_document_sets?(collections_and_document_sets)
       =render partial: '/dashboard/hierarchical_collections_and_document_sets', locals: {collections_and_document_sets: collections_and_document_sets}
     -else
-      =render partial: '/dashboard/alphabetical_collections_and_document_sets', locals: {collections_and_document_sets: collections_and_document_sets}
+      =render partial: '/dashboard/alphabetical_collections_and_document_sets', collection: @collections_and_document_sets, as: :cds
     
   aside.sidecol
     h2 Recent Activity


### PR DESCRIPTION
This is my first attempt with trying to fix some of the performance
issues described in #1175.

While show_to? isn't the problem, I am still hoping that this helps to
reduce complexity.

Unfortunately some methods we use depend on collections and document
sets being iterated (which is the expensive part), so just move that
code to collections_list for now.