### PR TITLE
Join collection on signup

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -26,10 +26,6 @@ class RegistrationsController < Devise::RegistrationsController
     else
       @user = build_resource(sign_up_params)
     end
-    
-    # Record the `joined` deed based on Ahoy Visit
-    join_collection = joined_from_collection(current_visit.id)
-    @user.join_collection(join_collection) unless join_collection.nil?
 
     #this is the default Devise code
     yield resource if block_given?
@@ -48,7 +44,11 @@ class RegistrationsController < Devise::RegistrationsController
       if session[:guest_user_id]
         session[:guest_user_id] = nil
       end
-
+      
+      # Record the `joined` deed based on Ahoy Visit
+      join_collection = joined_from_collection(current_visit.id)
+      @user.join_collection(join_collection) unless join_collection.nil?
+    
     else
       clean_up_passwords resource
       @validatable = devise_mapping.validatable?

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,5 +1,5 @@
 class RegistrationsController < Devise::RegistrationsController
-  
+
   def new
     super
   end
@@ -27,6 +27,10 @@ class RegistrationsController < Devise::RegistrationsController
       @user = build_resource(sign_up_params)
     end
     
+    # Record the `joined` deed based on Ahoy Visit
+    join_collection = joined_from_collection(current_visit.id)
+    @user.join_collection(join_collection) unless join_collection.nil?
+
     #this is the default Devise code
     yield resource if block_given?
       
@@ -75,4 +79,11 @@ class RegistrationsController < Devise::RegistrationsController
     true
   end
 
+  private
+
+  def joined_from_collection(visit_id)
+    first_event = Ahoy::Event.where(visit_id: visit_id).first
+    collection = first_event.properties["collection_id"] || nil
+    return collection
+  end
 end

--- a/app/models/deed_type.rb
+++ b/app/models/deed_type.rb
@@ -21,6 +21,7 @@ class DeedType
   WORK_ADDED = 'work_add'
   COLLECTION_ACTIVE = 'coll_act'
   COLLECTION_INACTIVE = 'coll_inact'
+  COLLECTION_JOINED = 'coll_join'
 
   # The TYPES hash houses all of the deed types and makes is easier to access
   # groups of deed types and also their human-readable names. Any new deed type
@@ -39,8 +40,9 @@ class DeedType
     TRANSLATION_REVIEW => 'Translation Page Needs Review',
     TRANSLATION_INDEXED => 'Translation Page Indexed',
     WORK_ADDED => 'Work Added',
-    COLLECTION_ACTIVE => 'coll_act',
-    COLLECTION_INACTIVE => 'coll_inact'
+    COLLECTION_ACTIVE => 'Collection Active',
+    COLLECTION_INACTIVE => 'Collection Inactive',
+    COLLECTION_JOINED => 'Collection Joined'
   }
 
   # This `class << self` inherited group replaces the need to call `self.` on

--- a/app/models/deed_type.rb
+++ b/app/models/deed_type.rb
@@ -66,7 +66,8 @@ class DeedType
         NEEDS_REVIEW,
         TRANSLATION_REVIEW,
         COLLECTION_ACTIVE,
-        COLLECTION_INACTIVE
+        COLLECTION_INACTIVE,
+        COLLECTION_JOINED
       ]
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -225,5 +225,11 @@ class User < ActiveRecord::Base
       self.notification.save
     end
   end
-
+  def join_collection(collection_id)
+      deed = Deed.new
+      deed.collection = Collection.find(collection_id)
+      deed.deed_type = DeedType::COLLECTION_JOINED
+      deed.user = self
+      deed.save!
+  end
 end

--- a/app/views/deed/_deed.html.slim
+++ b/app/views/deed/_deed.html.slim
@@ -9,6 +9,8 @@
 -article = deed.article.nil? ? '' : link_to(deed.article.title, collection_article_show_url(deed.article.collection.owner, deed.article.collection, deed.article), only_path: !mailer)
 -if(!deed.work.nil? && !deed.work.collection.nil? )
   -work = link_to(deed.work.title, collection_read_work_url(deed.work.collection.owner, deed.work.collection, deed.work), only_path: !mailer)
+-unless(deed.collection.nil?)
+  -collection = link_to(deed.collection.title, collection_url(deed.collection.owner, deed.collection), only_path: !mailer )
 
 -output = "#{user} "
 
@@ -52,19 +54,22 @@
 -when DeedType::WORK_ADDED
   -output += "added #{work}"
 
+-when DeedType::COLLECTION_JOINED
+    -output += "joined "
+    
+    -if deed.collection.nil?
+      -output += "this collection"
+    -else
+      -output += collection
+
 -if(long_view && !deed.work.nil?)
   -if deed.work.collection
     -work = link_to(deed.work.title, collection_read_work_url(deed.work.collection.owner, deed.work.collection, deed.work), only_path: !mailer )
   -else
     -work = deed.work.title      
   -output += " in the work #{work}"
-
--if(@collection.nil? && !deed.collection.nil?)
-  -collection = link_to(deed.collection.title, collection_url(deed.collection.owner, deed.collection), only_path: !mailer )
-  -if(deed.deed_type == DeedType::COLLECTION_JOINED)
-    -output += "joined #{collection}"
-  -else
-    -output += " in #{collection} collection"
+-if(!collection.nil? && deed.deed_type != DeedType::COLLECTION_JOINED)
+  -output += " in #{collection} collection"
 
 -if(long_view && deed.deed_type == DeedType::NOTE_ADDED && !deed.note.nil?)
   -output += ", saying &ldquo;#{deed.note.title}&rdquo;"

--- a/app/views/deed/_deed.html.slim
+++ b/app/views/deed/_deed.html.slim
@@ -61,7 +61,10 @@
 
 -if(@collection.nil? && !deed.collection.nil?)
   -collection = link_to(deed.collection.title, collection_url(deed.collection.owner, deed.collection), only_path: !mailer )
-  -output += " in #{collection} collection"
+  -if(deed.deed_type == DeedType::COLLECTION_JOINED)
+    -output += "joined #{collection}"
+  -else
+    -output += " in #{collection} collection"
 
 -if(long_view && deed.deed_type == DeedType::NOTE_ADDED && !deed.note.nil?)
   -output += ", saying &ldquo;#{deed.note.title}&rdquo;"

--- a/spec/factories/collection.rb
+++ b/spec/factories/collection.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :collection do
     sequence(:title) { |n| "Collection Title #{n}" }
+    sequence(:slug)  { |n| "collection-title-#{n}" }
     owner_user_id { association(:user).id }
 
     trait :with_links do

--- a/spec/features/devise_spec.rb
+++ b/spec/features/devise_spec.rb
@@ -63,6 +63,8 @@ describe "Devise" do
       click_button('Create Account')
       
       expect(page.current_path).to eq coll_path
+      expect(page).to have_content("#{user.display_name} joined #{collection.title}")
+      
       visit dashboard_watchlist_path
       expect(page).to have_content("#{user.display_name} joined #{collection.title}")
     end

--- a/spec/features/devise_spec.rb
+++ b/spec/features/devise_spec.rb
@@ -15,6 +15,8 @@ describe "Devise" do
 
     let(:user)  { build(:user) }
     let(:owner) { build(:owner) }
+    let(:collection) { create(:collection) }
+    let(:coll_path){ collection_path(collection.owner, collection) }
 
     it "creates a new user account" do 
       visit new_user_registration_path
@@ -47,6 +49,22 @@ describe "Devise" do
       page.fill_in 'Display name', with: user.display_name
       click_button('Create Account')
       expect(page.current_path).to eq old_path
+    end
+    it "logs a `joined` deed if landing page was a collection" do
+      # This is the Landing Page
+      visit coll_path
+      # Complete user registration 
+      visit new_user_registration_path
+      page.fill_in 'Login', with: user.login
+      page.fill_in 'Email address', with: user.email
+      page.fill_in 'Password', with: user.password
+      page.fill_in 'Password confirmation', with: user.password
+      page.fill_in 'Display name', with: user.display_name
+      click_button('Create Account')
+      
+      expect(page.current_path).to eq coll_path
+      visit dashboard_watchlist_path
+      expect(page).to have_content("#{user.display_name} joined #{collection.title}")
     end
     it "creates a new trial owner account" do
       visit users_new_trial_path

--- a/spec/models/deed_type_spec.rb
+++ b/spec/models/deed_type_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe DeedType, type: :model do
-  types_count = 15
+  types_count = 16
 
   describe 'TYPES' do
     it "has all #{types_count} DeedTypes" do


### PR DESCRIPTION
Closes #1370 

This PR adds the `Collection Joined` Deed Type and automatically has new users "join" a collection based on where they entered the site.

Although the `Ahoy::Visit` does include a `landing_page` field, I couldn't figure out a good way to parse the path to determine whether it was, in fact, a path that included a `Collection`. As a way around this, I've opted to use the oldest `Ahoy::Event` from the `current_visit`. Ostensibly, this gives the same data, since the first `Event` of a `Visit` includes, by definition, the landing page. The advantage of using the `Event` is that it provides`Controller#method` as well as the URL parameters. So, we can check to see if this `Event` includes a `collection_id`, and if so, we can pass it to the `join_collection` method on the `User`, which makes the `Deed`.

The tests are basic, but cover the core functionality.