### PR TITLE
Too many ahoy errors, again

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -268,7 +268,6 @@ end
 
 
   def track_action
-    ahoy.track_visit
     extras = {}
     extras[:collection_id] = @collection.id if @collection
     extras[:collection_title] = @collection.title if @collection

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -1,4 +1,3 @@
 class Ahoy::Store < Ahoy::Stores::ActiveRecordTokenStore
-  # customize here
-#  Ahoy.track_visits_immediately = true
+  Ahoy.track_visits_immediately = true
 end

--- a/spec/features/ahoy_spec.rb
+++ b/spec/features/ahoy_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'Ahoy' do
+  before :each do
+    DatabaseCleaner.start
+  end
+  after :each do
+    DatabaseCleaner.clean
+  end
+
+  it 'logs a visit' do
+    visit count = Visit.count
+    visit root_path
+    expect(Visit.count).to eq(count + 1)
+  end
+end

--- a/spec/features/ahoy_spec.rb
+++ b/spec/features/ahoy_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'Ahoy' do
+
   before :each do
     DatabaseCleaner.start
   end
@@ -9,7 +10,7 @@ describe 'Ahoy' do
   end
 
   it 'logs a visit' do
-    visit count = Visit.count
+    count = Visit.count
     visit root_path
     expect(Visit.count).to eq(count + 1)
   end


### PR DESCRIPTION
Closes #1314 

I think I figured this out. 

First off, I added a spec test for logging Ahoy visits, so we will be alerted to regressions. And on that theme, this PR does not regress, as the last one did.

The problem with the duplicate entries is related to the fact that in the `ApplicationController` we were calling `track_visit` for every request. This method seems to be the one that *initiates* a visit, so it was trying to insert the `current_visit` into the DB for every request. Obviously, this is what was giving us the MySQL errors.

Our first attempt to fix this simply removed that code (see #1366). The result was that *no* visits were tracked.

After reading the (sparse) documentation for v1.6.1 of the gem (which we are using), there was no indication that we should have had to add any code to the application to start logging `visits`. I found a setting to `track_visits_immediately`, which the documentation describes as:

> Visitor and visit ids are generated on the first request (so you can use them immediately), but the track_visit method isn’t called until the JavaScript library posts to the server. This prevents browsers with cookies disabled from creating multiple visits and ensures visits are not created for API endpoints

Since I couldn't (and still can't) find any JavaScript related to Ahoy, I set this to `true`. Now, if I remove the explicit call to the `track_visits` the visit is still recorded, but we don't get any errors.