### PR TITLE
Restrict document set routes.

### DIFF
--- a/app/controllers/document_sets_controller.rb
+++ b/app/controllers/document_sets_controller.rb
@@ -1,10 +1,21 @@
 class DocumentSetsController < ApplicationController
+  before_filter :authorized?, :except => [:index]
   before_action :set_document_set, only: [:show, :edit, :update, :destroy]
 
   respond_to :html
 
   # no layout if xhr request
   layout Proc.new { |controller| controller.request.xhr? ? false : nil }, :only => [:new, :create, :edit, :update]
+
+  def authorized?
+    unless user_signed_in?
+      ajax_redirect_to dashboard_path
+    end
+    if @document_set && !current_user.like_owner?(@document_set)
+      ajax_redirect_to dashboard_path
+    end
+  end
+
 
   def index
     @works = @collection.works.order(:title).paginate(page: params[:page], per_page: 20)


### PR DESCRIPTION
Closes #1425

The DocSet controller seemed to not have any authentication logic whatsoever. I borrowed the auth logic from the `collection_controller` and restricted all but the index method.