### PR TITLE
Fix for keeping owner signup flow with validation errors

### DIFF
--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -20,6 +20,9 @@ section.signon
     .signon_field
       =f.label :display_name
       =f.text_field :display_name
+    .signon_field
+      =f.hidden_field :owner
+      =f.hidden_field :paid_date
     -if RECAPTCHA_ENABLED
       .signon_field
         =recaptcha_tags


### PR DESCRIPTION
Closes #1424 

At present, this PR is just a patch so that new `owner` registrations will still carry through if they get some validation errors. 

We are losing the owner signup flow because the hidden field `is_owner` isn't a part of the normal `new_user` form. Because it is the `new_user` form that gets displayed with the validation errors, the hidden `is_owner: true` field is getting wiped out and the registration becomes a normal collaborator registration.

## Current Patch
I've added the `is_owner` (and `paid_through`) hidden fields to the normal user registration view. They default to `false/nil` (respectively), so normal registrations aren't affected. However, when a new `owner` gets validation errors, the (wrong) `new_user` form is still displayed but the hidden fields are properly populated with `is_owner: true` and `2.weeks.from.now` so the flow doesn't break.

## However...
We should do some work on this. I see two problems:
  1. Obviously, the wrong form is still being displayed. I think the solution here, actually, is to only use one form and conditionally display relevant text for the desired signup. Presumably we could still use the `/new_trial` route, we'd just use it to display the normal form, but with the `is_owner` hidden field populated with `true`.
  2. Currently, we are setting the `paid_through` variable on the client. Though I doubt it would happen frequently (if ever), this value could be changed by the client and someone could, potentially, give themselves a permanent free trial. We should move this assignment to the server when the owner is created.

If we do some `is_owner` checking in the `create` method, we may be able to keep these forms completely separate, but I think the simpler solution (i.e., less copy-pasta and conditionals) is to just unify the forms. I want to get some feedback from y'all before I commit to any of this, though.