### PR TITLE
Removed dependencies on trial owner feature absent from master deploy…

### DIFF
--- a/spec/features/devise_spec.rb
+++ b/spec/features/devise_spec.rb
@@ -48,44 +48,6 @@ describe "Devise" do
       click_button('Create Account')
       expect(page.current_path).to eq old_path
     end
-    it "creates a new trial owner account" do
-      visit users_new_trial_path
-      page.fill_in 'Login', with: owner.login
-      page.fill_in 'Email address', with: owner.email
-      page.fill_in 'Password', with: owner.password
-      page.fill_in 'Password confirmation', with: owner.password
-      page.fill_in 'Display name', with: owner.display_name
-      click_button('Create Account')
-      expect(page).to have_content("Signed In As#{owner.display_name}")
-    end
-    it "redirects owner to dashboard/owner#freetrial after signup" do 
-      visit users_new_trial_path
-      page.fill_in 'Login', with: owner.login
-      page.fill_in 'Email address', with: owner.email
-      page.fill_in 'Password', with: owner.password
-      page.fill_in 'Password confirmation', with: owner.password
-      page.fill_in 'Display name', with: owner.display_name
-      click_button('Create Account')
-      # This is the closest I can get to testing this path.
-      # Ideally we would also test that the path includes `#freetrial`
-      # but this seems to be a limitation of Capybara-Webkit
-      expect(page.current_path).to eq dashboard_owner_path
-    end
-    it "does not redirect owner to previous page after signup" do
-      # Previous page
-      visit old_path
-      visit users_new_trial_path
-      page.fill_in 'Login', with: owner.login
-      page.fill_in 'Email address', with: owner.email
-      page.fill_in 'Password', with: owner.password
-      page.fill_in 'Password confirmation', with: owner.password
-      page.fill_in 'Display name', with: owner.display_name
-      click_button('Create Account')
-      # This is the closest I can get to testing this path.
-      # Ideally we would also test that the path includes `#freetrial`
-      # but this seems to be a limitation of Capybara-Webkit
-      expect(page.current_path).to eq dashboard_owner_path
-    end
   end
 
   context "user login" do


### PR DESCRIPTION
This removes the `development/fromthepage.com` tests requiring trial owner functionality so that `master` can be deployed.