### PR TITLE
transcribe: fix save button bug

### DIFF
--- a/app/assets/stylesheets/sections/page.scss
+++ b/app/assets/stylesheets/sections/page.scss
@@ -211,7 +211,6 @@
   }
   textarea, div.editarea {
     height: calc(100% - 50px);
-    margin-top: 45px;
     resize: none;
     padding: $gapSize / 2;
   }

--- a/app/assets/stylesheets/sections/page.scss
+++ b/app/assets/stylesheets/sections/page.scss
@@ -210,7 +210,7 @@
     box-shadow: none;
   }
   textarea, div.editarea {
-    height: calc(100% - 50px);
+    height: 100%;
     resize: none;
     padding: $gapSize / 2;
   }


### PR DESCRIPTION
margin-top causes the textarea to overlap with the "Save Changes" button
(when transcribing a lengthy document), making the button unclickable.

Removing the CSS property fixes the issue.

Fixes: #1437