### PR TITLE
layout: make footer smaller

### DIFF
--- a/app/assets/stylesheets/components/layout.scss
+++ b/app/assets/stylesheets/components/layout.scss
@@ -49,38 +49,35 @@
 }
 
 .footer {
-  left: 0;
+  display: flex;
+  box-sizing: border-box;
+  position: absolute;
   bottom: 0;
   width: 100%;
   color: $footerFg;
-  text-align: left;
   padding: $gapSize;
-  position: absolute;
-  vertical-align: top;
-  display: inline-block;
   background: $footerBg;
-  height: $footerHeight;
-  box-sizing: border-box;
-  &_copyright {
-    position: absolute;
-    bottom: $gapSize;
-    left: $gapSize;
-  }
-  &_nav {
-    width: 200px;
-    float: right;
-    a {
-      text-decoration: none !important;
-      display: block;
-      font-size: $fontSizeBig;
-      line-height: 30px;
-    }
-  }
-  a {
-    color: inherit;
-    text-decoration: underline;
-    &:hover { color: lighten($footerFg, 20); }
-  }
+}
+
+.footer ul {
+  margin: 0;
+  padding: 0;
+}
+
+.footer_nav li {
+  margin-right: 0.4em;
+  display: inline;
+}
+
+.footer_copyright {
+  flex: auto;
+  text-align: right;
+}
+
+.footer_nav li a, .footer_copyright a {
+  color: inherit;
+  text-decoration: underline;
+  &:hover { color: lighten($footerFg, 20); }
 }
 
 .wrapper {

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -90,14 +90,14 @@ html lang="en-US"
     =(yield :content_below).force_encoding 'UTF-8'
 
     footer.footer
+      ul.footer_nav
+        li =link_to 'Documentation', 'http://content.fromthepage.com/project-owner-documentation/', target: '_blank'
+        li =link_to 'Blog', 'http://content.fromthepage.com', target: '_blank'
+        li =link_to 'About', about_path
+        li =link_to 'Terms & Conditions', 'http://fromthepage.wpengine.com/terms-of-service/'
+        li =link_to 'Privacy Policy', privacy_path
+        li =mail_to 'support@fromthepage.com', 'Contact Us'
       .footer_copyright &copy; #{Time.now.year} #{link_to 'FromThePage', root_path}. All rights reserved.
-      .footer_nav
-        =link_to 'Documentation', 'http://content.fromthepage.com/project-owner-documentation/', target: '_blank'
-        =link_to 'Blog', 'http://content.fromthepage.com', target: '_blank'
-        =link_to 'About', about_path
-        =link_to 'Terms & Conditions', 'http://fromthepage.wpengine.com/terms-of-service/'
-        =link_to 'Privacy Policy', privacy_path
-        =mail_to 'support@fromthepage.com', 'Contact Us'
 
     .page-busy-overlay
 


### PR DESCRIPTION
Use a list and flexbox to rearrange links and copyright notice
accordingly (so that they fit on a small footer).

Fixes: #1439