### PR TITLE
Owner profile page collection and docset visibility

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -67,7 +67,7 @@ class UserController < ApplicationController
       @user = User.friendly.find(params[:id])
     end
     if !@user.deleted || current_user.admin 
-      @collections_and_document_sets = @user.owned_collection_and_document_sets
+      @collections_and_document_sets = @user.visible_collections_and_document_sets(current_user)
       @collection_ids = @collections_and_document_sets.map {|collection| collection.id}
       @deeds = Deed.where(collection_id: @collection_ids).order("created_at DESC").limit(10)
       @notes = @user.notes.limit(10)

--- a/app/models/document_set.rb
+++ b/app/models/document_set.rb
@@ -19,7 +19,7 @@ class DocumentSet < ActiveRecord::Base
   scope :carousel, -> {where(pct_completed: [nil, 1..90]).joins(:collection).where.not(collections: {picture: nil}).where.not(description: [nil, '']).where(is_public: true).reorder("RAND()")}
 
   def show_to?(user)
-    self.is_public? || (user && user.collaborator?(self)) || self.collection.show_to?(user)
+    self.is_public? || (user && user.like_owner?(self)) || (user && user.collaborator?(self))
   end
 
   def intro_block

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -150,7 +150,7 @@ class User < ActiveRecord::Base
   end
   
   def unrestricted_collections
-    collections = self.all_owner_collections.unrestricted
+    self.all_owner_collections.unrestricted
   end
 
   def unrestricted_document_sets
@@ -161,8 +161,12 @@ class User < ActiveRecord::Base
     DocumentSet.where(owner_user_id: self.id)
   end
 
-  def owned_collection_and_document_sets
-    (unrestricted_collections + unrestricted_document_sets).sort_by {|obj| obj.title}
+  def collections_and_document_sets
+    (collections + document_sets).sort_by {|obj| obj.title}
+  end
+
+  def visible_collections_and_document_sets(user)
+    collections_and_document_sets.select {|cds| cds.show_to?(user) }
   end
 
   def slug_candidates

--- a/app/views/dashboard/_alphabetical_collections_and_document_sets.html.slim
+++ b/app/views/dashboard/_alphabetical_collections_and_document_sets.html.slim
@@ -1,17 +1,16 @@
-
-    .collections
-      -snippet = truncate(strip_tags(cds.intro_block), length: 300, separator: ' ') || ''
-      -owner_link = link_to cds.owner.display_name, user_profile_path(cds.owner) unless cds.owner.nil?
-      .collection
-        -unless cds.picture.blank?
-          .collection_image
-            =image_tag(cds.picture_url(:thumb), alt: cds.title)
-        .collection_details
-          h4.collection_title =link_to cds.title, collection_path(cds.owner, cds) unless cds.owner.nil?
-          -if cds.has_untranscribed_pages?
-            p
-              =link_to "Start Transcribing", collection_start_transcribing_path(cds.owner, cds), class: 'button'
-          -unless snippet.empty?
-            p.collection_snippet =snippet
-          .collection_summary
-            span =="Owned by #{owner_link}"
+.collections
+  -snippet = truncate(strip_tags(cds.intro_block), length: 300, separator: ' ') || ''
+  -owner_link = link_to cds.owner.display_name, user_profile_path(cds.owner) unless cds.owner.nil?
+  .collection
+    -unless cds.picture.blank?
+      .collection_image
+        =image_tag(cds.picture_url(:thumb), alt: cds.title)
+    .collection_details
+      h4.collection_title =link_to cds.title, collection_path(cds.owner, cds) unless cds.owner.nil?
+      -if cds.has_untranscribed_pages?
+        p
+          =link_to "Start Transcribing", collection_start_transcribing_path(cds.owner, cds), class: 'button'
+      -unless snippet.empty?
+        p.collection_snippet =snippet
+      .collection_summary
+        span =="Owned by #{owner_link}"

--- a/app/views/dashboard/_hierarchical_collections_and_document_sets.html.slim
+++ b/app/views/dashboard/_hierarchical_collections_and_document_sets.html.slim
@@ -1,39 +1,40 @@
-    .collections
-      -collections_and_document_sets.each do |cds|
-        -if cds.show_to?(current_user)
-
-          -if is_a_public_collection?(cds)
-            -snippet = truncate(strip_tags(cds.intro_block), length: 300, separator: ' ') || ''
-            -owner_link = link_to cds.owner.display_name, user_profile_path(cds.owner)
-            .collection
-              -unless cds.picture.blank?
-                .collection_image
-                  =image_tag(cds.picture_url(:thumb), alt: cds.title)
-              .collection_details
-                h4.collection_title =link_to cds.title, collection_path(cds.owner, cds)
-                -unless snippet.empty?
-                  p.collection_snippet =snippet
-                -if cds.has_untranscribed_pages?
-                  p
-                    =link_to "Start Transcribing", collection_start_transcribing_path(cds.owner, cds), class: 'button'
-                .collection_summary
-                  span =="Owned by #{owner_link}"
-                ul
-                -cds.document_sets.each do |doc_set|
-                  -if doc_set.is_public
-                    li =link_to doc_set.title, collection_path(doc_set.owner, doc_set)
-          -elsif is_a_private_document_set?(cds)
-            -snippet = truncate(strip_tags(cds.intro_block), length: 300, separator: ' ') || ''
-            -owner_link = link_to cds.owner.display_name, user_profile_path(cds.owner)
-            .collection
-              -unless cds.picture.blank?
-                .collection_image
-                  =image_tag(cds.picture_url(:thumb), alt: cds.title)
-              .collection_details
-                h4.collection_title =link_to cds.title, collection_path(cds.owner, cds)
-                -unless snippet.empty?
-                  p.collection_snippet =snippet
-                .collection_summary
-                  span =="Owned by #{owner_link}"
-          
-        
+.collections
+  -if cds.class == Collection
+    -snippet = truncate(strip_tags(cds.intro_block), length: 300, separator: ' ') || ''
+    -owner_link = link_to cds.owner.display_name, user_profile_path(cds.owner)
+    .collection
+      -unless cds.picture.blank?
+        .collection_image
+          =image_tag(cds.picture_url(:thumb), alt: cds.title)
+      .collection_details
+        h4.collection_title =link_to cds.title, collection_path(cds.owner, cds)
+        -unless snippet.empty?
+          p.collection_snippet =snippet
+        -if cds.has_untranscribed_pages?
+          p
+            =link_to "Start Transcribing", collection_start_transcribing_path(cds.owner, cds), class: 'button'
+        .collection_summary
+          span =="Owned by #{owner_link}"
+        ul
+        -cds.document_sets.each do |doc_set|
+          -if doc_set.is_public
+            li =link_to doc_set.title, collection_path(doc_set.owner, doc_set)
+  -elsif cds.class == DocumentSet
+    -unless @collections_and_document_sets.include? cds.collection
+      -snippet = truncate(strip_tags(cds.intro_block), length: 300, separator: ' ') || ''
+      -owner_link = link_to cds.owner.display_name, user_profile_path(cds.owner)
+      .collection
+        -unless cds.picture.blank?
+          .collection_image
+            =image_tag(cds.picture_url(:thumb), alt: cds.title)
+        .collection_details
+          h4.collection_title =link_to cds.title, collection_path(cds.owner, cds)
+          -unless snippet.empty?
+            p.collection_snippet =snippet
+          -if cds.has_untranscribed_pages?
+          p
+            =link_to "Start Transcribing", collection_start_transcribing_path(cds.owner, cds), class: 'button'
+          .collection_summary
+            span =="Owned by #{owner_link}"
+  
+    

--- a/app/views/user/_owner_profile.html.slim
+++ b/app/views/user/_owner_profile.html.slim
@@ -1,5 +1,4 @@
 -user_name = user.display_name.presence || user.login
-
 section.user-profile
   .user-profile_image
     .userpic =gravatar_image_tag user.email, :alt => user_name, :gravatar => { :size => 256 }
@@ -39,9 +38,9 @@ section.user-profile
           br
             
 .columns.list
-  article.maincol  
-    -if any_public_collections_with_document_sets?(collections_and_document_sets)
-      =render partial: '/dashboard/hierarchical_collections_and_document_sets', locals: {collections_and_document_sets: collections_and_document_sets}
+  article.maincol 
+    -if @collections_and_document_sets.any?{ |c| c.class == Collection && c.supports_document_sets }
+      =render partial: '/dashboard/hierarchical_collections_and_document_sets', collection: @collections_and_document_sets, as: :cds
     -else
       =render partial: '/dashboard/alphabetical_collections_and_document_sets', collection: @collections_and_document_sets, as: :cds
     

--- a/spec/factories/collection.rb
+++ b/spec/factories/collection.rb
@@ -1,14 +1,20 @@
 FactoryBot.define do
   factory :collection do
     sequence(:title) { |n| "Collection Title #{n}" }
-    owner_user_id { association(:user).id }
+    owner_user_id { association(:owner).id }
+    works { build_list :work_with_pages, 2 }
 
     trait :with_links do
       works { build_stubbed_list :work_with_links, 2 }
     end
-
     trait :with_pages do
       works { build_list :work_with_pages, 2 }
+    end
+    trait :private do 
+      restricted { true }
+    end
+    trait :docset_enabled do
+      supports_document_sets { true }
     end
   end
 end

--- a/spec/factories/document_set.rb
+++ b/spec/factories/document_set.rb
@@ -1,7 +1,16 @@
 FactoryBot.define do
   factory :document_set do
     sequence(:title) { |n| "DocumentSet Title #{n}" }
-    collection_id { association(:collection).id }
-    owner_user_id { association(:user).id }
+    collection_id { association(:collection, :docset_enabled).id }
+    owner_user_id { association(:owner).id }
+
+    trait :public do
+      # Document Sets are private by default!
+      is_public { true }
+    end
+    trait :private do
+      # Document Sets are private by default!
+      is_public { false }
+    end
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -8,10 +8,14 @@ FactoryBot.define do
   
     factory :owner do
       owner { true }
+      sequence(:display_name) { |n| "Owner #{n} Display Name" }
+      sequence(:login) { |n| "owner_#{n}_login" }
     end
 
     factory :admin do
       admin { true }
+      sequence(:display_name) { |n| "Admin #{n} Display Name" }
+      sequence(:login) { |n| "admin_#{n}_login" }
     end
   end
 end

--- a/spec/features/collaborator_spec.rb
+++ b/spec/features/collaborator_spec.rb
@@ -1,0 +1,126 @@
+require 'spec_helper'
+
+describe "Collaborator actions" do
+    before :each do
+        DatabaseCleaner.start
+    end
+    after :each do
+        DatabaseCleaner.clean
+    end
+    
+    let(:collaborator){ create(:user) }
+    context "when collection and docset are public" do
+        let(:collection){ create(:collection)}
+        let(:docset){ create(:document_set, :public)}
+        let(:work){ collection.works.first }
+
+        it "can view public collections from user profile" do
+            login_as(collaborator, :scope => :user)
+            visit user_profile_path(collection.owner)
+            expect(page).to have_content(collection.title)
+        end
+        it "can view public document sets from user profile" do 
+            login_as(collaborator, :scope => :user)
+            visit user_profile_path(docset.owner)
+            expect(page).to have_content(docset.title)
+        end
+        it "can view public collection page" do
+            login_as(collaborator, :scope => :user)
+            visit collection_path(collection.owner, collection)
+            expect(page.current_path).to eq(collection_path(collection.owner, collection))
+        end
+        it "can view public works from collection page" do
+            login_as(collaborator, :scope => :user)
+            visit collection_path(collection.owner, collection)
+            expect(page).to have_content(work.title)
+        end
+    end
+    context "when collection is private and docset is public" do
+        let(:private_collection){ create(:collection, :private) }
+        let(:docset){ create(:document_set, :public,
+            collection: private_collection,
+            owner: private_collection.owner
+        )}
+
+        it "cannot view private collections from user profile" do
+            login_as(collaborator, :scope => :user)
+            visit user_profile_path(private_collection.owner)
+            expect(page).not_to have_content(private_collection.title)
+        end
+        it "can view public docsets from user profile" do
+            login_as(collaborator, :scope => :user)
+            visit user_profile_path(docset.owner)
+            expect(page).to have_content(docset.title)
+        end
+    end
+    context "when collection is public and docset is private" do
+        let(:collection){ create(:collection) }
+        let(:docset){ create(:document_set, :private,
+            collection: collection,
+            owner: collection.owner
+        )}
+        it "can view public collections from user profile" do
+            login_as(collaborator, :scope => :user)
+            visit user_profile_path(collection.owner)
+            expect(page).to have_content(collection.title)
+        end
+        it "can view private docset from user profile" do
+            login_as(collaborator, :scope => :user)
+            visit user_profile_path(docset.owner)
+            expect(page).not_to have_content(docset.title)
+        end
+    end
+    context "when collection is private and docset is private" do
+        let(:collection){ create(:collection, :private) }
+        let(:docset){ create(:document_set, :private,
+            collection: collection,
+            owner: collection.owner
+        )}
+
+        it "cannot view private collections from user profile" do
+            login_as(collaborator, :scope => :user)
+            visit user_profile_path(collection.owner)
+            expect(page).not_to have_content(collection.title)
+        end
+        it "cannot view private docset from user profile" do
+            login_as(collaborator, :scope => :user)
+            visit user_profile_path(docset.owner)
+            expect(page).not_to have_content(docset.title)
+        end
+        context "when added as a collaborator to a private collection" do
+            let(:collection){ create(:collection, :private,
+                collaborators: [collaborator]
+            )}
+            let(:docset){ create(:document_set, :private,
+                collection: collection,
+            )}
+            it "can view the private collection" do
+                login_as(collaborator, :scope => :user)
+                visit user_profile_path(collection.owner)
+                expect(page).to have_content(collection.title)
+            end
+            it "can view private document sets, though not explicitly named" do
+                login_as(collaborator, :scope => :user)
+                visit user_profile_path(docset.owner)
+                expect(page).to have_content(docset.title)
+            end
+        end
+        context "when added as a collaborator to a private docset" do
+            let(:collection){ create(:collection, :private)}
+            let(:docset){ create(:document_set, :private,
+                collection: collection,
+                collaborators: [collaborator]
+            )}
+            it "cannot view private collections" do
+                login_as(collaborator, :scope => :user)
+                visit user_profile_path(docset.owner)
+                expect(page).not_to have_content(collection.title)
+            end
+            it "can view private document sets" do
+                login_as(collaborator, :scope => :user)
+                visit user_profile_path(docset.owner)
+                expect(page).to have_content(docset.title)
+            end
+        end
+    end
+end


### PR DESCRIPTION
Closes #1196 
Closes #1435 

# Overview
This PR addresses the way that we display collections and document sets on owner profile pages. Formerly, only public collections and docsets would show up on the owner profile pages, regardless of whether the current user is a collaborator.

Importantly, this PR only addresses whether a collection or docset is *displayed* and not whether a given user can make edits (those permissions are working as desired, as far as I know).

After some discussion, we clarified the specific functionality for all combinations of private/public collection/docset for public/collaborator viewing (tests included). The truth table (the feature tests follow this format):

1. When Collection and DocSet are both public, non-owners should see them.
2. When Collection is private and Docset is public, non-owners should see Docset, but not Collection.
3. When Collection is public and Docset is private, non-owners see Collection, but not Docset
4. When both are private, no one sees anything.
5. When a user is added as a collection-level collaborator to a collection they can see the the *collection and all docsets*.
6. When a user is added as a docset-level collaborator, they can see the specific docset, but not its parent collection (if it's private).

This should give us the functionality that @atomrab is describing in #1192. Students who have been added as collaborators to specific docsets should be able to see those docsets from his user profile page, but will not be able to see the full collection, nor see other docsets. 