### PR TITLE
Proper handling of docset auth

### DIFF
--- a/app/controllers/document_sets_controller.rb
+++ b/app/controllers/document_sets_controller.rb
@@ -1,5 +1,5 @@
 class DocumentSetsController < ApplicationController
-  before_filter :authorized?, :except => [:index]
+  before_filter :authorized?
   before_action :set_document_set, only: [:show, :edit, :update, :destroy]
 
   respond_to :html
@@ -8,10 +8,10 @@ class DocumentSetsController < ApplicationController
   layout Proc.new { |controller| controller.request.xhr? ? false : nil }, :only => [:new, :create, :edit, :update]
 
   def authorized?
-    unless user_signed_in?
+    if !user_signed_in?
       ajax_redirect_to dashboard_path
     end
-    if @document_set && !current_user.like_owner?(@document_set)
+    if @collection && !current_user.like_owner?(@collection)
       ajax_redirect_to dashboard_path
     end
   end

--- a/app/controllers/document_sets_controller.rb
+++ b/app/controllers/document_sets_controller.rb
@@ -8,14 +8,10 @@ class DocumentSetsController < ApplicationController
   layout Proc.new { |controller| controller.request.xhr? ? false : nil }, :only => [:new, :create, :edit, :update]
 
   def authorized?
-    if !user_signed_in?
-      ajax_redirect_to dashboard_path
-    end
-    if @collection && !current_user.like_owner?(@collection)
+    unless user_signed_in? && @collection && current_user.like_owner?(@collection)
       ajax_redirect_to dashboard_path
     end
   end
-
 
   def index
     @works = @collection.works.order(:title).paginate(page: params[:page], per_page: 20)

--- a/app/views/document_sets/_edit.html.slim
+++ b/app/views/document_sets/_edit.html.slim
@@ -1,6 +1,6 @@
   p If the document set is marked as public, works put within it will be readable even if the collection is marked as private.
 
-  =form_for(@document_set, url: document_set_path(@document_set)) do |f|
+  =form_for(@document_set, url: document_set_path(@document_set, collection_id: @collection)) do |f|
     =validation_summary @document_set.errors
     =f.hidden_field :collection_id
     table.form.settings

--- a/app/views/document_sets/new.html.slim
+++ b/app/views/document_sets/new.html.slim
@@ -2,7 +2,7 @@
   h1 Create New Document Set
   p If the document set is marked as public, works put within it will be readable even if the collection is marked as private.
 
-  =form_for(@document_set, url: create_document_set_path) do |f|
+  =form_for(@document_set, url: create_document_set_path(:collection_id => @collection)) do |f|
     =validation_summary @document_set.errors
     =f.hidden_field :collection_id
     table.form


### PR DESCRIPTION
I originally misunderstood how this route worked. The page under consideration should only be able to be edited by people with *collection*-level owner permissions. This is the right way to fix that page's permissions errors.