### PR TITLE
Added Bullet and RMP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'omniauth-google-oauth2'
 
 gem 'rack-reverse-proxy', :require => 'rack/reverse_proxy'
 
+
 group :assets do
   gem 'therubyracer'
   gem 'uglifier'
@@ -67,9 +68,7 @@ group :development, :test do
   gem 'binding_of_caller' # goes with better_errors
   # Supporting gem for RailsPanel
   # https://github.com/dejan/rails_panel
-  gem 'meta_request'
   gem 'bullet'
-  gem 'rack-mini-profiler'
 end
 
 # Use SASS for stylesheets
@@ -96,3 +95,10 @@ gem 'iso-639'
 
 # Quiet asset lines in log files
 gem 'quiet_assets', '~> 1.1.0', group: :development
+
+# Profiling for use in prod
+gem 'flamegraph'
+gem 'memory_profiler'
+gem 'meta_request'
+gem 'rack-mini-profiler'
+gem 'stackprof'

--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,8 @@ group :development, :test do
   # Supporting gem for RailsPanel
   # https://github.com/dejan/rails_panel
   gem 'meta_request'
+  gem 'bullet'
+  gem 'rack-mini-profiler'
 end
 
 # Use SASS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,7 @@ GEM
     faraday_middleware (0.13.0)
       faraday (>= 0.7.4, < 1.0)
     ffi (1.10.0)
+    flamegraph (0.9.5)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
     geocoder (1.5.1)
@@ -180,6 +181,7 @@ GEM
     mail (2.5.5)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    memory_profiler (0.9.14)
     meta_request (0.6.0)
       callsite (~> 0.0, >= 0.0.11)
       rack-contrib (>= 1.1, < 3)
@@ -359,6 +361,7 @@ GEM
     sshkit (1.18.1)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    stackprof (0.2.12)
     temple (0.8.0)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
@@ -415,12 +418,14 @@ DEPENDENCIES
   devise-encryptable
   devise_masquerade
   factory_bot_rails
+  flamegraph
   friendly_id
   gravatar_image_tag
   iiif-presentation!
   iso-639
   jquery-rails
   launchy
+  memory_profiler
   meta_request
   mysql2 (= 0.3.21)
   nokogiri
@@ -449,6 +454,7 @@ DEPENDENCIES
   savon (~> 2.12.0)
   shoulda
   slim (~> 3.0.0)
+  stackprof
   therubyracer
   uglifier
   vcr

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,9 @@ GEM
       debug_inspector (>= 0.0.1)
     browser (2.5.3)
     builder (3.2.3)
+    bullet (6.0.2)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (10.0.2)
     callsite (0.0.11)
     capistrano (3.4.1)
@@ -241,6 +244,8 @@ GEM
       rack (>= 1.0, < 3)
     rack-contrib (1.8.0)
       rack (~> 1.4)
+    rack-mini-profiler (1.0.2)
+      rack (>= 1.2.0)
     rack-proxy (0.6.5)
       rack
     rack-reverse-proxy (0.12.0)
@@ -371,6 +376,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
+    uniform_notifier (1.12.1)
     user_agent_parser (2.5.1)
     uuidtools (2.1.5)
     vcr (5.0.0)
@@ -397,6 +403,7 @@ DEPENDENCIES
   autoprefixer-rails (<= 8.6.5)
   better_errors
   binding_of_caller
+  bullet
   capistrano (~> 3.4.0)
   capistrano-bundler (~> 1.1.2)
   capistrano-rails (= 1.1.3)
@@ -427,6 +434,7 @@ DEPENDENCIES
   pry-awesome_print
   pry-byebug
   quiet_assets (~> 1.1.0)
+  rack-mini-profiler
   rack-reverse-proxy
   rails (= 4.1.2)
   recaptcha

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,11 @@
 class ApplicationController < ActionController::Base
+  
+  before_action do
+    if current_user && current_user.admin
+      Rack::MiniProfiler.authorize_request
+    end
+  end
+
   before_filter :load_objects_from_params
   before_filter :update_ia_work_server
   before_filter :update_omeka_urls

--- a/config/initializers/rack-mini-profiler.rb
+++ b/config/initializers/rack-mini-profiler.rb
@@ -1,0 +1,2 @@
+# Use Rack Mini Profiler everywhere
+Rack::MiniProfiler.config.start_hidden = true


### PR DESCRIPTION
Currently this just adds the Bullet and Rack-Mini-Profiler gems to the gemfile with no configuration.

The RMP gem "just works" in the development environment, but the Bullet gem requires some config in the `development.rb` initializer. We `.gitignore` that initializer, however, so we'll need to either need to check it back in or just configure it for ourselves (I'm inclined toward checking it back in, personally).

I've opened  #1485 to address configuring RMP for use in production environments.