### PR TITLE
Improve dashboard#landing_page route perf

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'omniauth-google-oauth2'
 
 gem 'rack-reverse-proxy', :require => 'rack/reverse_proxy'
 
+
 group :assets do
   gem 'therubyracer'
   gem 'uglifier'
@@ -67,9 +68,7 @@ group :development, :test do
   gem 'binding_of_caller' # goes with better_errors
   # Supporting gem for RailsPanel
   # https://github.com/dejan/rails_panel
-  gem 'meta_request'
   gem 'bullet'
-  gem 'rack-mini-profiler'
 end
 
 # Use SASS for stylesheets
@@ -96,3 +95,10 @@ gem 'iso-639'
 
 # Quiet asset lines in log files
 gem 'quiet_assets', '~> 1.1.0', group: :development
+
+# Profiling for use in prod
+gem 'flamegraph'
+gem 'memory_profiler'
+gem 'meta_request'
+gem 'rack-mini-profiler'
+gem 'stackprof'

--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,8 @@ group :development, :test do
   # Supporting gem for RailsPanel
   # https://github.com/dejan/rails_panel
   gem 'meta_request'
+  gem 'bullet'
+  gem 'rack-mini-profiler'
 end
 
 # Use SASS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,7 @@ GEM
     faraday_middleware (0.13.0)
       faraday (>= 0.7.4, < 1.0)
     ffi (1.10.0)
+    flamegraph (0.9.5)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
     geocoder (1.5.1)
@@ -180,6 +181,7 @@ GEM
     mail (2.5.5)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    memory_profiler (0.9.14)
     meta_request (0.6.0)
       callsite (~> 0.0, >= 0.0.11)
       rack-contrib (>= 1.1, < 3)
@@ -359,6 +361,7 @@ GEM
     sshkit (1.18.1)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    stackprof (0.2.12)
     temple (0.8.0)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
@@ -415,12 +418,14 @@ DEPENDENCIES
   devise-encryptable
   devise_masquerade
   factory_bot_rails
+  flamegraph
   friendly_id
   gravatar_image_tag
   iiif-presentation!
   iso-639
   jquery-rails
   launchy
+  memory_profiler
   meta_request
   mysql2 (= 0.3.21)
   nokogiri (~> 1.8.1)
@@ -449,6 +454,7 @@ DEPENDENCIES
   savon (~> 2.12.0)
   shoulda
   slim (~> 3.0.0)
+  stackprof
   therubyracer
   uglifier
   vcr

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,9 @@ GEM
       debug_inspector (>= 0.0.1)
     browser (2.5.3)
     builder (3.2.3)
+    bullet (6.0.2)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (10.0.2)
     callsite (0.0.11)
     capistrano (3.4.1)
@@ -241,6 +244,8 @@ GEM
       rack (>= 1.0, < 3)
     rack-contrib (1.8.0)
       rack (~> 1.4)
+    rack-mini-profiler (1.0.2)
+      rack (>= 1.2.0)
     rack-proxy (0.6.5)
       rack
     rack-reverse-proxy (0.12.0)
@@ -371,6 +376,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
+    uniform_notifier (1.12.1)
     user_agent_parser (2.5.1)
     uuidtools (2.1.5)
     vcr (5.0.0)
@@ -397,6 +403,7 @@ DEPENDENCIES
   autoprefixer-rails (<= 8.6.5)
   better_errors
   binding_of_caller
+  bullet
   capistrano (~> 3.4.0)
   capistrano-bundler (~> 1.1.2)
   capistrano-rails (= 1.1.3)
@@ -427,6 +434,7 @@ DEPENDENCIES
   pry-awesome_print
   pry-byebug
   quiet_assets (~> 1.1.0)
+  rack-mini-profiler
   rack-reverse-proxy
   rails (= 4.1.2)
   recaptcha
@@ -448,4 +456,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,11 @@
 class ApplicationController < ActionController::Base
+  
+  before_action do
+    if current_user && current_user.admin
+      Rack::MiniProfiler.authorize_request
+    end
+  end
+
   before_filter :load_objects_from_params
   before_filter :update_ia_work_server
   before_filter :update_omeka_urls

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -127,23 +127,22 @@ class DashboardController < ApplicationController
   end
 
   def landing_page
-    
     if params[:search]
       # Get matching Collections and Docsets
-      @search_results =  Collection.search(params[:search]).unrestricted + DocumentSet.search(params[:search]).unrestricted
-      
+      @search_results = Collection.search(params[:search]).unrestricted + DocumentSet.search(params[:search]).unrestricted
+
       # Get user_ids from the resulting search
       search_user_ids = User.search(params[:search]).pluck(:id) + @search_results.map(&:owner_user_id)
-      
+
       # Get matching users and users from Collections and DocSets search
       @owners = User.where(id: search_user_ids).where.not(account_type: nil)
     else
       # Get random Collections and DocSets from paying users
-      @owners = User.paid_owners.includes(:random_collections, :random_document_sets).order(:display_name)
-      
+      @owners = User.non_trial_owners.includes(:random_collections, :random_document_sets).order(:display_name)
+
       # Sampled Randomly down to 8 items for Carousel
-      docsets = DocumentSet.includes(:owner).where(owner_user_id: @owners.ids).sample(5)
-      colls = Collection.includes(:owner).where(owner_user_id: @owners.ids).sample(5)
+      docsets = DocumentSet.carousel.includes(:owner).where(owner_user_id: @owners.ids).sample(5)
+      colls = Collection.carousel.includes(:owner).where(owner_user_id: @owners.ids).sample(5)
       @collections = (docsets + colls).sample(8)
     end
   end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,9 +1,15 @@
-class DashboardController < ApplicationController
+# frozen_string_literal: true
 
+class DashboardController < ApplicationController
   include AddWorkHelper
 
-  before_filter :authorized?, :only => [:owner, :staging, :omeka, :startproject, :summary]
-  before_filter :get_data, :only => [:owner, :staging, :omeka, :upload, :new_upload, :startproject, :empty_work, :create_work, :summary]
+  before_filter :authorized?,
+    only: [:owner, :staging, :omeka, :startproject, :summary]
+
+  before_filter :get_data,
+    only: [:owner, :staging, :omeka, :upload, :new_upload,
+           :startproject, :empty_work, :create_work, :summary]
+
   before_action :remove_col_id
 
   def authorized?
@@ -32,16 +38,14 @@ class DashboardController < ApplicationController
     @works = current_user.owner_works
     @ia_works = current_user.ia_works
     @document_sets = current_user.document_sets
-
-    logger.debug("DEBUG: #{current_user.inspect}")
   end
 
-  #Public Dashboard - list of all collections
+  # Public Dashboard - list of all collections
   def index
-    unless (Collection.all.count > 1000)
-      redirect_to collections_list_path
-    else
+    if Collection.all.count > 1000
       redirect_to landing_page_path
+    else
+      redirect_to collections_list_path
     end
   end
 
@@ -59,67 +63,65 @@ class DashboardController < ApplicationController
           collections_and_document_sets << collection
         elsif current_user.like_owner?(collection)
           collections_and_document_sets << collection
-        end 
+        end
       end
     else
       collections_and_document_sets = Collection.joins(:owner).preload(:owner).where(restricted: false) + DocumentSet.joins(:owner).preload(:owner).where(is_public: true)
     end
 
-    @collections_and_document_sets = collections_and_document_sets.sort { |a,b| a.title <=> b.title }
+    @collections_and_document_sets = collections_and_document_sets.sort { |a, b| a.title <=> b.title }
   end
 
-  #Owner Dashboard - start project
-  #other methods in AddWorkHelper
+  # Owner Dashboard - start project
+  # other methods in AddWorkHelper
   def startproject
     @work = Work.new
     @work.collection = @collection
     @document_upload = DocumentUpload.new
-    @document_upload.collection=@collection
+    @document_upload.collection = @collection
     @omeka_items = OmekaItem.all
     @omeka_sites = current_user.omeka_sites
     @sc_collections = ScCollection.all
   end
 
-  #Owner Dashboard - list of works
+  # Owner Dashboard - list of works
   def owner
   end
 
-  #Owner Summary Statistics - statistics for all owned collections
+  # Owner Summary Statistics - statistics for all owned collections
   def summary
     @statistics_object = current_user
-    @subjects_disabled = @statistics_object.collections.all? { |c| c.subjects_disabled }
+    @subjects_disabled = @statistics_object.collections.all?(&:subjects_disabled)
   end
 
-  #Collaborator Dashboard - watchlist
+  # Collaborator Dashboard - watchlist
   def watchlist
-    works = Work.joins(:deeds).where(deeds: {user_id: current_user.id}).distinct
-    collections = Collection.joins(:deeds).where(deeds: {user_id: current_user.id}).distinct.order_by_recent_activity.limit(5)
-    document_sets = DocumentSet.joins(works: :deeds).where(works: {id: works.ids}).order('deeds.created_at DESC').distinct.limit(5)
-    @collections = (collections + document_sets).sort{|a,b| a.title <=> b.title }.take(5)
+    works = Work.joins(:deeds).where(deeds: { user_id: current_user.id }).distinct
+    collections = Collection.joins(:deeds).where(deeds: { user_id: current_user.id }).distinct.order_by_recent_activity.limit(5)
+    document_sets = DocumentSet.joins(works: :deeds).where(works: { id: works.ids }).order('deeds.created_at DESC').distinct.limit(5)
+    @collections = (collections + document_sets).sort { |a, b| a.title <=> b.title }.take(5)
     @page = recent_work
   end
 
-  #Collaborator Dashboard - user with no activity watchlist
+  # Collaborator Dashboard - user with no activity watchlist
   def recent_work
     recent_deed_ids = Deed.joins(:collection, :work).merge(Collection.unrestricted).merge(Work.unrestricted)
-                  .where("work_id is not null").order('created_at desc').distinct.limit(5).pluck(:work_id)
-    @works = Work.joins(:pages).where(id: recent_deed_ids).where(pages: {status: nil})
+      .where("work_id is not null").order('created_at desc').distinct.limit(5).pluck(:work_id)
+    @works = Work.joins(:pages).where(id: recent_deed_ids).where(pages: { status: nil })
 
-#find the first blank page in the most recently accessed work (as long as the works list isn't blank)
-    unless @works.empty?
-      recent_work = @works.first.pages.where(status: nil).first
-    #if the works list is blank, return nil
-    else
-      recent_work = nil
+    # find the first blank page in the most recently accessed work (as long as the works list isn't blank)
+    recent_work = unless @works.empty?
+      @works.first.pages.where(status: nil).first
+      # if the works list is blank, return nil
     end
   end
 
-  #Collaborator Dashboard - activity
+  # Collaborator Dashboard - activity
   def editor
     @user = current_user
   end
 
-  #Guest Dashboard - activity
+  # Guest Dashboard - activity
   def guest
     @collections = Collection.order_by_recent_activity.unrestricted.distinct.limit(5)
   end
@@ -132,12 +134,11 @@ class DashboardController < ApplicationController
       @owners = User.where(id: search_ids).where.not(account_type: nil)
     else
       id_list = User.where.not(account_type: [nil, 'Trial']).pluck(:id)
-      #merging on collections with those user ids filters out owners without collections
-      @owners = User.joins(:collections).where(collections: {restricted: false}).where(collections: {owner_user_id: id_list}).distinct.order(:display_name)
+      # merging on collections with those user ids filters out owners without collections
+      @owners = User.joins(:collections).where(collections: { restricted: false }).where(collections: { owner_user_id: id_list }).distinct.order(:display_name)
     end
 
-    #these are for the carousel
-    @collections = @owners.map {|user| Collection.carousel.where(owner_user_id: user.id).first }.compact.sample(8)
+    # these are for the carousel
+    @collections = @owners.map { |user| Collection.carousel.where(owner_user_id: user.id).first }.compact.sample(8)
   end
-
 end

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -5,21 +5,4 @@ module DashboardHelper
     @works = collection.works.order(:title).limit(15)
   end
 
-  def find_page(collection)
-    page = Page.joins(:work).where(works: {collection_id: collection.id}).where(works: {restrict_scribes: false}).where(status: nil).sample(1).first
-  end
-
-  def owner_projects(owner)
-    if params[:search]
-      projects = @search_results.map {|col| col if col.owner_user_id == owner.id}.compact
-    else
-      sets = DocumentSet.unrestricted.where(owner_user_id: owner.id).where.not(pct_completed: 90..100).where.not(description: [nil, '']).select {|set| set.works.exists? }
-      collections = Collection.unrestricted.where(owner_user_id: owner.id).where.not(pct_completed: 90..100).where.not(intro_block: [nil, '']).select {|c| c.works.exists? }
-      projects = (sets + collections).sample(3)
-    end
-    return projects
-  end
-
-
-
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -15,6 +15,8 @@ class Collection < ActiveRecord::Base
   has_one :sc_collection, :dependent => :destroy
   has_many :transcription_fields, :dependent => :destroy
 
+  has_many :pages, through: :works
+
   belongs_to :owner, :class_name => 'User', :foreign_key => 'owner_user_id'
   has_and_belongs_to_many :owners, :class_name => 'User', :join_table => :collection_owners
   has_and_belongs_to_many :collaborators, :class_name => 'User', :join_table => :collection_collaborators
@@ -34,6 +36,12 @@ class Collection < ActiveRecord::Base
   scope :unrestricted, -> { where(restricted: false)}
   scope :order_by_incomplete, -> { joins(works: :work_statistic).reorder('work_statistics.complete ASC')}
   scope :carousel, -> {where(pct_completed: [nil, 1..90]).where.not(picture: nil).where.not(intro_block: [nil, '']).where(restricted: false).reorder("RAND()")}
+
+  scope :sample, -> (sample_size = 5) do
+    carousel
+    reorder("RAND()") unless sample_size > 1
+    limit(sample_size).reorder("RAND()")
+  end
 
   def self.access_controlled(user)
     if user.nil?

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -35,7 +35,13 @@ class Collection < ActiveRecord::Base
   scope :order_by_recent_activity, -> { joins(:deeds).order('deeds.created_at DESC') }
   scope :unrestricted, -> { where(restricted: false)}
   scope :order_by_incomplete, -> { joins(works: :work_statistic).reorder('work_statistics.complete ASC')}
+  
   scope :carousel, -> {where(pct_completed: [nil, 1..90]).where.not(picture: nil).where.not(intro_block: [nil, '']).where(restricted: false).reorder("RAND()")}
+  
+  scope :has_intro_block, -> { where.not(intro_block: [nil, '']) }
+  scope :not_near_complete, -> { where(pct_completed: [nil, 0..90]) }
+  scope :not_empty, -> { where.not(works_count: [0, nil]) }
+
 
   scope :sample, -> (sample_size = 5) do
     carousel

--- a/app/models/document_set.rb
+++ b/app/models/document_set.rb
@@ -10,6 +10,9 @@ class DocumentSet < ActiveRecord::Base
 
   belongs_to :owner, :class_name => 'User', :foreign_key => 'owner_user_id'
   belongs_to :collection
+
+  has_many :pages, through: :works
+
   has_and_belongs_to_many :works
   has_and_belongs_to_many :collaborators, :class_name => 'User', :join_table => :document_set_collaborators
   
@@ -17,6 +20,12 @@ class DocumentSet < ActiveRecord::Base
 
   scope :unrestricted, -> { where(is_public: true)}
   scope :carousel, -> {where(pct_completed: [nil, 1..90]).joins(:collection).where.not(collections: {picture: nil}).where.not(description: [nil, '']).where(is_public: true).reorder("RAND()")}
+
+  scope :sample, -> (sample_size = 5) do
+    carousel
+    reorder("RAND()") unless sample_size > 1
+    limit(sample_size).reorder("RAND()")
+  end
 
   def show_to?(user)
     self.is_public? || (user && user.collaborator?(self)) || self.collection.show_to?(user)

--- a/app/models/document_set.rb
+++ b/app/models/document_set.rb
@@ -4,7 +4,7 @@ class DocumentSet < ActiveRecord::Base
   extend FriendlyId
   friendly_id :slug_candidates, :use => [:slugged, :history]
   
-  attr_accessible :title, :description, :collection_id, :picture, :is_public, :slug, :pct_completed
+  attr_accessible :title, :description, :collection_id, :picture, :is_public, :slug, :pct_completed, :works_count
 
   mount_uploader :picture, PictureUploader
 
@@ -13,14 +13,19 @@ class DocumentSet < ActiveRecord::Base
 
   has_many :pages, through: :works
 
-  has_and_belongs_to_many :works
+  has_many :document_set_works
+  has_many :works, through: :document_set_works
+
   has_and_belongs_to_many :collaborators, :class_name => 'User', :join_table => :document_set_collaborators
   
   validates :title, presence: true, length: { minimum: 3, maximum: 255 }
 
   scope :unrestricted, -> { where(is_public: true)}
   scope :carousel, -> {where(pct_completed: [nil, 1..90]).joins(:collection).where.not(collections: {picture: nil}).where.not(description: [nil, '']).where(is_public: true).reorder("RAND()")}
-
+  scope :has_intro_block, -> { where.not(description: [nil, '']) }
+  scope :not_near_complete, -> { where(pct_completed: [nil, 0..90]) }
+  scope :not_empty, -> { where.not(works_count: [0, nil]) }
+  
   scope :sample, -> (sample_size = 5) do
     carousel
     reorder("RAND()") unless sample_size > 1

--- a/app/models/document_set_work.rb
+++ b/app/models/document_set_work.rb
@@ -1,0 +1,7 @@
+class DocumentSetWork < ActiveRecord::Base
+  
+  self.table_name = "document_sets_works"
+  
+  belongs_to :document_set, counter_cache: :works_count
+  belongs_to :work
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,10 +54,11 @@ class User < ActiveRecord::Base
   has_many :random_document_sets, -> { unrestricted.sample }, 
     class_name: "DocumentSet", :foreign_key => "owner_user_id"
 
-  scope :owners,         -> { where(owner: true) }
-  scope :trial_owners,   -> { owners.where(account_type: 'Trial') }
-  scope :paid_owners,    -> { owners.where('paid_date > ?', Time.now) }
-  scope :expired_owners, -> { owners.where('paid_date <= ?', Time.now) }
+  scope :owners,           -> { where(owner: true) }
+  scope :trial_owners,     -> { owners.where(account_type: 'Trial') }
+  scope :non_trial_owners, -> { owners.where.not(account_type: [nil, 'Trial']) }
+  scope :paid_owners,      -> { owners.where('paid_date > ?', Time.now) }
+  scope :expired_owners,   -> { owners.where('paid_date <= ?', Time.now) }
 
   validates :display_name, presence: true
   validates :login, presence: true, uniqueness: { case_sensitive: false }, format: { with: /\A[a-zA-Z0-9_\.]*\z/, message: "Invalid characters in username"}, exclusion: { in: %w(transcribe translate work collection deed), message: "Username is invalid"}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,6 +49,16 @@ class User < ActiveRecord::Base
   has_many :notes, -> { order 'created_at DESC' }
   has_many :deeds
 
+  has_many :random_collections,   -> { unrestricted.sample },
+    class_name: "Collection",  :foreign_key => "owner_user_id"
+  has_many :random_document_sets, -> { unrestricted.sample }, 
+    class_name: "DocumentSet", :foreign_key => "owner_user_id"
+
+  scope :owners,         -> { where(owner: true) }
+  scope :trial_owners,   -> { owners.where(account_type: 'Trial') }
+  scope :paid_owners,    -> { owners.where('paid_date > ?', Time.now) }
+  scope :expired_owners, -> { owners.where('paid_date <= ?', Time.now) }
+
   validates :display_name, presence: true
   validates :login, presence: true, uniqueness: { case_sensitive: false }, format: { with: /\A[a-zA-Z0-9_\.]*\z/, message: "Invalid characters in username"}, exclusion: { in: %w(transcribe translate work collection deed), message: "Username is invalid"}
   validates :website, allow_blank: true, format: { with: URI.regexp }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,8 +57,8 @@ class User < ActiveRecord::Base
   scope :owners,           -> { where(owner: true) }
   scope :trial_owners,     -> { owners.where(account_type: 'Trial') }
   scope :non_trial_owners, -> { owners.where.not(account_type: [nil, 'Trial']) }
-  scope :paid_owners,      -> { owners.where('paid_date > ?', Time.now) }
-  scope :expired_owners,   -> { owners.where('paid_date <= ?', Time.now) }
+  scope :paid_owners,      -> { non_trial_owners.where('paid_date > ?', Time.now) }
+  scope :expired_owners,   -> { non_trial_owners.where('paid_date <= ?', Time.now) }
 
   validates :display_name, presence: true
   validates :login, presence: true, uniqueness: { case_sensitive: false }, format: { with: /\A[a-zA-Z0-9_\.]*\z/, message: "Invalid characters in username"}, exclusion: { in: %w(transcribe translate work collection deed), message: "Username is invalid"}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,9 +49,9 @@ class User < ActiveRecord::Base
   has_many :notes, -> { order 'created_at DESC' }
   has_many :deeds
 
-  has_many :random_collections,   -> { unrestricted.sample },
+  has_many :random_collections,   -> { unrestricted.has_intro_block.not_near_complete.not_empty.sample },
     class_name: "Collection",  :foreign_key => "owner_user_id"
-  has_many :random_document_sets, -> { unrestricted.sample }, 
+  has_many :random_document_sets, -> { unrestricted.has_intro_block.not_near_complete.not_empty.sample }, 
     class_name: "DocumentSet", :foreign_key => "owner_user_id"
 
   scope :owners,           -> { where(owner: true) }

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -4,7 +4,7 @@ class Work < ActiveRecord::Base
 
   has_many :pages, -> { order 'position' }, :dependent => :destroy
   belongs_to :owner, :class_name => 'User', :foreign_key => 'owner_user_id'
-  belongs_to :collection
+  belongs_to :collection, counter_cache: :works_count
   has_many :deeds, -> { order 'created_at DESC' }, :dependent => :destroy
   has_one :ia_work, :dependent => :destroy
   has_one :omeka_item, :dependent => :destroy
@@ -14,7 +14,9 @@ class Work < ActiveRecord::Base
   has_many :table_cells, :dependent => :destroy
 
   has_and_belongs_to_many :scribes, :class_name => 'User', :join_table => :transcribe_authorizations
-  has_and_belongs_to_many :document_sets
+  
+  has_many :document_set_works
+  has_many :document_sets, through: :document_set_works
 
   after_save :update_statistic
   after_destroy :cleanup_images

--- a/app/views/dashboard/landing_page.html.slim
+++ b/app/views/dashboard/landing_page.html.slim
@@ -7,7 +7,7 @@
 
     ul
       -@collections.each do |c|
-        -link_page = find_page(c)
+        -link_page = c.pages.includes(:work).needs_transcription.first
         -snippet = truncate(strip_tags(c.intro_block), length: 300, separator: ' ') || ''
         li
           =link_to(image_tag(c.picture_url, alt: c.title), collection_path(c.owner, c))
@@ -19,14 +19,17 @@
           br
           -unless link_page.blank?
             -if user_signed_in?
-              =link_to "Transcribe a page", collection_transcribe_page_path(link_page.work.collection.owner, link_page.work.collection, link_page.work, link_page), class: 'projects_link'
+              =link_to "Transcribe a page", collection_transcribe_page_path(c.owner, c, link_page.work, link_page), class: 'projects_link'
             -else
-              =link_to "Transcribe a page", collection_guest_page_path(link_page.work.collection.owner, link_page.work.collection, link_page.work, link_page), class: 'projects_link'
+              =link_to "Transcribe a page", collection_guest_page_path(c.owner, c, link_page.work, link_page), class: 'projects_link'
 
 .columns.project-list
   article.maincol
     -@owners.each do |owner|
-      -projects = owner_projects(owner)
+      -if params[:search]
+        -projects = @search_results.select{ |p| p.owner_user_id == owner.id}
+      -else
+        -projects = (owner.random_collections + owner.random_document_sets).sample(3)
       -unless projects.blank?
         .project-list_projects
           .projects-owner
@@ -44,7 +47,7 @@
                     =image_tag(project.picture_url(:thumb), alt: project.title)
                 .projects_collection
                   h5
-                    =link_to project.title, collection_path(project.owner, project)
+                    =link_to project.title, collection_path(owner, project)
                   -unless snippet.empty?
                     .projects_collection_snippet =snippet
             .projects_link =link_to "More...", user_profile_path(owner)

--- a/db/migrate/20190906201041_add_collection_and_document_set_counter_cache_cols.rb
+++ b/db/migrate/20190906201041_add_collection_and_document_set_counter_cache_cols.rb
@@ -1,0 +1,20 @@
+class AddCollectionAndDocumentSetCounterCacheCols < ActiveRecord::Migration
+  def up
+    add_column :collections, :works_count, :integer, default: 0
+    add_column :document_sets, :works_count, :integer, default: 0
+
+    puts "Setting Collection Work Counts..."
+    Collection.all.each do |c|
+      Collection.reset_counters c.id, :works
+    end
+
+    puts "Setting DocumentSet Work Counts..."
+    DocumentSet.all.each do |ds|
+      DocumentSet.reset_counters ds.id, :document_set_works
+    end
+  end
+  def down
+    remove_column :collections, :works_count, :integer
+    remove_column :document_sets, :works_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190713144825) do
+ActiveRecord::Schema.define(version: 20190906201041) do
 
   create_table "ahoy_events", force: true do |t|
     t.integer  "visit_id"
@@ -37,11 +37,11 @@ ActiveRecord::Schema.define(version: 20190713144825) do
 
   create_table "article_versions", force: true do |t|
     t.string   "title"
-    t.text     "source_text"
-    t.text     "xml_text"
+    t.text     "source_text", limit: 16777215
+    t.text     "xml_text",    limit: 16777215
     t.integer  "user_id"
     t.integer  "article_id"
-    t.integer  "version",     default: 0
+    t.integer  "version",                      default: 0
     t.datetime "created_on"
   end
 
@@ -50,14 +50,14 @@ ActiveRecord::Schema.define(version: 20190713144825) do
 
   create_table "articles", force: true do |t|
     t.string   "title"
-    t.text     "source_text"
+    t.text     "source_text",   limit: 16777215
     t.datetime "created_on"
-    t.integer  "lock_version",                          default: 0
-    t.text     "xml_text"
+    t.integer  "lock_version",                                           default: 0
+    t.text     "xml_text",      limit: 16777215
     t.string   "graph_image"
     t.integer  "collection_id"
-    t.decimal  "latitude",      precision: 7, scale: 5
-    t.decimal  "longitude",     precision: 8, scale: 5
+    t.decimal  "latitude",                       precision: 7, scale: 5
+    t.decimal  "longitude",                      precision: 8, scale: 5
     t.string   "uri"
   end
 
@@ -112,30 +112,44 @@ ActiveRecord::Schema.define(version: 20190713144825) do
     t.string   "title"
     t.integer  "owner_user_id"
     t.datetime "created_on"
-    t.text     "intro_block"
-    t.string   "footer_block",              limit: 2000
-    t.boolean  "restricted",                             default: false
+    t.text     "intro_block",               limit: 16777215
+    t.text     "footer_block",              limit: 16777215
+    t.boolean  "restricted",                                 default: false
     t.string   "picture"
-    t.boolean  "supports_document_sets",                 default: false
-    t.boolean  "subjects_disabled",                      default: false
+    t.boolean  "supports_document_sets",                     default: false
+    t.boolean  "subjects_disabled",                          default: false
     t.text     "transcription_conventions"
     t.string   "slug"
-    t.boolean  "review_workflow",                        default: false
-    t.boolean  "hide_completed",                         default: true
+    t.boolean  "review_workflow",                            default: false
+    t.boolean  "hide_completed",                             default: true
     t.text     "help"
     t.text     "link_help"
-    t.boolean  "field_based",                            default: false
-    t.boolean  "voice_recognition",                      default: false
+    t.boolean  "field_based",                                default: false
+    t.boolean  "voice_recognition",                          default: false
     t.string   "language"
-    t.string   "license_key"
     t.string   "text_language"
+    t.string   "license_key"
     t.integer  "pct_completed"
     t.string   "default_orientation"
-    t.boolean  "is_active",                              default: true
+    t.boolean  "is_active",                                  default: true
+    t.integer  "works_count",                                default: 0
   end
 
   add_index "collections", ["owner_user_id"], name: "index_collections_on_owner_user_id", using: :btree
   add_index "collections", ["slug"], name: "index_collections_on_slug", unique: true, using: :btree
+
+  create_table "comments", force: true do |t|
+    t.integer  "parent_id"
+    t.integer  "user_id"
+    t.datetime "created_at",                                               null: false
+    t.integer  "commentable_id",                    default: 0,            null: false
+    t.string   "commentable_type",                  default: "",           null: false
+    t.integer  "depth"
+    t.string   "title"
+    t.text     "body",             limit: 16777215
+    t.string   "comment_type",     limit: 10,       default: "annotation"
+    t.string   "comment_status",   limit: 10
+  end
 
   create_table "deeds", force: true do |t|
     t.string   "deed_type",        limit: 10
@@ -177,6 +191,7 @@ ActiveRecord::Schema.define(version: 20190713144825) do
     t.string   "slug"
     t.integer  "pct_completed"
     t.string   "default_orientation"
+    t.integer  "works_count",         default: 0
   end
 
   add_index "document_sets", ["collection_id"], name: "index_document_sets_on_collection_id", using: :btree
@@ -281,7 +296,7 @@ ActiveRecord::Schema.define(version: 20190713144825) do
 
   create_table "notes", force: true do |t|
     t.string   "title"
-    t.text     "body"
+    t.text     "body",          limit: 16777215
     t.integer  "user_id"
     t.integer  "collection_id"
     t.integer  "work_id"
@@ -387,7 +402,7 @@ ActiveRecord::Schema.define(version: 20190713144825) do
     t.string   "view"
     t.string   "tag"
     t.string   "description"
-    t.text     "html"
+    t.text     "html",        limit: 16777215
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -396,12 +411,12 @@ ActiveRecord::Schema.define(version: 20190713144825) do
 
   create_table "page_versions", force: true do |t|
     t.string   "title"
-    t.text     "transcription"
-    t.text     "xml_transcription"
+    t.text     "transcription",      limit: 16777215
+    t.text     "xml_transcription",  limit: 16777215
     t.integer  "user_id"
     t.integer  "page_id"
-    t.integer  "work_version",       default: 0
-    t.integer  "page_version",       default: 0
+    t.integer  "work_version",                        default: 0
+    t.integer  "page_version",                        default: 0
     t.datetime "created_on"
     t.text     "source_translation"
     t.text     "xml_translation"
@@ -412,7 +427,7 @@ ActiveRecord::Schema.define(version: 20190713144825) do
 
   create_table "pages", force: true do |t|
     t.string   "title"
-    t.text     "source_text"
+    t.text     "source_text",        limit: 16777215
     t.string   "base_image"
     t.integer  "base_width"
     t.integer  "base_height"
@@ -420,8 +435,8 @@ ActiveRecord::Schema.define(version: 20190713144825) do
     t.integer  "work_id"
     t.datetime "created_on"
     t.integer  "position"
-    t.integer  "lock_version",       default: 0
-    t.text     "xml_text"
+    t.integer  "lock_version",                        default: 0
+    t.text     "xml_text",           limit: 16777215
     t.integer  "page_version_id"
     t.string   "status"
     t.text     "source_translation"
@@ -441,6 +456,11 @@ ActiveRecord::Schema.define(version: 20190713144825) do
 
   add_index "pages_sections", ["page_id", "section_id"], name: "index_pages_sections_on_page_id_and_section_id", using: :btree
   add_index "pages_sections", ["section_id", "page_id"], name: "index_pages_sections_on_section_id_and_page_id", using: :btree
+
+  create_table "plugin_schema_info", id: false, force: true do |t|
+    t.string  "plugin_name"
+    t.integer "version"
+  end
 
   create_table "sc_canvases", force: true do |t|
     t.string   "sc_id"
@@ -500,8 +520,8 @@ ActiveRecord::Schema.define(version: 20190713144825) do
   add_index "sections", ["work_id"], name: "index_sections_on_work_id", using: :btree
 
   create_table "sessions", force: true do |t|
-    t.string   "session_id", null: false
-    t.text     "data"
+    t.string   "session_id",                  default: "", null: false
+    t.text     "data",       limit: 16777215
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -645,22 +665,22 @@ ActiveRecord::Schema.define(version: 20190713144825) do
 
   create_table "works", force: true do |t|
     t.string   "title"
-    t.string   "description",               limit: 4000
+    t.text     "description",               limit: 16777215
     t.datetime "created_on"
     t.integer  "owner_user_id"
-    t.boolean  "restrict_scribes",                       default: false
-    t.integer  "transcription_version",                  default: 0
-    t.text     "physical_description"
-    t.text     "document_history"
-    t.text     "permission_description"
+    t.boolean  "restrict_scribes",                           default: false
+    t.integer  "transcription_version",                      default: 0
+    t.text     "physical_description",      limit: 16777215
+    t.text     "document_history",          limit: 16777215
+    t.text     "permission_description",    limit: 16777215
     t.string   "location_of_composition"
     t.string   "author"
-    t.text     "transcription_conventions"
+    t.text     "transcription_conventions", limit: 16777215
     t.integer  "collection_id"
-    t.boolean  "scribes_can_edit_titles",                default: false
-    t.boolean  "supports_translation",                   default: false
+    t.boolean  "scribes_can_edit_titles",                    default: false
+    t.boolean  "supports_translation",                       default: false
     t.text     "translation_instructions"
-    t.boolean  "pages_are_meaningful",                   default: true
+    t.boolean  "pages_are_meaningful",                       default: true
     t.boolean  "ocr_correction"
     t.string   "slug"
     t.string   "picture"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,16 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     %x[bundle exec rake assets:precompile]
+    
+    puts "Setting Collection Work Counts..."
+    Collection.all.each do |c|
+      Collection.reset_counters c.id, :works
+    end
+
+    puts "Setting DocumentSet Work Counts..."
+    DocumentSet.all.each do |ds|
+      DocumentSet.reset_counters ds.id, :document_set_works
+    end
   end
 
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
Closes #1493 

This addresses the slow `dashboard#landingpage` (where the "Find A Project" button takes you as a guest performance.

# Performance

## Initial Measurements
This route had two major problems:
  1. Querying for the relevant collections and docsets used a couple `.map` operations which fired off N+1 queries.
  2. Collection rendering was also exhibiting N+1
**Results**: ~240 queries per page load, total time to render ~2.5 seconds

## Improved Measurements
The Collection/Docset rendering was slow do to the fact that we were not only *not* eager loading, but, when references to a particular Collection's `owner` were used (e.g., in `link_to`), they were accessed through the inverse relationship that they were queried from. In other words, when we are looping through `@users as |user| , then looping through `user.collections as |collection|`, we would reference `collection.owner` rather than just `user` and this was firing off N+1 queries.

I was able to remove the `map` function from the Carousel logic and reduced this to a single query.

I added a couple convenience scopes and relationships in order to allow us to eager load a small sample of collections and document sets for each user. This was a [technique I got from here](https://www.justinweiss.com/articles/how-to-preload-rails-scopes/) and it's pretty slick.

There **is** exactly ONE N+1 case here. The way we find a link to an untranscribed page in a collection currently requires us to make an extra query to the `works` table for every project in the carousel. However, there can not be more than 8 items in the carousel, so, N will never be greater than 8. It's easily solvable for the Collection's case if we were to store the `collection_id` on the page object.  For obvious reasons, however, the case for Docsets would not be so clean. There may be a way to do something similar to what I did with `random_collections` in the link (above), but I couldn't figure out a way to make it work `:through` a third relationship.

Anyway, I thought I could live with the extra 8 queries; especially since I had removed nearly 200.
 
**Addendum**
In order to prevent further N+1s, we had to add `counter_caches` to `Collection`s and `DocumentSet`s; this meant that I had to make some small changes to the database (added columns) and to explicitly define the `has_and_belongs_to_many` relationship between `DocumentSet`s and `Work`s. That's why there's the new `DocumentSetWork` model.

**Results:** ~20-40 queries (I haven't figured out what causes this variance), total time to render ~500ms

# Behavior

## Former Behaviour (Non-search)
Two instance variables (`@owners` and `@collections`) are passed to the view.
  1. `@owners` is a list of distinct "true" owners (i.e., those listed in `owner_user_id`, rather than the many-to-many `owners`) who have *public` collections.
  2. `@collections` is actually the collection of `Collection`s (notably, not `DocumentSet`s!) for the Carousel. It maps over the `@owners` and selects the first `Collection`s that matches the `.carousel` scope (below) which is "truly" owned by the `|owner|`. It then `.compacts` and `.sample`s that result to get 8 "random" `Collection`s
  3. The `.carousel` scope is defined thusly:
```
    .where(pct_completed: [nil, 1..90])
    .where.not(picture: nil)
    .where.not(intro_block: [nil, ''])
    .where(restricted: false)
    .reorder("RAND()")}
```
I read this as a randomly sorted list of **public** `Collection`s  that **have a picture** and a **non-empty `intro_block`** and are either **empty** (though, no 0 pct?) or **up-to 90% complete**.

**But, it gets worse...**
The view uses two helper methods in the `dashboard_helper` to generate the "Start Transcribing" links and also to call out to for which `Collection`s and `DocumentSet`s to display.
  1. We've already talked about fixing the `start_transcribing` links, that'll be taken care of in the PR for #1428 (So, we'll ignore this one for now).
  2. The `dashboard_helper#owner_projects` method is the culprit here. It accepts an `owner` and returns a randomly sampled set of 3 **public** `Collection`s and `DocumentSet`s that are "truly" owned by the `owner` that are less than 90% complete, that have an `intro_block`, and also aren't empty (i.e., they have `Work`s).

The view itself will only display an `owner` if the `owner` actually has some `Collection`s or `DocumentSet`s to display.

## Problems:
1. It seems like we should be including collections/docsets that the current user is authorized to work on (either as a scribe or as an owner) as well as public ones
2. The Carousel should probably be `Collection`s and `DocumentSet`s.

Otherwise, I think the functionality is fine.