### PR TITLE
layout: fix footer text alignment

### DIFF
--- a/app/assets/stylesheets/components/layout.scss
+++ b/app/assets/stylesheets/components/layout.scss
@@ -64,6 +64,10 @@
   padding: 0;
 }
 
+.footer_nav {
+  text-align: left;
+}
+
 .footer_nav li {
   margin-right: 0.4em;
   display: inline;


### PR DESCRIPTION
When browsing the site from a mobile phone, the text inside .footer_nav
will look centered and out of place compared to when browsing from a
computer with a larger screen.

Set text-align: left on .footer_nav to fix this issue.

This improves on #1457.