### PR TITLE
Mark blank redirect to transcribe view

### DIFF
--- a/app/controllers/transcribe_controller.rb
+++ b/app/controllers/transcribe_controller.rb
@@ -48,13 +48,13 @@ class TranscribeController  < ApplicationController
       @page.save
       record_deed(DeedType::PAGE_MARKED_BLANK)
       @work.work_statistic.recalculate({type: 'blank'}) if @work.work_statistic
-      redirect_to collection_display_page_path(@collection.owner, @collection, @page.work, @page.id) and return
+      redirect_to collection_transcribe_page_path(@collection.owner, @collection, @page.work, @page.id) and return
     elsif @page.status == Page::STATUS_BLANK && params[:page]['mark_blank'] == '0'
       @page.status = nil
       @page.translation_status = nil
       @page.save
       @work.work_statistic.recalculate({type: 'blank'}) if @work.work_statistic
-      redirect_to collection_display_page_path(@collection.owner, @collection, @page.work, @page.id) and return
+      redirect_to collection_transcribe_page_path(@collection.owner, @collection, @page.work, @page.id) and return
     else
       return true
     end

--- a/app/controllers/transcribe_controller.rb
+++ b/app/controllers/transcribe_controller.rb
@@ -41,20 +41,31 @@ class TranscribeController  < ApplicationController
   def guest
   end
 
-  def mark_page_blank
+  def mark_page_blank(options = { redirect: 'display' })
+    redirect_path = case options[:redirect]
+      when 'transcribe'
+        collection_transcribe_page_path(@collection.owner, @collection, @page.work, @page.id)
+      else
+        collection_display_page_path(@collection.owner, @collection, @page.work, @page.id)
+      end
+
     if params[:page]['mark_blank'] == '1'
       @page.status = Page::STATUS_BLANK
       @page.translation_status = Page::STATUS_BLANK
       @page.save
       record_deed(DeedType::PAGE_MARKED_BLANK)
       @work.work_statistic.recalculate({type: 'blank'}) if @work.work_statistic
-      redirect_to collection_transcribe_page_path(@collection.owner, @collection, @page.work, @page.id) and return
+      flash[:notice] = "Saved"
+      redirect_to redirect_path 
+      return false
     elsif @page.status == Page::STATUS_BLANK && params[:page]['mark_blank'] == '0'
       @page.status = nil
       @page.translation_status = nil
       @page.save
       @work.work_statistic.recalculate({type: 'blank'}) if @work.work_statistic
-      redirect_to collection_transcribe_page_path(@collection.owner, @collection, @page.work, @page.id) and return
+      flash[:notice] = "Saved"
+      redirect_to redirect_path
+      return false
     else
       return true
     end
@@ -100,7 +111,7 @@ class TranscribeController  < ApplicationController
     @page.attributes = params[:page]
     #if page has been marked blank, call the mark_blank code 
     unless params[:page]['needs_review'] == '1'
-      mark_page_blank or return
+      mark_page_blank(redirect: 'transcribe') or return
     end
     #check to see if the page needs to be marked as needing review
     needs_review

--- a/spec/features/editor_actions_spec.rb
+++ b/spec/features/editor_actions_spec.rb
@@ -25,8 +25,6 @@ describe "editor actions" , :order => :defined do
       page.find('.tabs').click_link("Transcribe")
       page.find('#page_mark_blank').set(true)
       page.find('#save_button_top').click
-
-      page.find('.tabs').click_link("Transcribe")
       expect(page).to have_checked_field('page_mark_blank')
     end
     it "resets page status to nil if empty and not marked BLANK" do

--- a/spec/features/needs_review_spec.rb
+++ b/spec/features/needs_review_spec.rb
@@ -39,14 +39,14 @@ describe "needs review", :order => :defined do
     page.find('.work-page_title', text: @page1.title).click_link(@page1.title)
     page.check('page_mark_blank')
     find('#save_button_top').click
-    expect(page).to have_content("This page is blank")
+    expect(page).to have_content("This page is marked blank")
     expect(Page.find_by(id: @page1.id).status).to eq ('blank')
     expect(Page.find_by(id: @page1.id).translation_status).to eq ('blank')
     page.find('.page-nav_next').click
+    page.find('.tabs').click_link("Overview")
     expect(page).to have_content(@page2.title)
     expect(page).to have_content("This page is not transcribed")
     page.find('a', text: 'mark the page blank').click
-    expect(page).to have_content("This page is blank")
     expect(page).to have_content("This page is blank")
     expect(Page.find_by(id: @page2.id).status).to eq ('blank')
     expect(Page.find_by(id: @page2.id).translation_status).to eq ('blank')


### PR DESCRIPTION
Closes #1507 
~~A two-liner. We were just redirecting to the wrong route.~~

True to form, this is actually more complex than we thought.

We allow users to "mark page blank" from the reading view, which means we need to redirect to either the reading view or the transcribe view depending on where the user came from.

I've added an option with a default value to the `mark_page_blank` method that conditional sets the redirect path. All the early return stuff in the `save_transcription` and related methods made me uneasy about doing much refactoring.