### PR TITLE
collection: display name

### DIFF
--- a/app/views/collection/edit.html.slim
+++ b/app/views/collection/edit.html.slim
@@ -126,7 +126,7 @@
           .userpic
             =gravatar_image_tag user.email, :alt => user.display_name
           .username
-            =link_to user.name_with_identifier, user_profile_path(user)
+            =link_to user.display_name, user_profile_path(user)
             small =pluralize(contributions, 'contribution')
           -if user != @main_owner
             =link_to 'Remove', { :action => 'remove_collaborator', :user_id => user.id, :collection_id => @collection.id }, class: 'remove', title: 'Remove', 'aria-label' => 'Remove collaborator'

--- a/app/views/collection/edit.html.slim
+++ b/app/views/collection/edit.html.slim
@@ -144,7 +144,7 @@
         .userpic
           =gravatar_image_tag user.email, :alt => user.display_name
         .username
-          =link_to user.name_with_identifier, user_profile_path(user)
+          =link_to user.display_name, user_profile_path(user)
           small =pluralize(contributions, 'contribution')
         -if user != @main_owner
           =link_to '', { :action => 'remove_owner', :user_id => user.id, :collection_id => @collection.id }, class: 'remove', title: 'Remove', 'aria-label' => 'Remove owner'

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -132,8 +132,8 @@ describe "collection settings js tasks", :order => :defined do
     login_as(@owner, :scope => :user)
     visit collection_path(@collection.owner, @collection)
     page.find('.tabs').click_link("Settings")
-    page.find('.user-label', text: @rest_user.name_with_identifier).find('a.remove').click
-    page.find('.user-label', text: @notify_user.name_with_identifier).find('a.remove').click
+    page.find('.user-label', text: @rest_user.display_name).find('a.remove').click
+    page.find('.user-label', text: @notify_user.display_name).find('a.remove').click
     expect(page).not_to have_selector('.user-label', text: @rest_user.name_with_identifier)
   end
 

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -83,8 +83,8 @@ describe "collection settings js tasks", :order => :defined do
     login_as(@owner, :scope => :user)
     visit collection_path(@collection.owner, @collection)
     page.find('.tabs').click_link("Settings")
-    page.find('.user-label', text: @rest_user.name_with_identifier).find('a.remove').click
-    page.find('.user-label', text: @notify_user.name_with_identifier).find('a.remove').click
+    page.find('.user-label', text: @rest_user.display_name).find('a.remove').click
+    page.find('.user-label', text: @notify_user.display_name).find('a.remove').click
     expect(page).not_to have_selector('.user-label', text: @rest_user.name_with_identifier)
   end
 


### PR DESCRIPTION
rather than "display_name - email", otherwise the layout breaks.

Fixes: #1544.