### PR TITLE
Home page fixes

### DIFF
--- a/app/assets/stylesheets/sections/home.scss
+++ b/app/assets/stylesheets/sections/home.scss
@@ -19,31 +19,18 @@ a.button.big.learn-more {
   background: $footerBg image-url('static/home/header.jpg') no-repeat center bottom;
   background-size: cover;
   .wrapper {
-    position: relative;
+    display: flex;
+    padding: 0 20px;
     min-height: 517px;
-    padding: 0;
-
-    &:after {
-      width: 0;
-      content: '';
-      height: 100%;
-      display: inline-block;
-      vertical-align: middle;
-    }
+    align-items: center;
+    justify-content: center;
   }
   &_box {
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
     color: #FFF;
+    padding: 60px;
     text-align: left;
     max-width: $widthMax;
-    line-height: normal;
-    display: inline-block;
-    vertical-align: middle;
     background: rgba(#100, 0.6);
-    margin: 0 auto;
-    padding: 60px;
 
     &_title {
       margin: 0;
@@ -59,6 +46,7 @@ a.button.big.learn-more {
     &_text {
       font-size: 125%;
       max-width: 600px;
+      line-height: normal;
       margin: 0.5em 0 0 0;
     }
     a.learn-more {
@@ -74,10 +62,7 @@ a.button.big.learn-more {
     .wrapper { height: 400px; }
   }
   @media screen and (max-width: $widthMin) {
-    .wrapper {
-      height: 350px;
-      text-align: center;
-    }
+    .wrapper { height: 350px; }
   }
 }
 

--- a/app/assets/stylesheets/sections/home.scss
+++ b/app/assets/stylesheets/sections/home.scss
@@ -127,15 +127,20 @@ a.button.big.learn-more {
   }
 }
 
-#quotes {
+.quotes {
   padding-top: 55px;
-  ol {
+
+  &_list {
+    margin: 0;
+    padding: 0;
+    display: flex;
     list-style: none;
+    justify-content: space-between;
   }
-  .justified_box {
-    width: 30%;
-    position: relative;
-    box-sizing: border-box;
+  &_list_item {
+    flex: 0 1 31%;
+    display: flex;
+    flex-direction: column;
     padding: 0 0 $gapSize 0;
   }
   h2 {
@@ -145,8 +150,9 @@ a.button.big.learn-more {
   }
   blockquote {
     margin: 0;
+    display: flex;
+    flex: 1 1 auto;
     p {
-      min-height: 130px;
       color: $bodyFg;
       margin: 0 0 20px 0;
       padding: $gapSize;
@@ -168,9 +174,10 @@ a.button.big.learn-more {
   }
   cite {
     line-height: 2;
+    margin-top: 5px;
+    min-height: 48px;
     font-style: normal;
     color: $bodyFgFaded;
-    margin-top: $gapSize;
     display: inline-block;
     small {
       display: block;

--- a/app/assets/stylesheets/sections/home.scss
+++ b/app/assets/stylesheets/sections/home.scss
@@ -71,8 +71,11 @@ a.button.big.learn-more {
   padding: 10px 0 40px 0;
 
   h2 {
+    margin: 0 auto;
+    max-width: 800px;
     font-size: 24px;
     color: $bodyFgDark;
+    line-height: normal;
   }
 }
 

--- a/app/assets/stylesheets/sections/home.scss
+++ b/app/assets/stylesheets/sections/home.scss
@@ -82,10 +82,15 @@ a.button.big.learn-more {
 .advantages {
   @include highlightBox;
 
-  .justified_box {
-    width: 30%;
-    position: relative;
-    box-sizing: border-box;
+  &_list {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    list-style: none;
+    justify-content: space-between;
+  }
+  &_list_item {
+    flex: 0 1 31%;
     padding: 0 0 $gapSize 0;
   }
   &_title {
@@ -97,15 +102,16 @@ a.button.big.learn-more {
   &_text {
     margin: 0.5em 0;
     color: $bodyFg;
+    line-height: 1.3;
+    min-height: 5.2em;
     font-size: $fontSizeStrong;
   }
   ul {
-    list-style: none;
+    list-style-type: disc;
     font-size: $fontSizeBig;
-    margin-top: 24px;
-    margin-left: 0;
+    margin: 15px 0 0 1em;
     li {
-      padding-top: 10px;
+      margin-top: 5px;
     }
   }
   .start {

--- a/app/views/static/splash.html.slim
+++ b/app/views/static/splash.html.slim
@@ -70,7 +70,7 @@ section.quotes
     =link_to 'Learn More', about_path, class: 'button big learn-more'
 
 section#transcription_count
-  span#count #{Page.where.not(:status=>nil).count}
+  span#count #{number_with_delimiter Page.where.not(:status=>nil).count}
   p Pages Transcribed with FromThePage
 
 section.spotlight

--- a/app/views/static/splash.html.slim
+++ b/app/views/static/splash.html.slim
@@ -45,22 +45,22 @@ section.advantages
     h4 Start transcribing your documents.
     =link_to 'Learn More', about_path, class: 'button big learn-more'
 
-section#quotes
+section.quotes
   h2 What FromThePage Users Are Saying
-  ol.justified.vtop
-    li.justified_box
+  ol.quotes_list
+    li.quotes_list_item
       blockquote
         p The interface is flexible. The images are easy to manipulate, the transcription pane is very easy to use. […] It is extremely easy to deploy—I got my project up and running in about an hour.
       cite
         span Sue Perdue
         small Documentary Editor
-    li.justified_box
+    li.quotes_list_item
       blockquote
         p I love that the site works for a public library as well as an academic and we benefit from working alongside different institutions on a digital platform…
-      cite.advantages_quote_cite
+      cite
         span Victoria Duncan
         small Indianapolis Public Library
-    li.justified_box
+    li.quotes_list_item
       blockquote
         p We’re especially impressed with how FromThePage has recently extended IIIF support to include links to all relevant export formats at both the document and work level.
       cite

--- a/app/views/static/splash.html.slim
+++ b/app/views/static/splash.html.slim
@@ -14,8 +14,8 @@ section#description
   h2 Use FromThePage for everything from simple, plain-text transcription projects to bilingual digital scholarly editions with annotations.
 
 section.advantages
-  ol.justified.vtop
-    li.justified_box
+  ol.advantages_list
+    li.advantages_list_item
       h2.advantages_title Transcribe
       p.advantages_text Transcribe documents from anywhere – upload PDFs and pictures, or directly import documents from a digital library.
       ul
@@ -25,14 +25,14 @@ section.advantages
         li Indexing
         li Translation
         li Multiple export formats (TEI, CSV, HTML, IIIF/Open Annotation)
-    li.justified_box
+    li.advantages_list_item
       h2.advantages_title Collaborate
       p.advantages_text Make your transcription project public or select authorized collaborators.
       ul
         li Version control
         li Automatic markup
         li In-document collaborator notes
-    li.justified_box
+    li.advantages_list_item
       h2.advantages_title Manage
       p.advantages_text Review the progress of your transcription project and the most recent activity in the transcriber community at a glance.
       ul

--- a/config/initializers/slim.rb
+++ b/config/initializers/slim.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Prettify html source for development only
-Slim::Engine.set_options pretty: Rails.env.development?, sort_attrs: false, tabsize: 2, format: :html
+# Slim::Engine.set_options pretty: Rails.env.development?, sort_attrs: false, tabsize: 2, format: :html


### PR DESCRIPTION
I've noticed a few bugs on the home page, this PR fixes them.

1. Fixed broken intro box layout on a tablet:
![FromThePage1 17 14 06](https://user-images.githubusercontent.com/4656448/69996281-284c6280-156b-11ea-925d-a9cc1ea1af0c.png)

2. Fixed layout of the Advantages and Feedbacks sections:
![FromThePage2 17 14 07](https://user-images.githubusercontent.com/4656448/69996340-49ad4e80-156b-11ea-885d-c615b851d2ad.png)

3. The above bug was appearing only in production (in development it was ok) and it was caused by minification of the html in production. So I've turned the minification (or, to be exact, turned off pretty html formatting) in development mode to find out similar issues (if any) during development.

4. Added number formatting for the Pages Transcribed:
![FromThePage3](https://user-images.githubusercontent.com/4656448/69996912-76ae3100-156c-11ea-8754-df125c737279.png)
