### PR TITLE
Decouple Intercom further for master branch

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -271,7 +271,7 @@ class Work < ActiveRecord::Base
   end
 
   def alert_intercom
-    if INTERCOM_ACCESS_TOKEN
+    if (defined? INTERCOM_ACCESS_TOKEN) && INTERCOM_ACCESS_TOKEN
       if self.owner.owner_works.count == 1
         intercom=Intercom::Client.new(token:INTERCOM_ACCESS_TOKEN)
         intercom.events.create(event_name: "first-upload", email: User.current_user.email, created_at: Time.now.to_i)

--- a/app/views/dashboard/owner.html.slim
+++ b/app/views/dashboard/owner.html.slim
@@ -51,4 +51,5 @@
     h3 Your Activity
     =deeds_for({ :user_id => current_user.id, :limit => 10 })
 
-=render partial: 'shared/intercom'
+-if (defined? INTERCOM_APP_ID) && !INTERCOM_APP_ID.blank?
+  =render partial: 'shared/intercom'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -104,10 +104,11 @@ html lang="en-US"
     =javascript_include_tag 'application'
     =yield :javascript
 
-    -if user_signed_in? && current_user.owner?
-      =render :partial => '/shared/intercom_customer'
-    -elsif controller_name=='static'
-      =render :partial => '/shared/intercom'
+    -if defined? INTERCOM_APP_ID
+      -if user_signed_in? && current_user.owner? && !INTERCOM_APP_ID.blank?
+        =render :partial => '/shared/intercom_customer'
+      -elsif controller_name=='static' && !INTERCOM_APP_ID.blank?
+        =render :partial => '/shared/intercom'
 
     -unless GA_ACCOUNT.blank?
       =render :partial => '/layouts/ga'


### PR DESCRIPTION
This allows sites to not have defined the intercom tokens in their 01fromthepage initializer.