### PR TITLE
Keep crawlers from launching full-text searches

### DIFF
--- a/app/views/article/show.html.slim
+++ b/app/views/article/show.html.slim
@@ -60,8 +60,8 @@
 
     h3 References
     ul.article-category-list
-      li =link_to "All references to #{@article.title}", { :controller => 'display', :action => 'search', :article_id => @article.id }
-      li =link_to "All references to #{@article.title} in pages that do not link to this subject", :controller => 'display', :action => 'search', :article_id => @article.id, :unlinked_only => true
+      li =link_to "All references to #{@article.title}", { :controller => 'display', :action => 'search', :article_id => @article.id }, { :rel => 'nofolllow' }
+      li =link_to "All references to #{@article.title} in pages that do not link to this subject", { :controller => 'display', :action => 'search', :article_id => @article.id, :unlinked_only => true}, { :rel => 'nofolllow' }
     br
     =render :partial => 'article_links'
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,5 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 #
 # To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+User-agent: *
+Disallow: /display/search


### PR DESCRIPTION
This both adds `rel="nofollow"` to the problem links and modifies `robots.txt` to ban the URLs entirely.