### PR TITLE
Update article_category route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,7 +98,7 @@ Fromthepage::Application.routes.draw do
     get 'delete', to: 'article#delete'
     get 'show', to: 'article#show'
     get 'combine_duplicate', to: 'article#combine_duplicate'
-    put 'article_category', :to => 'article#article_category'
+    post 'article_category', :to => 'article#article_category'
   end
 
   scope 'export', as: 'export' do


### PR DESCRIPTION
This fixes an issue I was running into running on the rails6 branch. I'm not sure if it is the correct fix but it works as far as I can tell. Previous to this fix, adding a category to a subject would fail with: ActionController::RoutingError (No route matches [POST] "/article/article_category"):