### PR TITLE
Expand scope of update_next_untranscribed_pages

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -33,7 +33,7 @@ class Page < ApplicationRecord
   after_save :update_sections_and_tables
   after_save :update_tex_figures
   after_save do
-    work.update_next_untranscribed_pages if self == work.next_untranscribed_page
+    work.update_next_untranscribed_pages if self == work.next_untranscribed_page or work.next_untranscribed_page.nil?
   end
 
   after_initialize :defaults


### PR DESCRIPTION
If a work becomes completely transcribed but then later a page within that
work becomes untranscribed, `next_untranscribed_page` never gets updated.
This causes the work to be missing from some views where works with
untranscribed pages are listed.

This change causes `update_next_untranscribed_pages` to also be run if
`next_untranscribed_page` is currently `nil`. This was tested by completing a
work, subsequently deleting a transcription for a page, saving, then
verifying in the database that the column went from null to the correct
id.