### PR TITLE
Update user_params filter to use real_name

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -232,6 +232,6 @@ class AdminController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:display_name, :real_name, :login, :email, :account_type, :start_date, :paid_date, :user, :owner)
+    params.require(:user).permit(:real_name, :login, :email, :account_type, :start_date, :paid_date, :user, :owner)
   end
 end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -98,7 +98,7 @@ class UserController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:display_name, :orcid, :slug, :website, :location, :about, notifications: [:user_activity, :owner_stats, :add_as_collaborator, :add_as_owner, :note_added])
+    params.require(:user).permit(:real_name, :orcid, :slug, :website, :location, :about, notifications: [:user_activity, :owner_stats, :add_as_collaborator, :add_as_owner, :note_added])
   end
 
 end

--- a/app/views/admin/edit_user.html.slim
+++ b/app/views/admin/edit_user.html.slim
@@ -5,11 +5,8 @@
     =validation_summary @user.errors
     table.form
       tr.big
-        th =f.label :display_name
-        td.w100 =f.text_field :display_name
-      tr
         th =f.label :real_name
-        td =f.text_field :real_name
+        td.w100 =f.text_field :real_name
       tr
         th =f.label :login, 'User login'
         td =f.text_field :login


### PR DESCRIPTION
This fixes a bug where neither users nor admins could update the real name
of a user profile. The `user_params` permit list had `:display_name`, however,
per the model that is an auto-generated field and `:real_name` is the one
used in the form.

This has been tested and verified to work correctly now.