### PR TITLE
Remove display_name from admin edit_user form

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -65,7 +65,7 @@ class AdminController < ApplicationController
 
   def update_user
     owner = @user.owner
-    if @user.update_attributes(params[:user])
+    if @user.update(user_params)
       if owner == false && @user.owner == true
         if SMTP_ENABLED
           begin
@@ -224,4 +224,9 @@ class AdminController < ApplicationController
 
   end
 
+  private
+
+  def user_params
+    params.require(:user).permit(:real_name, :login, :email, :account_type, :start_date, :paid_date, :user, :owner)
+  end
 end

--- a/app/views/admin/edit_user.html.slim
+++ b/app/views/admin/edit_user.html.slim
@@ -5,11 +5,8 @@
     =validation_summary @user.errors
     table.form
       tr.big
-        th =f.label :display_name
-        td.w100 =f.text_field :display_name
-      tr
         th =f.label :real_name
-        td =f.text_field :real_name
+        td.w100 =f.text_field :real_name
       tr
         th =f.label :login, 'User login'
         td =f.text_field :login


### PR DESCRIPTION
The display_name field is intended to be auto generated and leads to
unexpected behavior for the user when it is modified. This removes the
display_name form field from the edit_user form and the user_params permit
list. This also adjusts the real_name form field to have the top-of-form
styling that display_name previously had.

Signed-off-by: Jacob Creedon <jcreedon@gmail.com>