### PR TITLE
Orphan notes explode on display of (missing) page title

### DIFF
--- a/app/views/user/profile.html.slim
+++ b/app/views/user/profile.html.slim
@@ -36,11 +36,12 @@
         th.w25 =t('.page')
         th.w75 =t('.note')
       -@notes.includes(:page).each do |note|
-        -note_text = truncate(strip_tags(note.body), :length => 200)
-        tr
-          td.nowrap =note.created_at.localtime.strftime("%b %d, %Y, %l:%M %p")
-          td.overflow =link_to note.page.title, collection_display_page_path(note.page.collection.owner, note.page.collection, note.page.work, note.page)
-          td =link_to note_text, collection_display_page_path(note.page.collection.owner, note.page.collection, note.page.work, note.page, anchor: "note-#{note.id}")
+        -if note.page
+          -note_text = truncate(strip_tags(note.body), :length => 200)
+          tr
+            td.nowrap =note.created_at.localtime.strftime("%b %d, %Y, %l:%M %p")
+            td.overflow =link_to note.page.title, collection_display_page_path(note.page.collection.owner, note.page.collection, note.page.work, note.page)
+            td =link_to note_text, collection_display_page_path(note.page.collection.owner, note.page.collection, note.page.work, note.page, anchor: "note-#{note.id}")
 
     br
 


### PR DESCRIPTION
For some reason, some notes are not being deleted with the pages they are on are deleted.  (This seems rare, and may only happen when an individual page is deleted from a work; the example problem showed a note on a missing page, but with an existing work and collection, so the work had not been deleted.)

When we try to display a user's activity and their recent notes, the profile display was blowing up because of a nil page.

Closes #1898 