### PR TITLE
Fixes #1911 and Fixes #1913 by permitting params

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -93,6 +93,11 @@ class RegistrationsController < Devise::RegistrationsController
 
   private
 
+  def sign_up_params
+    params.require(:user).permit(:login, :real_name, :owner, :activity_email, :paid_date, :display_name, :email, :password, :password_confirmation)
+  end
+
+
   def joined_from_collection(visit_id)
     first_event = Ahoy::Event.where(visit_id: visit_id).first
     collection = first_event.properties["collection_id"] || nil

--- a/app/controllers/transcribe_controller.rb
+++ b/app/controllers/transcribe_controller.rb
@@ -476,6 +476,6 @@ protected
   private
 
   def page_params
-    params.require(:page).permit(:source_text, :source_translation)
+    params.require(:page).permit(:source_text, :source_translation, :title)
   end
 end

--- a/app/controllers/work_controller.rb
+++ b/app/controllers/work_controller.rb
@@ -248,6 +248,24 @@ class WorkController < ApplicationController
   private
 
   def work_params
-    params.require(:work).permit(:title, :description, :collection_id, :supports_translation, :slug, :ocr_correction, :transcription_conventions)
+    params.require(:work).permit(
+      :title, 
+      :description, 
+      :collection_id, 
+      :supports_translation, 
+      :slug, 
+      :ocr_correction, 
+      :transcription_conventions,
+      :author, 
+      :location_of_composition, 
+      :identifier, 
+      :pages_are_meaningful, 
+      :physical_description, 
+      :document_history, 
+      :permission_description, 
+      :translation_instructions,
+      :scribes_can_edit_titles, 
+      :restrict_scribes,
+      :picture)
   end
 end


### PR DESCRIPTION
Several controllers did not have permitted parameter statements.

This affected
saving page titles
saving most work settings
adding a name to a new user on the registration form

This fixes #1911 and fixes #1913 as well as the registration form problem.