### PR TITLE
Replace non-XML 1.0 characters with space

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,7 @@ script:
 
 branches:
   only:
+    - main
     - master
-    - ui-design
     - development
     - fromthepage.com
-    - indianapolis
-    - rails6

--- a/app/models/xml_source_processor.rb
+++ b/app/models/xml_source_processor.rb
@@ -323,6 +323,7 @@ module XmlSourceProcessor
     source = source || ""
     safe = source.gsub /\&/, '&amp;'
     safe.gsub! /\&amp;amp;/, '&amp;'
+    safe.gsub! /[^\u0009\u000A\u000D\u0020-\uD7FF\uE000-\uFFFD\u10000-\u10FFFF]/, ' '
 
     string = <<EOF
     <?xml version="1.0" encoding="UTF-8"?>

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -177,7 +177,7 @@ describe "collection settings js tasks", :order => :defined do
 
     it "transcribing doesn't work for inactive collections" do
       visit collection_display_page_path(@collection.owner, @collection, @page.work, @page.id)
-      expect(page).not_to have_link('Transcribe')
+      #expect(page).not_to have_link('Transcribe') #for FromThePage there is a "Sign Up to Transcribe" link
     end
 
     it "toggles collection active" do

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -177,7 +177,7 @@ describe "collection settings js tasks", :order => :defined do
 
     it "transcribing doesn't work for inactive collections" do
       visit collection_display_page_path(@collection.owner, @collection, @page.work, @page.id)
-      #expect(page).not_to have_link('Transcribe') #for FromThePage there is a "Sign Up to Transcribe" link
+      expect(page).not_to have_link('Transcribe')
     end
 
     it "toggles collection active" do

--- a/spec/models/xml_source_processor_spec.rb
+++ b/spec/models/xml_source_processor_spec.rb
@@ -15,7 +15,7 @@ EXPECTED_XML_DISABLED = <<EOF
       </page>
 EOF
 
-SOURCE_TEXT_ILLEGAL_CHARS = "\fWith a lo\vad of illegal \u0002 charac\u0001ters and a tab\t"
+SOURCE_TEXT_ILLEGAL_CHARS = "\fWith a lo\vad of illegal \u000C charac\u0014ters and a tab\t"
 EXPECTED_XML_ILLEGAL_CHARS = <<EOF
 <?xml version='1.0' encoding='UTF-8'?>    
       <page>

--- a/spec/models/xml_source_processor_spec.rb
+++ b/spec/models/xml_source_processor_spec.rb
@@ -15,6 +15,14 @@ EXPECTED_XML_DISABLED = <<EOF
       </page>
 EOF
 
+SOURCE_TEXT_ILLEGAL_CHARS = "\fWith a lo\vad of illegal \u0002 charac\u0001ters and a tab\t"
+EXPECTED_XML_ILLEGAL_CHARS = <<EOF
+<?xml version='1.0' encoding='UTF-8'?>    
+      <page>
+        <p> With a lo ad of illegal   charac ters and a tab\t</p>
+      </page>
+EOF
+
 RSpec.describe XmlSourceProcessor, type: :model do
   describe '#wiki_to_xml' do
   
@@ -45,6 +53,17 @@ RSpec.describe XmlSourceProcessor, type: :model do
         expect(Article.all.count).to eq(0)
         expect(PageArticleLink.all.count).to eq(0)
       end
+    end
+  end
+  describe '#valid_xml_from_source' do
+    let(:collection){ build_stubbed(:collection ) }
+    let(:work)      { build_stubbed(:work, collection: collection) }
+    let(:page)      { build_stubbed(:page, work: work, source_text: SOURCE_TEXT_ILLEGAL_CHARS)}
+
+    it 'builds the xml document' do
+      expect(work.collection).to eq(collection)
+      xml = page.wiki_to_xml(page, Page::TEXT_TYPE::TRANSCRIPTION)
+      expect(xml).to eq(EXPECTED_XML_ILLEGAL_CHARS)
     end
   end
   describe '#rename_article_links' do


### PR DESCRIPTION
This fixes #1875 (and potential other bugs caused by illegal characters) by replacing characters that are outside the [valid range for XML 1.0](https://www.w3.org/TR/xml/#charsets) with a space. I chose to replace with space rather than remove because someone might use some characters as spacing – and it could signal that there used to be an invisible character where there are unexpected spaces.

I ran a simple test to see that form feeds are replaced, as well as `NULL` characters, using:

```ruby
puts "blabla\fdljlkdf\tcheck\0".gsub! /[^\u0009\u000A\u000D\u0020-\uD7FF\uE000-\uFFFD\u10000-\u10FFFF]/, 'REPLACED'
#=> "blablaREPLACEDdljlkdf   checkREPLACED"
```

I didn't dare to touch the test spec `spec/models/xml_source_processor_spec.rb`, as I don't really know how to run it, though that is where I would add a new source string and expected XML return string.
However, in our production environment, I did add a similar line:

```ruby
safe.gsub! /\f/, ''
```

and the user who ran into the issue reported that the errors dissappeared. This line of course doesn't check for other illegal characters.