### PR TITLE
Fixes #2000 by escaping parentheses in regular expressions

### DIFF
--- a/app/controllers/abstract_xml_controller.rb
+++ b/app/controllers/abstract_xml_controller.rb
@@ -31,7 +31,7 @@ module AbstractXmlController
     matches.reverse!
     #for each article, check text to see if it needs to be linked
     for match in matches
-      match_regex = Regexp.new('\b'+match['display_text'].gsub('?', '\?').gsub('.', '\.')+'\b', Regexp::IGNORECASE)
+      match_regex = Regexp.new('\b'+match['display_text'].gsub('?', '\?').gsub('.', '\.').gsub('(', '\(').gsub(')', '\)')+'\b', Regexp::IGNORECASE)
       display_text = match['display_text']
       logger.debug("DEBUG looking for #{match_regex}")
 


### PR DESCRIPTION
If a collection had indexed a subject with a verbatim text that contains a single parenthesis, the autolink conversion to a regular expression exploded due to unbalanced parentheses.

