### PR TITLE
Resolves #1687 by displaying previously imported collection for manifests

### DIFF
--- a/app/controllers/sc_collections_controller.rb
+++ b/app/controllers/sc_collections_controller.rb
@@ -39,8 +39,8 @@ class ScCollectionsController < ApplicationController
       if service["@type"] == "sc:Collection"
         @sc_collection = ScCollection.collection_for_at_id(at_id)
         @collection = set_collection
-        render 'explore_collection', at_id: at_id
 
+        render 'explore_collection', at_id: at_id
       elsif service["@type"] == "sc:Manifest"
         @sc_manifest = ScManifest.manifest_for_at_id(at_id)
         find_parent = @sc_manifest.service["within"]

--- a/app/views/sc_collections/explore_collection.html.slim
+++ b/app/views/sc_collections/explore_collection.html.slim
@@ -39,6 +39,8 @@
         =label_tag 'select_all', "Select All Manifests"
 
         ul.iiif-works-list
+          -preimported_pairs = ScManifest.joins(:work => :collection).where(:at_id => @sc_collection.service.manifests.map { |m| m['@id'] } ).pluck('sc_manifests.at_id', 'collections.title')
+          -preimported_collections = Hash[ preimported_pairs.group_by(&:first).map{ |k,a| [k,a.map(&:last)] } ]
           -@sc_collection.service.manifests.each_with_index do |json_manifest, index|
             li
               -at_id = json_manifest["@id"]
@@ -46,6 +48,10 @@
               =check_box_tag("manifest_id[#{index}]", 1, true, class: "manifest_checks")
               =label_tag "manifest_id[#{index}]", class: 'manifest_labels' do
                 =link_to(label_name, { :action => :explore_manifest, :at_id => json_manifest['@id'], :sc_collection_id => @sc_collection.id})
+              -if preimported_collections[json_manifest['@id']]
+                i Already imported into
+                i #{' ' + preimported_collections[json_manifest['@id']].join(", ")}
+
         br
 
     -content_for :javascript


### PR DESCRIPTION
This modifies the IIIF collection import screen, by checking each manifest to see if it has previously been imported into the system and displaying the relevant collection name next to that manifest.  

Resolves #1687 