### PR TITLE
Resolves #2026 by paring still_editing down to the minimum

### DIFF
--- a/app/controllers/transcribe_controller.rb
+++ b/app/controllers/transcribe_controller.rb
@@ -5,12 +5,15 @@ class TranscribeController  < ApplicationController
 
   require 'rexml/document'
   include Magick
-  before_action :authorized?, :except => [:zoom, :guest, :help]
-  before_action :active?
+  before_action :authorized?, :except => [:zoom, :guest, :help, :still_editing]
+  before_action :active?, :except => [:still_editing]
 
   protect_from_forgery :except => [:zoom, :unzoom]
   #this prevents failed redirects after sign up
   skip_before_action :store_current_location
+  skip_before_action :load_objects_from_params, only: :still_editing
+  skip_before_action :load_html_blocks, only: :still_editing
+  skip_around_action :switch_locale, only: :still_editing
 
   def authorized?
     unless user_signed_in? && current_user.can_transcribe?(@work)
@@ -312,8 +315,9 @@ class TranscribeController  < ApplicationController
   end
 
   def still_editing
-    @page.update_column("edit_started_at", Time.now)
-    @page.update_column("edit_started_by_user_id", current_user.id)
+    @page = Page.find(params[:page_id])
+    @page.update_columns(edit_started_at: Time.now, edit_started_by_user_id: current_user.id)
+    render plain: ''
   end
 
   def goto_next_untranscribed_page


### PR DESCRIPTION
This pares the `still_editing` action down to 3 SQL calls.  

Previously this action called 17 SQL statements.