### PR TITLE
2101 enhance iiif api

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -19,11 +19,29 @@ class IiifController < ApplicationController
     render :plain => site_collection.to_json(pretty: true), :content_type => "application/json"
   end
 
+  def user_collections
+    site_collection = IIIF::Presentation::Collection.new
+    site_collection['@id'] = iiif_user_collections_url(@user)
+    site_collection.label = "IIIF resources avaliable on the FromThePage installation at #{Rails.application.config.action_mailer.default_url_options[:host]} for #{@user.display_name}."
+    (@user.collections.to_a + @user.document_sets.to_a).each do |collection_or_ds|
+      if collection_or_ds.is_public || collection_or_ds.api_access
+        site_collection.collections << iiif_collection_from_collection(collection_or_ds,false)
+      end
+    end
+
+    render :plain => site_collection.to_json(pretty: true), :content_type => "application/json"
+  end
+
   def collection
     iiif_collection = iiif_collection_from_collection(@collection,true)
 
     render :plain => iiif_collection.to_json(pretty: true), :content_type => "application/json"
   end
+
+  def document_set
+    iiif_collection = iiif_collection_from_collection(@document_set,true)
+    render :plain => iiif_collection.to_json(pretty: true), :content_type => "application/json"
+  end      
 
   def contributions
     domain = params[:domain]
@@ -113,7 +131,8 @@ class IiifController < ApplicationController
 
   def manifest
     work_id =  params[:id]
-    work = Work.where(id: work_id).first
+    work = Work.where(id: work_id).includes(:ia_work, :sc_manifest, :work_statistic).first
+
     seed = {
               '@id' => url_for({:controller => 'iiif', :action => 'manifest', :id => work_id, :only_path => false}),
               'label' => work.title
@@ -450,7 +469,11 @@ private
   end
 
   def iiif_collection_id_from_collection(collection)
-    url_for({ :controller => 'iiif', :action => 'collection', :collection_id => collection.id, :only_path => false })
+    if collection.is_a? DocumentSet
+      iiif_document_set_url(collection)
+    else
+      url_for({ :controller => 'iiif', :action => 'collection', :collection_id => collection.id, :only_path => false })
+    end
   end
 
   def iiif_collection_from_collection(collection,depth)
@@ -462,7 +485,7 @@ private
     end
 
     if depth == true
-      collection.works.each do |work|
+      collection.works.includes(:sc_manifest, :ia_work, :work_statistic).each do |work|
         seed = {
                   '@id' => url_for({:controller => 'iiif', :action => 'manifest', :id => work.id, :only_path => false}),
                   'label' => work.title

--- a/app/models/document_set.rb
+++ b/app/models/document_set.rb
@@ -193,4 +193,12 @@ class DocumentSet < ApplicationRecord
       'ltr'
     end
   end
+
+  def sc_collection # association does not exist for document sets
+    nil
+  end
+  
+  def api_access # API access is only controlled by public/private for document sets
+    false
+  end
 end

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -3,8 +3,6 @@
 section.signon
   h1 
     |Sign in 
-  -if ENABLE_SAML  
-    =button_to('Sign in with your Institution (SSO)', registrations_choose_provider_path, class: 'strong signin')
   =form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
     =devise_error_messages!
     fieldset.signon_fieldset
@@ -26,7 +24,13 @@ section.signon
   - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
     =link_to 'Forgot your password?', new_password_path(resource_name), class: 'forgot'
 
+  -if ENABLE_SAML  
+    hr
+    h4 or
+    =button_to('Sign in with your Institution (SSO)', registrations_choose_provider_path, class: 'strong signin')
+
   hr
+
 
   section#sign_up.signup-links
     h2 Sign Up

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -260,7 +260,9 @@ Fromthepage::Application.routes.draw do
   get '/iiif/:id/manifest', :to => 'iiif#manifest', as: :iiif_manifest
   get '/iiif/:id/layer/:type', :to => 'iiif#layer'
   get '/iiif/collection/:collection_id', :to => 'iiif#collection', as: :iiif_collection
+  get '/iiif/set/:document_set_id', :to => 'iiif#document_set', as: :iiif_document_set
   get '/iiif/collections', :to => 'iiif#collections'
+  get '/iiif/collections/:user_id', :to => 'iiif#user_collections', as: :iiif_user_collections
   get '/iiif/:page_id/list/:annotation_type', :to => 'iiif#list'
   get '/iiif/:page_id/notes', :to => 'iiif#notes'
   get '/iiif/:page_id/note/:note_id', :to => 'iiif#note'


### PR DESCRIPTION
Closes #2101 by
* Exposing a new API endpoint to list a user's collections
* Adding support for user-based queries into the collections API, which makes that API functional for projects that were not imported via IIIF or are CONTENTdm-based.
* Adding support for document sets to the API
* Improving performance of most API calls.