### PR TITLE
2119 work search doc set

### DIFF
--- a/app/controllers/document_sets_controller.rb
+++ b/app/controllers/document_sets_controller.rb
@@ -14,7 +14,13 @@ class DocumentSetsController < ApplicationController
   end
 
   def index
-    @works = @collection.works.order(:title).paginate(page: params[:page], per_page: 20)
+    page = params[:page]
+    page = 1 if page.blank?
+    if params[:search]
+      @works = @collection.search_works(params[:search]).order(:title).paginate(page: page, per_page: 20)
+    else
+      @works = @collection.works.order(:title).paginate(page: page, per_page: 20)
+    end
   end
 
   def show

--- a/app/models/document_set.rb
+++ b/app/models/document_set.rb
@@ -175,7 +175,7 @@ class DocumentSet < ApplicationRecord
   end
 
   def search_collection_works(search)
-    self.collection.works.where("title LIKE ?", "%#{search}%")
+    self.collection.search_works(search)
   end
 
   def self.search(search)

--- a/app/views/document_sets/index.html.slim
+++ b/app/views/document_sets/index.html.slim
@@ -34,6 +34,13 @@ br
 
 -if @collection.document_sets.present?
   h3 =t('.assign_works_to_document_sets')
+  =form_tag({:controller => 'document_sets', :action => 'index'}, method: :get, enforce_utf8: false, class: 'collection-search') do
+    =hidden_field_tag('collection_id', @collection.slug)
+    =search_field_tag :search, params[:search], placeholder: t('.search_for_works')
+    =button_tag t('.search')
+    =label_tag 'search', "Search for works", class: 'hidden'
+
+
   =form_tag(document_set_assign_works_path(collection_id: @collection.id))
     table.datagrid
       thead

--- a/config/locales/document_sets/document_sets-en.yml
+++ b/config/locales/document_sets/document_sets-en.yml
@@ -38,6 +38,7 @@ en:
       unrestricted: "Unrestricted"
       save: "Save"
       no_document_sets: "This collection has no document sets"
+      search_for_works: "Search for works..."
     new:
       create_new_document_set: "Create New Document Set"
       document_set_is_marked_public: "If the document set is marked as public, works put within it will be readable even if the collection is marked as private."


### PR DESCRIPTION
This adds a work search bar to the collection-level document set assignment screen and has the set-specific assignment screen's search bar duplicate the metadata search present elsewhere.

Closes #2119 