### PR TITLE
2122 assign sets on import

### DIFF
--- a/app/controllers/sc_collections_controller.rb
+++ b/app/controllers/sc_collections_controller.rb
@@ -114,7 +114,7 @@ class ScCollectionsController < ApplicationController
       collection_id = collection.id
     end
 
-    if md=collection_id.match(/D(\d+)/)
+    if collection_id.is_a?(String) && (md=collection_id.match(/D(\d+)/))
       document_set = DocumentSet.find_by(id: md[1])
       collection = document_set.collection
     else
@@ -142,7 +142,7 @@ class ScCollectionsController < ApplicationController
     logger.info rake_call
     system(rake_call)
     #flash notice about the rake task
-    flash[:info] = t('.import_is_processing')
+    flash[:notice] = t('.import_is_processing')
 
     ajax_redirect_to collection_path(collection.owner, collection)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -165,5 +165,19 @@ module ApplicationHelper
     html
   end
 
+  def target_collection_options(default)
+    option_data = {}
+    current_user.collections.sort { |a,b| a.title <=> b.title }.each do |c| 
+      option_data[c.title]=c.id 
+      c.document_sets.sort { |a,b| a.title <=> b.title }.each do |set|
+        option_data[" -- #{set.title}"] = "D#{set.id}"
+      end
+    end
+
+    options_for_select(option_data)
+
+
+  end
+
 
 end

--- a/app/models/sc_manifest.rb
+++ b/app/models/sc_manifest.rb
@@ -52,7 +52,7 @@ class ScManifest < ApplicationRecord
     convert_with_collection(user, collection)
   end
 
-  def convert_with_collection(user, collection)
+  def convert_with_collection(user, collection, document_set=nil)
     self.save!
 
     work = Work.new
@@ -79,6 +79,10 @@ class ScManifest < ApplicationRecord
 
     self.work = work
     self.save!
+
+    if document_set
+      document_set.works << work
+    end
 
     work
   end

--- a/app/views/sc_collections/explore_collection.html.slim
+++ b/app/views/sc_collections/explore_collection.html.slim
@@ -31,7 +31,7 @@
         =hidden_field_tag :sc_collection_id, @sc_collection.id
         -new_collection = @collection ? @collection.id : nil
         .iiif-select-form
-          =select_tag :collection_id, options_from_collection_for_select(current_user.collections, 'id', 'title', new_collection), id: 'manifest_import', prompt: '- Select a collection to import into -', required: true, 'aria-label' => "Select a collection"
+          =select_tag :collection_id, target_collection_options(new_collection), id: 'manifest_import', prompt: '- Select a collection to import into -', required: true, 'aria-label' => "Select a collection"
           =button_tag 'Import Checked Manifests'
 
         =check_box_tag("select_all", 1, true)

--- a/app/views/sc_collections/explore_manifest.html.slim
+++ b/app/views/sc_collections/explore_manifest.html.slim
@@ -21,7 +21,7 @@
       	=hidden_field_tag :sc_collection_id, @sc_collection.id
       =hidden_field_tag :at_id, @sc_manifest.at_id
       -new_collection = @collection ? @collection.id : nil
-      =f.select(:collection_id, options_from_collection_for_select(current_user.collections, 'id', 'title', new_collection), {prompt: '- Select a collection to import into -'}, {required: true, 'aria-label' => 'Select a collection to import into'})
+      =f.select(:collection_id, target_collection_options(new_collection), {prompt: '- Select a collection to import into -'}, {required: true, 'aria-label' => 'Select a collection to import into'})
       =f.button 'Import Manifest'
       -if ContentdmTranslator.iiif_manifest_is_cdm?(@sc_manifest.at_id)
         =label_tag :contentdm_ocr, 'Import OCR text from CONTENTdm'

--- a/lib/tasks/iiif_collection_import.rake
+++ b/lib/tasks/iiif_collection_import.rake
@@ -9,7 +9,14 @@ namespace :fromthepage do
     collection_id = args.collection_id
     user_id = args.user_id
     import_ocr = ActiveRecord::Type::Boolean.new.cast(args.import_ocr)
-    collection = Collection.find_by(id: collection_id)
+    document_set = nil
+
+    if md=collection_id.match(/D(\d+)/)
+      document_set = DocumentSet.find_by(id: md[1])
+      collection = document_set.collection
+    else
+      collection = Collection.find_by(id: collection_id)
+    end
     user = User.find_by(id: user_id)
     manifest_array = manifest_indices.split(" ")
     puts "manifest_indices were #{manifest_indices.inspect}"
@@ -24,6 +31,9 @@ namespace :fromthepage do
           sc_manifest = ScManifest.manifest_for_at_id(at_id)
           work = nil
           work = sc_manifest.convert_with_collection(user, collection)
+          if document_set
+            document_set.works << work
+          end
           puts "#{work.title} has been imported"
           unless work.errors.blank?
             error.update(work.errors)


### PR DESCRIPTION
Closes #2122

This modifies the following
* When importing from CONTENTdm or IIIF, a the target collection select list is sorted by collection title and now displays document sets under each collection
* If a document set is chosen, imported works are added to the target collection and also the target document set.