### PR TITLE
Show all notes for #2246, improved perf, link to display

### DIFF
--- a/app/controllers/deed_controller.rb
+++ b/app/controllers/deed_controller.rb
@@ -32,7 +32,11 @@ class DeedController < ApplicationController
   end
 
   def notes
-    @deeds = Deed.where(collection_id: @collection.id, deed_type: DeedType::NOTE_ADDED).order('created_at DESC').paginate :page => params[:page], :per_page => PAGES_PER_SCREEN
+    if @collection
+      @deeds = Deed.where(collection_id: @collection.id, deed_type: DeedType::NOTE_ADDED).order('created_at DESC').includes(:note, :page, :user, :work, :collection).paginate :page => params[:page], :per_page => PAGES_PER_SCREEN
+    else
+      @deeds = Deed.where(deed_type: DeedType::NOTE_ADDED).order('created_at DESC').joins(:collection).includes(:note, :page, :user, :work).where("collections.restricted = 0").paginate :page => params[:page], :per_page => PAGES_PER_SCREEN
+    end
     render :list
   end
 

--- a/app/views/admin/index.html.slim
+++ b/app/views/admin/index.html.slim
@@ -8,7 +8,8 @@ section.admin-counters
   .counter(data-prefix="#{number_with_delimiter @articles_count}") #{'Article'.pluralize(@articles_count)}
   .counter(data-prefix="#{number_with_delimiter @transcribed_count}") #{'Transcribed Page'.pluralize(@transcribed_count)}
   .counter(data-prefix="#{number_with_delimiter @pages_count}") #{'Page'.pluralize(@pages_count)}
-  .counter(data-prefix="#{number_with_delimiter @notes_count}") #{'Note'.pluralize(@notes_count)}
+  =link_to deed_notes_path do
+    .counter.link(data-prefix="#{number_with_delimiter @notes_count}") #{'Note'.pluralize(@notes_count)}
   =link_to admin_owner_list_path do
     .counter.link(data-prefix="#{number_with_delimiter @owners_count}") #{'Owner'.pluralize(@owners_count)}
   =link_to admin_user_list_path do

--- a/app/views/deed/_deed.html.slim
+++ b/app/views/deed/_deed.html.slim
@@ -5,10 +5,10 @@
 -user_name = deed.user.display_name if deed.user
 
 -user = link_to(user_name, user_profile_url(deed.user, only_path: !mailer))
--page = deed.page.nil? ? '' : link_to(deed.page.title, collection_display_page_url(deed.collection.owner, deed.collection, deed.work, deed.page, only_path: !mailer))
--article = deed.article.nil? ? '' : link_to(deed.article.title, collection_article_show_url(deed.collection.owner, deed.collection, deed.article, only_path: !mailer))
+-page = deed.page.nil? ? '' : link_to(deed.page.title, collection_display_page_url(deed.page.collection.owner, deed.page.collection, deed.work, deed.page, only_path: !mailer))
+-article = deed.article.nil? ? '' : link_to(deed.article.title, collection_article_show_url(deed.article.collection.owner, deed.article.collection, deed.article, only_path: !mailer))
 -if(!deed.work.nil? && !deed.work.collection.nil? )
-  -work = link_to(deed.work.title, collection_read_work_url(deed.collection.owner, deed.collection, deed.work, only_path: !mailer))
+  -work = link_to(deed.work.title, collection_read_work_url(deed.work.collection.owner, deed.work.collection, deed.work, only_path: !mailer))
 -unless(deed.collection.nil?)
   -collection = link_to(deed.collection.title, collection_url(deed.collection.owner, deed.collection, only_path: !mailer ))
 

--- a/app/views/deed/_deed.html.slim
+++ b/app/views/deed/_deed.html.slim
@@ -5,10 +5,10 @@
 -user_name = deed.user.display_name if deed.user
 
 -user = link_to(user_name, user_profile_url(deed.user, only_path: !mailer))
--page = deed.page.nil? ? '' : link_to(deed.page.title, collection_transcribe_page_url(deed.page.collection.owner, deed.page.collection, deed.page.work, deed.page, only_path: !mailer))
--article = deed.article.nil? ? '' : link_to(deed.article.title, collection_article_show_url(deed.article.collection.owner, deed.article.collection, deed.article, only_path: !mailer))
+-page = deed.page.nil? ? '' : link_to(deed.page.title, collection_display_page_url(deed.collection.owner, deed.collection, deed.work, deed.page, only_path: !mailer))
+-article = deed.article.nil? ? '' : link_to(deed.article.title, collection_article_show_url(deed.collection.owner, deed.collection, deed.article, only_path: !mailer))
 -if(!deed.work.nil? && !deed.work.collection.nil? )
-  -work = link_to(deed.work.title, collection_read_work_url(deed.work.collection.owner, deed.work.collection, deed.work, only_path: !mailer))
+  -work = link_to(deed.work.title, collection_read_work_url(deed.collection.owner, deed.collection, deed.work, only_path: !mailer))
 -unless(deed.collection.nil?)
   -collection = link_to(deed.collection.title, collection_url(deed.collection.owner, deed.collection, only_path: !mailer ))
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,7 +183,7 @@ Fromthepage::Application.routes.draw do
 
   scope 'deed', as: 'deed' do
     get 'list', to: 'deed#list'
-    get 'notes/:collection_id', to: 'deed#notes', as: 'notes'
+    get 'notes(/:collection_id)', to: 'deed#notes', as: 'notes'
   end
 
   scope 'static', as: 'static' do


### PR DESCRIPTION
Resolves #2246 and does the following:
Adds a site-wide notes stream of notes on public collections, links to it from the admin dashboard, improves performance of deed rendering for the activity stream for collections and the site, and changes the activity stream page link from transcribe to overview for a page.