### PR TITLE
Keep buttons at the top with a long conventions text

### DIFF
--- a/app/views/transcribe/display_page.html.slim
+++ b/app/views/transcribe/display_page.html.slim
@@ -91,7 +91,7 @@
   .page-toolbar
     .toolbar
       .toolbar_group.w100.fgfaded.wrap-text ==@work.set_transcription_conventions
-      .toolbar_group.aright
+      .toolbar_group.aright.vtop
         -unless @preview_xml
           =>button_tag t('.preview'), :name => 'preview', type: 'button'
         -else


### PR DESCRIPTION
Re #2458 - very easy fix.