### PR TITLE
Fix empty space in multi-page field layout

### DIFF
--- a/app/views/transcription_field/_field_layout.html.slim
+++ b/app/views/transcription_field/_field_layout.html.slim
@@ -1,10 +1,11 @@
 -field_order(@collection)
 .page-fields
   -@fields.each do |line, array|
-    .fields-row
-      -field_layout(array)
-      -@field_array.each do |field, cell|
-        -if (@page && (field.page_number == @page.position || field.page_number == nil )) || (current_page?({action: 'edit_fields'}))
+    -page_number = array.map{|field| field.page_number}.uniq.first
+    -if (@page && (page_number == @page.position || page_number == nil)) || (current_page?({action: 'edit_fields'}))
+      .fields-row
+        -field_layout(array)
+        -@field_array.each do |field, cell|
           -if field.input_type == 'spreadsheet'
             .spreadsheet-wrapper
               =render({ :partial => '/shared/handsontable', :locals => {:transcription_field => field} })


### PR DESCRIPTION
Re #2501 - This is how I've changed the condition to show `.fields-row` (based on your suggestion in Slack)

```ruby
-page_number = array.map{|field| field.page_number}.uniq.first
-if (@page && (page_number == @page.position || page_number == nil)) || (current_page?({action: 'edit_fields'}))
```