### PR TITLE
Add logging for #2555 and improve rendering performance

### DIFF
--- a/app/controllers/transcribe_controller.rb
+++ b/app/controllers/transcribe_controller.rb
@@ -415,7 +415,17 @@ protected
 
   def log_transcript_attempt
     # we have access to @page, @user, and params
-    log_message = log_attempt(TRANSCRIPTION, params[:page][:source_text])
+    if @page.field_based
+      if request.params[:fields].nil?
+        source_text = "[NULL FIELD-BASED PARAMS]"
+      else
+        source_text = request.params[:fields].pretty_inspect
+      end
+    else
+      source_text = params[:page][:source_text]
+    end
+
+    log_message = log_attempt(TRANSCRIPTION, source_text)
     return log_message
   end
 

--- a/app/views/shared/_handsontable.html.erb
+++ b/app/views/shared/_handsontable.html.erb
@@ -50,9 +50,10 @@
           <% end %>
         ],
       <% end %>
+      <% spreadsheet_column_count = transcription_field.spreadsheet_columns.count %>
       <% (transcription_field.starting_rows - cells_by_row.count).times do %>
         [
-          <% transcription_field.spreadsheet_columns.count.times do %>
+          <% spreadsheet_column_count.times do %>
             null,
           <% end %>
         ],


### PR DESCRIPTION
This adds logging for field-based transcriptions, which have not had our fail-safe logging in the past.

It also fixes a nested loop performance problem.