### PR TITLE
Improve text search performance/functionality for #2360

### DIFF
--- a/app/controllers/display_controller.rb
+++ b/app/controllers/display_controller.rb
@@ -101,7 +101,9 @@ class DisplayController < ApplicationController
       @search_string = CGI::escapeHTML(params[:search_string])
       # convert 'natural' search strings unless they're precise
       unless @search_string.match(/["+-]/)
-        @search_string.gsub!(/(\S+)/, '+\1*')
+        @search_string.gsub!(/\s+/, ' ')
+        @search_string = "+\"#{@search_string}\""
+        # @search_string.gsub!(/(\S+)/, '+\1*')
       end
       # restrict to pages that include that subject
       @pages = Page.order('work_id, position').joins(:work).where(work_id: @collection.works.ids).where("MATCH(search_text) AGAINST(? IN BOOLEAN MODE)", @search_string).paginate(page: params[:page])


### PR DESCRIPTION
Handle spaces in search strings, so that a search for `morgan s` becomes a search for `"morgan s"` instead of a search for `morgan AND s`.