### PR TITLE
Handle odd formatting for #2556

### DIFF
--- a/app/helpers/abstract_xml_helper.rb
+++ b/app/helpers/abstract_xml_helper.rb
@@ -118,7 +118,7 @@ module AbstractXmlHelper
           if sib.kind_of? REXML::Element
             sib.add_text(sigil)
           else
-            sib.value=sib.value+sigil
+            sib.value=sib.value+sigil unless sib.nil?
           end
         end
         e.replace_with(REXML::Element.new('br'))
@@ -188,6 +188,7 @@ module AbstractXmlHelper
         e.name='hr'
       else
         e.name='span'
+        rend ||= 'figure'
         e.add_text("{#{rend.titleize}}")
       end
     end


### PR DESCRIPTION
Handle hyphens at the beginnings of paragraphs and `figure` tags with no `rend` attribute.

To test, verify #2556 and do a full HTML export from a copy of Mount Auburn's collection.