### PR TITLE
Format tables in plaintext export for #2494

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -496,6 +496,7 @@ UPDATE `articles` SET graph_image=NULL WHERE `articles`.`id` IN (SELECT article_
       end
       n.replace("#{sigil}\n")
     end
+    doc.xpath("//table").each { |n| formatted_plaintext_table(n) }
     doc.xpath("//lb").each { |n| n.replace("\n")}
     doc.xpath("//br").each { |n| n.replace("\n")}
     doc.xpath("//div").each { |n| n.add_next_sibling("\n")}
@@ -503,6 +504,41 @@ UPDATE `articles` SET graph_image=NULL WHERE `articles`.`id` IN (SELECT article_
 
     doc.text.sub(/^\s*/m, '').gsub(/ *$/m,'')
   end
+
+  def formatted_plaintext_table(table_element)
+    text_table = ""
+
+    # clean up in-cell line-breaks
+    table_element.xpath('//lb').each { |n| n.replace(' ')}
+
+    # calculate the widths of each column based on max(header, cell[0...end])
+    column_count = ([table_element.xpath("//th").count] + table_element.xpath('//tr').map{|e| e.xpath('td').count }).max
+    column_widths = {}
+    1.upto(column_count) do |column_index|
+      longest_cell = (table_element.xpath("//tr/td[position()=#{column_index}]").map{|e| e.text().length}.max || 0)
+      corresponding_heading = heading_length = table_element.xpath("//th[position()=#{column_index}]").first
+      heading_length = corresponding_heading.nil? ? 0 : corresponding_heading.text().length
+      column_widths[column_index] = [longest_cell, heading_length].max
+    end
+
+    # print the header as markdown
+    cell_strings = []
+    table_element.xpath("//th").each_with_index do |e,i|
+      cell_strings << e.text.rjust(column_widths[i+1], ' ')
+    end
+    text_table << cell_strings.join(' | ') << "\n"
+
+    # print the separator
+    text_table << column_count.times.map{|i| ''.rjust(column_widths[i+1], '-')}.join(' | ') << "\n"
+
+    # print each row as markdown
+    table_element.xpath('//tr').each do |row_element|
+      text_table << row_element.xpath('td').map{|e| e.text.rjust(column_widths[e.path.match(/.*(\d)/)[1].to_i], ' ') }.join(' | ') << "\n"
+    end
+
+    table_element.replace(text_table)
+  end
+
 
   def modernize_absolute(filename)
     if filename

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -533,7 +533,7 @@ UPDATE `articles` SET graph_image=NULL WHERE `articles`.`id` IN (SELECT article_
 
     # print each row as markdown
     table_element.xpath('//tr').each do |row_element|
-      text_table << row_element.xpath('td').map{|e| e.text.rjust(column_widths[e.path.match(/.*(\d)/)[1].to_i], ' ') }.join(' | ') << "\n"
+      text_table << row_element.xpath('td').map{|e| e.text.rjust(column_widths[e.path.match(/.*\[(\d+)\]/)[1].to_i], ' ') }.join(' | ') << "\n"
     end
 
     table_element.replace(text_table)


### PR DESCRIPTION
Closes #2494 

To test:
* Do a plaintext export of a markdown-encoded work (JWG or Mount Auburn)
* Do a plaintext export of a spreadsheet-entered work