### PR TITLE
Preserve new fields order after save

### DIFF
--- a/app/views/transcription_field/edit_fields.html.slim
+++ b/app/views/transcription_field/edit_fields.html.slim
@@ -42,6 +42,7 @@ div.columns
         update: function(e, ui) {
           var line = $(this).index() + 1;
           var data = $(this).sortable('serialize');
+          ui.item.find('input[id=transcription_fields__line_number]').val(line);
           if (data) {
             $.ajax({
               url: "#{transcription_field_reorder_path(collection_id: @collection.id)}",


### PR DESCRIPTION
Re #2606 - Interesting bug, took some time to figure it out :)
Reordering was working correct, so if you _refresh the page_ after reordering everything will be fine. But reordering didn't update the line number value in the hidden input, so if you _submit the form_ right after reordering, it will post the wrong (old) line numbers and update. The small fix should resolve the issue.