### PR TITLE
Use riiif to serve OSD images to Safari/iOS for #2626

### DIFF
--- a/app/helpers/transcribe_helper.rb
+++ b/app/helpers/transcribe_helper.rb
@@ -58,6 +58,8 @@ module TranscribeHelper
       ["#{@page.sc_canvas.sc_service_id}/info.json"]
     elsif page.ia_leaf
       [@page.ia_leaf.iiif_image_info_url]
+    elsif browser.platform.ios? && browser.webkit?
+      ["#{url_for(:root)}image-service/#{page.id}/info.json"]
     else
       {type: 'image', url: file_to_url(page.canonical_facsimile_url)}.to_json
     end


### PR DESCRIPTION
To test:
* View a IIIF-imported page
* View an Internet Archive-imported page
* View a large uploaded page
