### PR TITLE
Fix editor min height

### DIFF
--- a/app/assets/stylesheets/sections/page.scss
+++ b/app/assets/stylesheets/sections/page.scss
@@ -156,6 +156,11 @@
   display: flex;
   box-sizing: border-box;
   flex-direction: column;
+
+  [data-layout-mode='ttb'] &,
+  [data-layout-mode='btt'] & {
+    min-height: calc((100vh - 74px - 3rem) / 2);
+  }
 }
 
 .page-imagescan {


### PR DESCRIPTION
Re #2622 - set minimum height of the transcription column to half of the available viewport height in vertical layout mode.