### PR TITLE
2395 bulk export work download

### DIFF
--- a/app/controllers/bulk_export_controller.rb
+++ b/app/controllers/bulk_export_controller.rb
@@ -81,6 +81,7 @@ class BulkExportController < ApplicationController
         :subject_csv_collection, 
         :table_csv_work, 
         :table_csv_collection,
-        :work_metadata_csv)
+        :work_metadata_csv,
+        :facing_edition_work)
     end
 end

--- a/app/controllers/bulk_export_controller.rb
+++ b/app/controllers/bulk_export_controller.rb
@@ -29,6 +29,21 @@ class BulkExportController < ApplicationController
     render :action => :new
   end
 
+  def create_for_work
+    @bulk_export = BulkExport.new(bulk_export_params)
+    @bulk_export.collection = @collection
+    @bulk_export.work = @work
+    @bulk_export.user = current_user
+    @bulk_export.status = BulkExport::Status::NEW
+
+    if @bulk_export.save
+      @bulk_export.submit_export_process
+
+      flash[:info] = "Export running.  Email will be sent to #{current_user.email} on completion."
+    end
+    redirect_to download_collection_work_path(@collection.owner.slug, @collection.slug, @work.slug)
+  end
+
   def download
     if @bulk_export.status == BulkExport::Status::FINISHED
       # read and spew the file

--- a/app/controllers/bulk_export_controller.rb
+++ b/app/controllers/bulk_export_controller.rb
@@ -21,12 +21,12 @@ class BulkExportController < ApplicationController
     @bulk_export.user = current_user
     @bulk_export.status = BulkExport::Status::NEW
 
-    if @bulk_export.save
+    if @bulk_export.save!
       @bulk_export.submit_export_process
 
       flash[:info] = "Export running.  Email will be sent to #{current_user.email} on completion."
     end
-    render :action => :new
+    redirect_to dashboard_exports_path
   end
 
   def create_for_work

--- a/app/controllers/bulk_export_controller.rb
+++ b/app/controllers/bulk_export_controller.rb
@@ -41,7 +41,7 @@ class BulkExportController < ApplicationController
 
       flash[:info] = "Export running.  Email will be sent to #{current_user.email} on completion."
     end
-    redirect_to download_collection_work_path(@collection.owner.slug, @collection.slug, @work.slug)
+    redirect_to dashboard_exports_path
   end
 
   def download

--- a/app/controllers/concerns/export_service.rb
+++ b/app/controllers/concerns/export_service.rb
@@ -50,7 +50,8 @@ module ExportService
 
     # run pandoc against the temp directory
     log_file = File.join(temp_dir, "#{file_stub}.log")
-    cmd = "pandoc -o #{output_file} #{md_file} --pdf-engine=xelatex > #{log_file} 2>&1"
+    cmd = "pandoc -o #{output_file} #{md_file} --pdf-engine=xelatex --verbose > #{log_file} 2>&1"
+    print cmd
     logger.info(cmd)
     system(cmd)
 

--- a/app/controllers/concerns/export_service.rb
+++ b/app/controllers/concerns/export_service.rb
@@ -12,7 +12,8 @@ module ExportService
   def export_printable_to_zip(work, edition, output_format, dirname, out)
     path = File.join dirname, 'printable', "facing_edition.pdf"
     tempfile = export_printable(work, edition, output_format)
-    out.add(path, tempfile)
+    out.put_next_entry(path)
+    out.write(IO.read(tempfile))
   end
 
   def export_printable(work, edition, format)
@@ -40,9 +41,9 @@ module ExportService
 
     file_stub = "#{@work.slug.gsub('-','_')}_#{time_stub}"
     md_file = File.join(temp_dir, "#{file_stub}.md")
-    if @output_type == 'pdf'
+    if format == 'pdf'
       output_file = File.join(temp_dir, "#{file_stub}.pdf")
-    elsif @output_type == 'doc'
+    elsif format == 'doc'
       output_file = File.join(temp_dir, "#{file_stub}.docx")      
     end
 

--- a/app/controllers/concerns/export_service.rb
+++ b/app/controllers/concerns/export_service.rb
@@ -9,6 +9,54 @@ module ExportService
     out.write file.read
   end
 
+  def export_printable_to_zip(work, edition, output_format, dirname, out)
+    path = File.join dirname, 'printable', "facing_edition.pdf"
+    tempfile = export_printable(work, edition, output_format)
+    out.add(path, tempfile)
+  end
+
+  def export_printable(work, edition, format)
+
+    # render to a string
+    rendered_markdown = 
+      ApplicationController.new.render_to_string(
+        :template => '/export/facing_edition.html', 
+        :layout => false,
+        :assigns => {
+          :collection => work.collection,
+          :work => work,
+          :edition_type => edition,
+          :output_type => format
+        }
+      )
+
+    # write the string to a temp directory
+    temp_dir = File.join(Rails.root, 'public', 'printable')
+    Dir.mkdir(temp_dir) unless Dir.exist? temp_dir
+
+    time_stub = Time.now.gmtime.iso8601.gsub(/\D/,'')
+    temp_dir = File.join(temp_dir, time_stub)
+    Dir.mkdir(temp_dir) unless Dir.exist? temp_dir
+
+    file_stub = "#{@work.slug.gsub('-','_')}_#{time_stub}"
+    md_file = File.join(temp_dir, "#{file_stub}.md")
+    if @output_type == 'pdf'
+      output_file = File.join(temp_dir, "#{file_stub}.pdf")
+    elsif @output_type == 'doc'
+      output_file = File.join(temp_dir, "#{file_stub}.docx")      
+    end
+
+    File.write(md_file, rendered_markdown)
+
+    # run pandoc against the temp directory
+    log_file = File.join(temp_dir, "#{file_stub}.log")
+    cmd = "pandoc -o #{output_file} #{md_file} --pdf-engine=xelatex > #{log_file} 2>&1"
+    logger.info(cmd)
+    system(cmd)
+
+    output_file
+  end
+
   def export_work_metadata_csv(dirname:, out:, collection:)
     path = "work_metadata.csv"
     out.put_next_entry(path)

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,13 +2,14 @@
 
 class DashboardController < ApplicationController
   include AddWorkHelper
+  PAGES_PER_SCREEN = 20
 
   before_action :authorized?,
     only: [:owner, :staging, :startproject, :summary]
 
   before_action :get_data,
     only: [:owner, :staging, :upload, :new_upload,
-           :startproject, :empty_work, :create_work, :summary]
+           :startproject, :empty_work, :create_work, :summary, :exports]
 
   before_action :remove_col_id
 
@@ -119,6 +120,11 @@ class DashboardController < ApplicationController
     document_sets = DocumentSet.joins(works: :deeds).where(works: { id: works.ids }).order('deeds.created_at DESC').distinct.limit(5)
     collections_list(true) # assigns @collections_and_document_sets for private collections only
     @collections = (collections + document_sets).sort { |a, b| a.title <=> b.title }.take(5)
+  end
+
+
+  def exports
+    @bulk_exports = current_user.bulk_exports.order('id DESC').paginate :page => params[:page], :per_page => PAGES_PER_SCREEN
   end
 
 

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -28,35 +28,7 @@ class ExportController < ApplicationController
   end
 
   def printable
-    @edition_type = params[:edition]
-    @output_type = params[:format]
-
-    # render to a string
-    rendered_markdown = render_to_string(:template => '/export/facing_edition.html', :layout => false)
-
-    # write the string to a temp directory
-    temp_dir = File.join(Rails.root, 'public', 'printable')
-    Dir.mkdir(temp_dir) unless Dir.exist? temp_dir
-
-    time_stub = Time.now.gmtime.iso8601.gsub(/\D/,'')
-    temp_dir = File.join(temp_dir, time_stub)
-    Dir.mkdir(temp_dir) unless Dir.exist? temp_dir
-
-    file_stub = "#{@work.slug.gsub('-','_')}_#{time_stub}"
-    md_file = File.join(temp_dir, "#{file_stub}.md")
-    if @output_type == 'pdf'
-      output_file = File.join(temp_dir, "#{file_stub}.pdf")
-    elsif @output_type == 'doc'
-      output_file = File.join(temp_dir, "#{file_stub}.docx")      
-    end
-
-    File.write(md_file, rendered_markdown)
-
-    # run pandoc against the temp directory
-    log_file = File.join(temp_dir, "#{file_stub}.log")
-    cmd = "pandoc -o #{output_file} #{md_file} --pdf-engine=xelatex > #{log_file} 2>&1"
-    logger.info(cmd)
-    system(cmd)
+    output_file = export_printable(@work, params[:edition], params[:format])    
 
     # spew the output to the browser
     send_data(File.read(output_file), 

--- a/app/helpers/export_helper.rb
+++ b/app/helpers/export_helper.rb
@@ -120,6 +120,10 @@ module ExportHelper
         end
       end
 
+      if bulk_export.facing_edition_work
+        export_printable_to_zip(work, 'facing', 'pdf', dirname, out)
+      end
+
       # Page-specific exports
 
       @work.pages.each do |page|

--- a/app/models/bulk_export.rb
+++ b/app/models/bulk_export.rb
@@ -4,6 +4,7 @@ class BulkExport < ApplicationRecord
 
   belongs_to :user
   belongs_to :collection
+  belongs_to :work
 
 
   module Status
@@ -21,7 +22,11 @@ class BulkExport < ApplicationRecord
     self.save
 
     begin
-      works = Work.includes(pages: [:notes, {page_versions: :user}]).where(collection_id: self.collection.id)
+      if self.work
+        works=[self.work]
+      else
+        works = Work.includes(pages: [:notes, {page_versions: :user}]).where(collection_id: self.collection.id)
+      end
 
       buffer = Zip::OutputStream.open(zip_file_name) do |out|
         write_work_exports(works, out, self.user, self)

--- a/app/models/bulk_export.rb
+++ b/app/models/bulk_export.rb
@@ -4,7 +4,7 @@ class BulkExport < ApplicationRecord
 
   belongs_to :user
   belongs_to :collection
-  belongs_to :work
+  belongs_to :work, optional: true
 
 
   module Status

--- a/app/views/bulk_export/index.html.slim
+++ b/app/views/bulk_export/index.html.slim
@@ -1,42 +1,44 @@
 =render(:partial => 'admin/header', :locals => { :selected => 6 })
+.columns
+  article.maincol
 
-table.admin-grid.datagrid.striped
-  thead
-    tr
-      th(colspan="2") =t('.user')
-      th.w100 =t('.upload_details')
-      th(colspan="1") =t('.date')
-      th(colspan="2") =t('.status')
+    table.admin-grid.datagrid.striped
+      thead
+        tr
+          th(colspan="2") =t('.user')
+          th.w100 =t('.upload_details')
+          th(colspan="1") =t('.date')
+          th(colspan="2") =t('.status')
 
-  tbody
-    -@bulk_exports.each do |bulk_export|
-      tr
-        td
-          =link_to(user_profile_path(bulk_export.user), class: 'userpic userpic-small')
-            =profile_picture(bulk_export.user)
-        td.nowrap.toleft
-          div =link_to bulk_export.user.login, user_profile_path(bulk_export.user)
-          small =bulk_export.user.email
-        td
-          -if bulk_export.collection.present?
-            p.fgfaded(data-prefix="Collection: ")
-              =link_to(bulk_export.collection.title, collection_url(bulk_export.user, bulk_export.collection))
-          .small.fgfaded(data-prefix="File Name: ")
-            =bulk_export.zip_file_name
-        td.nowrap
-          p
-            =bulk_export.created_at.localtime.strftime("%m/%d/%Y at %I:%M %p")
-        td.nowrap
-          small.label(class="upload-status-#{bulk_export.status}") =bulk_export.status.titleize
-        td.nowrap
-          dl.dropdown.right
-            dt tabindex=0
-              span Actions
-              =svg_symbol '#icon-list', class: 'icon'
-            dd
-              =link_to(t('.show_details'), bulk_export_show_path(:bulk_export_id => bulk_export.id))
+      tbody
+        -@bulk_exports.each do |bulk_export|
+          tr
+            td
+              =link_to(user_profile_path(bulk_export.user), class: 'userpic userpic-small')
+                =profile_picture(bulk_export.user)
+            td.nowrap.toleft
+              div =link_to bulk_export.user.login, user_profile_path(bulk_export.user)
+              small =bulk_export.user.email
+            td
+              -if bulk_export.collection.present?
+                p.fgfaded(data-prefix="Collection: ")
+                  =link_to(bulk_export.collection.title, collection_url(bulk_export.user, bulk_export.collection))
+              .small.fgfaded(data-prefix="File Name: ")
+                =bulk_export.zip_file_name
+            td.nowrap
+              p
+                =bulk_export.created_at.localtime.strftime("%m/%d/%Y at %I:%M %p")
+            td.nowrap
+              small.label(class="upload-status-#{bulk_export.status}") =bulk_export.status.titleize
+            td.nowrap
+              dl.dropdown.right
+                dt tabindex=0
+                  span Actions
+                  =svg_symbol '#icon-list', class: 'icon'
+                dd
+                  =link_to(t('.show_details'), bulk_export_show_path(:bulk_export_id => bulk_export.id))
 
-    .toolbar_group =will_paginate @bulk_exports
+        .toolbar_group =will_paginate @bulk_exports
 
-=render(:partial => 'shared/pagination', :locals => { :model => @bulk_exports, :entries_info => true })
+    =render(:partial => 'shared/pagination', :locals => { :model => @bulk_exports, :entries_info => true })
 

--- a/app/views/bulk_export/new.html.slim
+++ b/app/views/bulk_export/new.html.slim
@@ -61,6 +61,14 @@
               span One file per work
         li
           .bulk-export_format
+            h5 Facing Edition PDF
+            p.nomargin A PDF file containing images and transcripts on facing pages.
+          .bulk-export_options
+            =f.label :facing_edition_work
+              =f.check_box :facing_edition_work, value: @bulk_export.facing_edition_work
+              span One file per work
+        li
+          .bulk-export_format
             h5 Table/Field CSV
             p.nomargin Exports a spreadsheet with field-based or tabular data.
           .bulk-export_options

--- a/app/views/dashboard/_owner_header.html.slim
+++ b/app/views/dashboard/_owner_header.html.slim
@@ -16,6 +16,12 @@
   :options => {\
     :action => 'summary',
   },
+},{\
+  :name => 'Exports',
+  :selected => 4,
+  :options => {\
+    :action => 'exports',
+  },
 }]
 
 -selected_tab = tabs.find { |tab| tab[:selected] == selected }[:name] rescue ""
@@ -53,3 +59,4 @@ section.owner-counters
   =active_link_to t('.start_a_project'), dashboard_startproject_path
   =active_link_to t('.your_collections'), dashboard_owner_path
   =active_link_to t('.summary'), dashboard_summary_path
+  =active_link_to t('.exports'), dashboard_exports_path

--- a/app/views/dashboard/exports.html.slim
+++ b/app/views/dashboard/exports.html.slim
@@ -1,0 +1,62 @@
+=render(:partial => 'dashboard/owner_header', :locals => { :selected => 6 })
+
+
+
+.columns
+  article.maincol
+
+    table.admin-grid.datagrid.striped.
+      thead
+        tr
+          th(colspan="1") =t('.exported_item')
+          th(colspan="1") =t('.date')
+          th(colspan="2") =t('.status')
+
+      tbody
+        -@bulk_exports.each do |bulk_export|
+          tr
+            td
+              -if bulk_export.collection.present?
+                =link_to(bulk_export.collection.title, collection_url(bulk_export.user, bulk_export.collection))
+              -if bulk_export.work.present?
+                br
+                =link_to(bulk_export.work.title, collection_read_work_path(bulk_export.collection.owner, bulk_export.collection, bulk_export.work))
+            td.nowrap
+              p
+                =bulk_export.created_at.localtime.strftime("%m/%d/%Y at %I:%M %p")
+            td.nowrap
+              small.label(class="upload-status-#{bulk_export.status}") =bulk_export.status.titleize
+            td.nowrap
+              -if bulk_export.status == BulkExport::Status::FINISHED
+                =link_to(t('.download'), bulk_export_download_path(:bulk_export_id => bulk_export.id), class: 'btnExport button')
+
+
+
+        .toolbar_group =will_paginate @bulk_exports
+
+
+    =render(:partial => 'shared/pagination', :locals => { :model => @bulk_exports, :entries_info => true })
+
+  aside.sidecol
+    p This lists all bulk exports you have run.  Exports are cleaned after a few days, and are no longer available for download
+    p Reload this page to update the list.
+    =link_to 'Refresh', dashboard_exports_path, class: 'button'
+
+
+-content_for :javascript
+  javascript:
+    $(function() {
+      // Remove 'page_busy' spinner once download finished
+      // Cookie should be set to 'true' in the controller method
+      $('.btnExport').on('click', function() {
+        Cookies.remove('download_finished', {path: '/'});
+        var downloadCheckTimer = window.setInterval(function() {
+          var cookie = Cookies.get('download_finished');
+          if(cookie === 'true') {
+            $('html').removeClass('page-busy');
+            window.clearInterval(downloadCheckTimer);
+          }
+        }, 1000);
+      });
+    });
+

--- a/app/views/dashboard/exports.html.slim
+++ b/app/views/dashboard/exports.html.slim
@@ -4,6 +4,9 @@
 
 .columns
   article.maincol
+    p This lists all bulk exports you have run.  Exports are cleaned after a few days, and are no longer available for download
+
+    p Create a bulk export from the Export tab of a collection or the Download tab of a work.
 
     table.admin-grid.datagrid.striped.
       thead
@@ -38,7 +41,6 @@
     =render(:partial => 'shared/pagination', :locals => { :model => @bulk_exports, :entries_info => true })
 
   aside.sidecol
-    p This lists all bulk exports you have run.  Exports are cleaned after a few days, and are no longer available for download
     p Reload this page to update the list.
     =link_to 'Refresh', dashboard_exports_path, class: 'button'
 

--- a/app/views/export/facing_edition.html.erb
+++ b/app/views/export/facing_edition.html.erb
@@ -8,7 +8,7 @@
 <% unless @edition_type == 'text'%>
 \newpage
   <% if @work.sc_manifest %>
-![<%= page.title %>](<%= page.sc_canvas.sc_resource_id %>)
+![<%= page.title %>](<%= page.sc_canvas.sc_resource_id.sub('/full/full/', '/full/800,/') %>)
   <% elsif page.ia_leaf %>
 ![<%= page.title %>](<%= page.ia_leaf.facsimile_url %>)
   <% else %>

--- a/app/views/export/facing_edition.html.erb
+++ b/app/views/export/facing_edition.html.erb
@@ -8,7 +8,7 @@
 <% unless @edition_type == 'text'%>
 \newpage
   <% if @work.sc_manifest %>
-![<%= page.title %>](<%= page.sc_canvas.sc_resource_id.sub('/full/full/', '/full/800,/') %>)
+![<%= page.title %>](<%= page.sc_canvas.sc_resource_id %>)
   <% elsif page.ia_leaf %>
 ![<%= page.title %>](<%= page.ia_leaf.facsimile_url %>)
   <% else %>

--- a/app/views/shared/_work_tabs.html.slim
+++ b/app/views/shared/_work_tabs.html.slim
@@ -16,7 +16,7 @@
   :path => "#{versions_collection_work_path(@collection.owner, @collection, @work)}",
 }]
 
--if user_signed_in? && feature_enabled?(:download) && (@collection.user_download || current_user.like_owner?(@collection))
+-if user_signed_in? && ((feature_enabled?(:download) && @collection.user_download) || current_user.like_owner?(@collection))
   -tabs += [{\
     :name => t('.download'),
     :selected => 5,

--- a/app/views/user_mailer/bulk_export_finished.html.erb
+++ b/app/views/user_mailer/bulk_export_finished.html.erb
@@ -1,5 +1,11 @@
 <h2 style="color:#453939; margin:0; font-weight:normal;">Your export is ready!</h2>
 <p>
-  Your export has been processed and is ready at
-  <%= link_to('this link.', bulk_export_download_url(@bulk_export)) %>.
+  Your export of 
+  <%= @bulk_export.collection.title %> 
+  <% if @bulk_export.work %>
+    --
+    <%= @bulk_export.work.title %>
+  <% end %>
+  has been processed and is ready at
+  <%= link_to('this link.', dashboard_exports_path) %>.
 </p>

--- a/app/views/user_mailer/bulk_export_finished.html.erb
+++ b/app/views/user_mailer/bulk_export_finished.html.erb
@@ -7,5 +7,5 @@
     <%= @bulk_export.work.title %>
   <% end %>
   has been processed and is ready at
-  <%= link_to('this link.', dashboard_exports_path) %>.
+  <%= link_to('this link.', dashboard_exports_url) %>.
 </p>

--- a/app/views/work/download.html.slim
+++ b/app/views/work/download.html.slim
@@ -16,23 +16,6 @@
           p.nomargin Download a DOCX version of this work.
         .bulk-export_options
           span =button_to "Download", export_printable_path(@collection, @work), class: 'btnExport', params: { edition: 'text', format: 'doc', method: :get}
-      -if current_user.like_owner?(@collection)
-        li
-          .bulk-export_format
-            h5 Facing PDF
-            p.nomargin Download a PDF version of this work including images and text on facing pages.
-          .bulk-export_options
-            span =button_to "Download", export_printable_path(@collection, @work), class: 'btnExport', params: { edition: 'facing', format: 'pdf', method: :get}
-        li
-          .bulk-export_format
-            h5 Facing PDF (Bulk)
-            p.nomargin Download a PDF version of this work including images and text on facing pages.
-          .bulk-export_options
-            =form_for :bulk_export, url: bulk_export_create_for_work_path do |f| 
-              =f.hidden_field :collection_id, value: @collection.slug
-              =hidden_field_tag :work_id, @work.id
-              =f.hidden_field :table_csv_work, value: true
-              =f.submit 'Start'
 
 
     h2.nomargin Experiment
@@ -49,6 +32,70 @@
           p.nomargin Send the transcription of this work to Jason Davies' Word Trees visualizer for analysis.
         .bulk-export_options
           span =link_to("Analyze", "https://www.jasondavies.com/wordtree/?source=#{CGI.escape(iiif_work_export_plaintext_emended_url(@work.id))}", class: 'button')
+
+
+
+    -if current_user.like_owner?(@collection)
+      h2.nomargin Export
+      p Zip file export formats only accessible to project owners.
+      ul.bulk-export
+        li
+          .bulk-export_format
+            h5 Facing PDF
+            p.nomargin Download a PDF version of this work including images and text on facing pages.
+          .bulk-export_options
+            span =button_to "Download", export_printable_path(@collection, @work), class: 'btnExport', params: { edition: 'facing', format: 'pdf', method: :get}
+        li
+          .bulk-export_format
+            h5 Verbatim Plaintext
+            p.nomargin Export verbatim, plaintext transcripts as a zip file containing one file per page.
+          .bulk-export_options
+            =form_for :bulk_export, url: bulk_export_create_for_work_path do |f| 
+              =f.hidden_field :collection_id, value: @collection.slug
+              =hidden_field_tag :work_id, @work.id
+              =f.hidden_field :plaintext_verbatim_page, value: true
+              =f.submit 'Start'
+        li
+          .bulk-export_format
+            h5 Searchable Plaintext
+            p.nomargin Export plaintext transcripts optimized for full-text search as a zip file containing one file per page.
+          .bulk-export_options
+            =form_for :bulk_export, url: bulk_export_create_for_work_path do |f| 
+              =f.hidden_field :collection_id, value: @collection.slug
+              =hidden_field_tag :work_id, @work.id
+              =f.hidden_field :plaintext_searchable_page, value: true
+              =f.submit 'Start'
+        li
+          .bulk-export_format
+            h5 Expanded Plaintext
+            p.nomargin Export plaintext transcripts replacing verbatim text with canonical subject titles as a zip file containing one file per page.
+          .bulk-export_options
+            =form_for :bulk_export, url: bulk_export_create_for_work_path do |f| 
+              =f.hidden_field :collection_id, value: @collection.slug
+              =hidden_field_tag :work_id, @work.id
+              =f.hidden_field :plaintext_emended_page, value: true
+              =f.submit 'Start'
+        li
+          .bulk-export_format
+            h5 HTML
+            p.nomargin Export transcripts as a zip file containing one HTML file per page.
+          .bulk-export_options
+            =form_for :bulk_export, url: bulk_export_create_for_work_path do |f| 
+              =f.hidden_field :collection_id, value: @collection.slug
+              =hidden_field_tag :work_id, @work.id
+              =f.hidden_field :html_page, value: true
+              =f.submit 'Start'
+        li
+          .bulk-export_format
+            h5 Table/Field CSV
+            p.nomargin Export all tabular, spreadsheet, or field-based data as a single CSV file.
+          .bulk-export_options
+            =form_for :bulk_export, url: bulk_export_create_for_work_path do |f| 
+              =f.hidden_field :collection_id, value: @collection.slug
+              =hidden_field_tag :work_id, @work.id
+              =f.hidden_field :table_csv_work, value: true
+              =f.submit 'Start'
+
 
 -content_for :javascript
   javascript:

--- a/app/views/work/download.html.slim
+++ b/app/views/work/download.html.slim
@@ -48,8 +48,7 @@
               =f.hidden_field :collection_id, value: @collection.slug
               =hidden_field_tag :work_id, @work.id
               =f.hidden_field :facing_edition_work, value: true
-              =f.submit 'Start'
-            span =button_to "Download", export_printable_path(@collection, @work), class: 'btnExport', params: { edition: 'facing', format: 'pdf', method: :get}
+              =f.submit 'Export'
         li
           .bulk-export_format
             h5 Verbatim Plaintext
@@ -59,7 +58,7 @@
               =f.hidden_field :collection_id, value: @collection.slug
               =hidden_field_tag :work_id, @work.id
               =f.hidden_field :plaintext_verbatim_page, value: true
-              =f.submit 'Start'
+              =f.submit 'Export'
         li
           .bulk-export_format
             h5 Searchable Plaintext
@@ -69,7 +68,7 @@
               =f.hidden_field :collection_id, value: @collection.slug
               =hidden_field_tag :work_id, @work.id
               =f.hidden_field :plaintext_searchable_page, value: true
-              =f.submit 'Start'
+              =f.submit 'Export'
         li
           .bulk-export_format
             h5 Expanded Plaintext
@@ -79,7 +78,7 @@
               =f.hidden_field :collection_id, value: @collection.slug
               =hidden_field_tag :work_id, @work.id
               =f.hidden_field :plaintext_emended_page, value: true
-              =f.submit 'Start'
+              =f.submit 'Export'
         li
           .bulk-export_format
             h5 HTML
@@ -89,7 +88,7 @@
               =f.hidden_field :collection_id, value: @collection.slug
               =hidden_field_tag :work_id, @work.id
               =f.hidden_field :html_page, value: true
-              =f.submit 'Start'
+              =f.submit 'Export'
         li
           .bulk-export_format
             h5 Table/Field CSV
@@ -99,7 +98,7 @@
               =f.hidden_field :collection_id, value: @collection.slug
               =hidden_field_tag :work_id, @work.id
               =f.hidden_field :table_csv_work, value: true
-              =f.submit 'Start'
+              =f.submit 'Export'
 
 
 -content_for :javascript

--- a/app/views/work/download.html.slim
+++ b/app/views/work/download.html.slim
@@ -44,6 +44,11 @@
             h5 Facing PDF
             p.nomargin Download a PDF version of this work including images and text on facing pages.
           .bulk-export_options
+            =form_for :bulk_export, url: bulk_export_create_for_work_path do |f| 
+              =f.hidden_field :collection_id, value: @collection.slug
+              =hidden_field_tag :work_id, @work.id
+              =f.hidden_field :facing_edition_work, value: true
+              =f.submit 'Start'
             span =button_to "Download", export_printable_path(@collection, @work), class: 'btnExport', params: { edition: 'facing', format: 'pdf', method: :get}
         li
           .bulk-export_format

--- a/app/views/work/download.html.slim
+++ b/app/views/work/download.html.slim
@@ -17,12 +17,22 @@
         .bulk-export_options
           span =button_to "Download", export_printable_path(@collection, @work), class: 'btnExport', params: { edition: 'text', format: 'doc', method: :get}
       -if current_user.like_owner?(@collection)
-      li
-        .bulk-export_format
-          h5 Facing PDF
-          p.nomargin Download a PDF version of this work including images and text on facing pages.
-        .bulk-export_options
-          span =button_to "Download", export_printable_path(@collection, @work), class: 'btnExport', params: { edition: 'facing', format: 'pdf', method: :get}
+        li
+          .bulk-export_format
+            h5 Facing PDF
+            p.nomargin Download a PDF version of this work including images and text on facing pages.
+          .bulk-export_options
+            span =button_to "Download", export_printable_path(@collection, @work), class: 'btnExport', params: { edition: 'facing', format: 'pdf', method: :get}
+        li
+          .bulk-export_format
+            h5 Facing PDF (Bulk)
+            p.nomargin Download a PDF version of this work including images and text on facing pages.
+          .bulk-export_options
+            =form_for :bulk_export, url: bulk_export_create_for_work_path do |f| 
+              =f.hidden_field :collection_id, value: @collection.slug
+              =hidden_field_tag :work_id, @work.id
+              =f.hidden_field :table_csv_work, value: true
+              =f.submit 'Start'
 
 
     h2.nomargin Experiment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -176,6 +176,7 @@ Fromthepage::Application.routes.draw do
     get 'watchlist' => 'dashboard#watchlist'
     get 'startproject', to: 'dashboard#startproject'
     get 'summary', to: 'dashboard#summary'
+    get 'exports', to: 'dashboard#exports'
     get 'collaborator_time_export', to: 'dashboard#collaborator_time_export'
     post 'new_upload', to: 'dashboard#new_upload'
     post 'create_work', to: 'dashboard#create_work'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,6 +151,7 @@ Fromthepage::Application.routes.draw do
   scope 'bulk_export', as: 'bulk_export' do
     get ':collection_id/new', to: 'bulk_export#new', as: 'new'
     post ':collection_id/new', to: 'bulk_export#create', as: 'create'
+    post ':collection_id/work_create', to: 'bulk_export#create_for_work', as: 'create_for_work'
     get '/', to: 'bulk_export#index', as: 'index'
     get ':bulk_export_id', to: 'bulk_export#show', as: 'show'
     get ':bulk_export_id/download', to: 'bulk_export#download', as: 'download'

--- a/db/migrate/20210615223422_add_work_id_to_bulk_export.rb
+++ b/db/migrate/20210615223422_add_work_id_to_bulk_export.rb
@@ -1,0 +1,5 @@
+class AddWorkIdToBulkExport < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :bulk_exports, :work, null: true, foreign_key: true
+  end
+end

--- a/db/migrate/20210623214318_add_facing_pdf_to_bulk_export.rb
+++ b/db/migrate/20210623214318_add_facing_pdf_to_bulk_export.rb
@@ -1,0 +1,5 @@
+class AddFacingPdfToBulkExport < ActiveRecord::Migration[6.0]
+  def change
+    add_column :bulk_exports, :facing_edition_work, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_27_152944) do
+ActiveRecord::Schema.define(version: 2021_06_15_223422) do
 
   create_table "ahoy_activity_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "date"
@@ -18,8 +18,8 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.integer "collection_id"
     t.string "activity"
     t.integer "minutes"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["date", "collection_id", "user_id", "activity"], name: "ahoy_activity_day_user_collection", unique: true
   end
 
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.integer "user_id"
     t.string "name"
     t.text "properties"
-    t.timestamp "time"
+    t.datetime "time"
     t.index ["name", "time"], name: "index_ahoy_events_on_name_and_time"
     t.index ["user_id", "name"], name: "index_ahoy_events_on_user_id_and_name"
     t.index ["visit_id", "name"], name: "index_ahoy_events_on_visit_id_and_name"
@@ -45,8 +45,8 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
 
   create_table "article_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
-    t.text "source_text"
-    t.text "xml_text"
+    t.text "source_text", size: :medium
+    t.text "xml_text", size: :medium
     t.integer "user_id"
     t.integer "article_id"
     t.integer "version", default: 0
@@ -57,10 +57,10 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
 
   create_table "articles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
-    t.text "source_text"
+    t.text "source_text", size: :medium
     t.datetime "created_on"
     t.integer "lock_version", default: 0
-    t.text "xml_text"
+    t.text "xml_text", size: :medium
     t.string "graph_image"
     t.integer "collection_id"
     t.decimal "latitude", precision: 7, scale: 5
@@ -95,8 +95,10 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "work_metadata_csv", default: false
+    t.integer "work_id"
     t.index ["collection_id"], name: "index_bulk_exports_on_collection_id"
     t.index ["user_id"], name: "index_bulk_exports_on_user_id"
+    t.index ["work_id"], name: "index_bulk_exports_on_work_id"
   end
 
   create_table "categories", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -122,15 +124,15 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
   create_table "clientperf_results", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "clientperf_uri_id"
     t.integer "milliseconds"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["clientperf_uri_id"], name: "index_clientperf_results_on_clientperf_uri_id"
   end
 
   create_table "clientperf_uris", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "uri"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["uri"], name: "index_clientperf_uris_on_uri"
   end
 
@@ -142,16 +144,16 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
   create_table "collection_owners", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.integer "collection_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "collections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.integer "owner_user_id"
     t.datetime "created_on"
-    t.text "intro_block"
-    t.string "footer_block", limit: 2000
+    t.text "intro_block", size: :medium
+    t.text "footer_block", size: :medium
     t.boolean "restricted", default: false
     t.string "picture"
     t.boolean "supports_document_sets", default: false
@@ -165,18 +167,32 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.boolean "field_based", default: false
     t.boolean "voice_recognition", default: false
     t.string "language"
-    t.string "license_key"
     t.string "text_language"
+    t.string "license_key"
     t.integer "pct_completed"
     t.string "default_orientation"
     t.boolean "is_active", default: true
-    t.integer "next_untranscribed_page_id"
     t.integer "works_count", default: 0
+    t.integer "next_untranscribed_page_id"
     t.boolean "api_access", default: false
     t.boolean "facets_enabled", default: false
     t.boolean "user_download", default: false
     t.index ["owner_user_id"], name: "index_collections_on_owner_user_id"
+    t.index ["restricted"], name: "index_collections_on_restricted"
     t.index ["slug"], name: "index_collections_on_slug", unique: true
+  end
+
+  create_table "comments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "parent_id"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.integer "commentable_id", default: 0, null: false
+    t.string "commentable_type", default: "", null: false
+    t.integer "depth"
+    t.string "title"
+    t.text "body", size: :medium
+    t.string "comment_type", limit: 10, default: "annotation"
+    t.string "comment_status", limit: 10
   end
 
   create_table "deeds", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -187,13 +203,15 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.integer "article_id"
     t.integer "user_id"
     t.integer "note_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer "visit_id"
     t.string "prerender", limit: 2047
     t.string "prerender_mailer", limit: 2047
     t.boolean "is_public", default: true
     t.index ["article_id"], name: "index_deeds_on_article_id"
+    t.index ["collection_id", "user_id", "created_at"], name: "index_deeds_on_collection_id_user_id_created_at"
+    t.index ["collection_id", "user_id"], name: "index_deeds_on_collection_id_user_id"
     t.index ["collection_id"], name: "index_deeds_on_collection_id"
     t.index ["created_at"], name: "index_deeds_on_created_at"
     t.index ["note_id"], name: "index_deeds_on_note_id"
@@ -214,13 +232,13 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.string "title"
     t.text "description"
     t.string "picture"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string "slug"
     t.integer "pct_completed"
     t.string "default_orientation"
-    t.integer "next_untranscribed_page_id"
     t.integer "works_count", default: 0
+    t.integer "next_untranscribed_page_id"
     t.index ["collection_id"], name: "index_document_sets_on_collection_id"
     t.index ["owner_user_id"], name: "index_document_sets_on_owner_user_id"
     t.index ["slug"], name: "index_document_sets_on_slug", unique: true
@@ -236,8 +254,8 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.integer "user_id"
     t.integer "collection_id"
     t.string "file"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string "status", default: "new"
     t.boolean "preserve_titles", default: false
     t.boolean "ocr", default: false
@@ -276,15 +294,14 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.integer "reporter_user_id"
     t.integer "auditor_user_id"
     t.datetime "content_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["article_version_id"], name: "index_flags_on_article_version_id"
     t.index ["auditor_user_id"], name: "index_flags_on_auditor_user_id"
     t.index ["author_user_id"], name: "index_flags_on_author_user_id"
     t.index ["note_id"], name: "index_flags_on_note_id"
     t.index ["page_version_id"], name: "index_flags_on_page_version_id"
     t.index ["reporter_user_id"], name: "index_flags_on_reporter_user_id"
-    t.index ["status"], name: "index_flags_on_status"
   end
 
   create_table "friendly_id_slugs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -307,8 +324,8 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.integer "leaf_number"
     t.string "page_number"
     t.string "page_type"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.text "ocr_text"
     t.index ["page_id"], name: "index_ia_leaves_on_page_id"
   end
@@ -330,8 +347,8 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.string "sponsor"
     t.string "image_count"
     t.integer "title_leaf"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string "image_format", default: "jp2"
     t.string "archive_format", default: "zip"
     t.string "scandata_file"
@@ -350,15 +367,15 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
 
   create_table "notes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
-    t.text "body"
+    t.text "body", size: :medium
     t.integer "user_id"
     t.integer "collection_id"
     t.integer "work_id"
     t.integer "page_id"
     t.integer "parent_id"
     t.integer "depth"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["page_id"], name: "index_notes_on_page_id"
   end
 
@@ -369,8 +386,73 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.boolean "owner_stats", default: false
     t.boolean "user_activity", default: true
     t.integer "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "oai_repositories", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "url"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "oai_sets", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "set_spec"
+    t.string "repository_url"
+    t.integer "user_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "omeka_collections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "omeka_id"
+    t.integer "collection_id"
+    t.string "title"
+    t.string "description"
+    t.integer "omeka_site_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "omeka_files", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "omeka_id"
+    t.integer "omeka_item_id"
+    t.string "mime_type"
+    t.string "fullsize_url"
+    t.string "thumbnail_url"
+    t.string "original_filename"
+    t.integer "omeka_order"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "page_id"
+    t.index ["omeka_id"], name: "index_omeka_files_on_omeka_id"
+  end
+
+  create_table "omeka_items", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "title"
+    t.string "subject"
+    t.string "description"
+    t.string "rights"
+    t.string "creator"
+    t.string "format"
+    t.string "coverage"
+    t.integer "omeka_site_id"
+    t.integer "omeka_id"
+    t.string "omeka_url"
+    t.integer "omeka_collection_id"
+    t.integer "user_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "work_id"
+  end
+
+  create_table "omeka_sites", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "title"
+    t.string "api_url"
+    t.string "api_key"
+    t.integer "user_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "page_article_links", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -388,16 +470,16 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.string "view"
     t.string "tag"
     t.string "description"
-    t.text "html"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.text "html", size: :medium
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["controller", "view"], name: "index_page_blocks_on_controller_and_view"
   end
 
   create_table "page_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
-    t.text "transcription"
-    t.text "xml_transcription"
+    t.text "transcription", size: :medium
+    t.text "xml_transcription", size: :medium
     t.integer "user_id"
     t.integer "page_id"
     t.integer "work_version", default: 0
@@ -411,7 +493,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
 
   create_table "pages", id: :integer, options: "ENGINE=MyISAM DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
-    t.text "source_text"
+    t.text "source_text", size: :medium
     t.string "base_image"
     t.integer "base_width"
     t.integer "base_height"
@@ -420,7 +502,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.datetime "created_on"
     t.integer "position"
     t.integer "lock_version", default: 0
-    t.text "xml_text"
+    t.text "xml_text", size: :medium
     t.integer "page_version_id"
     t.string "status"
     t.text "source_translation"
@@ -428,7 +510,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.text "search_text"
     t.string "translation_status"
     t.text "metadata"
-    t.timestamp "edit_started_at"
+    t.datetime "edit_started_at"
     t.integer "edit_started_by_user_id"
     t.index ["edit_started_by_user_id"], name: "index_pages_on_edit_started_by_user_id"
     t.index ["search_text"], name: "pages_search_text_index", type: :fulltext
@@ -443,6 +525,11 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.index ["section_id", "page_id"], name: "index_pages_sections_on_section_id_and_page_id"
   end
 
+  create_table "plugin_schema_info", id: false, options: "ENGINE=MyISAM DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "plugin_name"
+    t.integer "version"
+  end
+
   create_table "sc_canvases", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "sc_id"
     t.integer "sc_manifest_id"
@@ -450,8 +537,8 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.string "sc_canvas_id"
     t.string "sc_canvas_label"
     t.string "sc_service_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer "height"
     t.integer "width"
     t.string "sc_resource_id"
@@ -462,8 +549,8 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
 
   create_table "sc_collections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "collection_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string "at_id"
     t.integer "parent_id"
     t.string "label"
@@ -474,12 +561,12 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.integer "work_id"
     t.integer "sc_collection_id"
     t.string "sc_id"
-    t.text "label", size: :tiny
+    t.text "label"
     t.text "metadata"
     t.string "first_sequence_id"
     t.string "first_sequence_label"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string "at_id"
     t.integer "collection_id"
     t.index ["sc_collection_id"], name: "index_sc_manifests_on_sc_collection_id"
@@ -491,16 +578,16 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.integer "depth"
     t.integer "position"
     t.integer "work_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["work_id"], name: "index_sections_on_work_id"
   end
 
   create_table "sessions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "session_id", null: false
-    t.text "data"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "session_id", default: "", null: false
+    t.text "data", size: :medium
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["session_id"], name: "index_sessions_on_session_id"
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
@@ -523,8 +610,8 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.string "header"
     t.text "content"
     t.integer "row"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer "transcription_field_id"
     t.index ["page_id"], name: "index_table_cells_on_page_id"
     t.index ["section_id"], name: "index_table_cells_on_section_id"
@@ -536,8 +623,8 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.integer "page_id"
     t.integer "position"
     t.text "source"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["page_id"], name: "index_tex_figures_on_page_id"
   end
 
@@ -601,6 +688,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.string "preferred_locale"
     t.string "api_key"
     t.string "picture"
+    t.index ["deleted"], name: "index_users_on_deleted"
     t.index ["login"], name: "index_users_on_login"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["slug"], name: "index_users_on_slug", unique: true
@@ -632,7 +720,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.string "utm_term"
     t.string "utm_content"
     t.string "utm_campaign"
-    t.timestamp "started_at"
+    t.datetime "started_at"
     t.index ["user_id"], name: "index_visits_on_user_id"
     t.index ["visit_token"], name: "index_visits_on_visit_token", unique: true
   end
@@ -662,8 +750,8 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.integer "transcribed_pages"
     t.integer "annotated_pages"
     t.integer "total_pages"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer "blank_pages", default: 0
     t.integer "incomplete_pages", default: 0
     t.integer "corrected_pages"
@@ -678,17 +766,17 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
 
   create_table "works", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
-    t.string "description", limit: 4000
+    t.text "description", size: :medium
     t.datetime "created_on"
     t.integer "owner_user_id"
     t.boolean "restrict_scribes", default: false
     t.integer "transcription_version", default: 0
-    t.text "physical_description"
-    t.text "document_history"
-    t.text "permission_description"
+    t.text "physical_description", size: :medium
+    t.text "document_history", size: :medium
+    t.text "permission_description", size: :medium
     t.string "location_of_composition"
     t.string "author"
-    t.text "transcription_conventions"
+    t.text "transcription_conventions", size: :medium
     t.integer "collection_id"
     t.boolean "scribes_can_edit_titles", default: false
     t.boolean "supports_translation", default: false
@@ -701,7 +789,6 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.string "identifier"
     t.integer "next_untranscribed_page_id"
     t.text "original_metadata"
-    t.string "uploaded_filename"
     t.string "genre"
     t.string "source_location"
     t.string "source_collection_name"
@@ -709,6 +796,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
     t.boolean "in_scope", default: true
     t.text "editorial_notes"
     t.string "document_date"
+    t.string "uploaded_filename"
     t.index ["collection_id"], name: "index_works_on_collection_id"
     t.index ["owner_user_id"], name: "index_works_on_owner_user_id"
     t.index ["slug"], name: "index_works_on_slug", unique: true
@@ -716,6 +804,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_152944) do
 
   add_foreign_key "bulk_exports", "collections"
   add_foreign_key "bulk_exports", "users"
+  add_foreign_key "bulk_exports", "works"
   add_foreign_key "cdm_bulk_imports", "users"
   add_foreign_key "editor_buttons", "collections"
   add_foreign_key "facet_configs", "metadata_coverages"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_15_223422) do
+ActiveRecord::Schema.define(version: 2021_06_23_214318) do
 
   create_table "ahoy_activity_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "date"
@@ -96,6 +96,7 @@ ActiveRecord::Schema.define(version: 2021_06_15_223422) do
     t.datetime "updated_at", null: false
     t.boolean "work_metadata_csv", default: false
     t.integer "work_id"
+    t.boolean "facing_edition_work"
     t.index ["collection_id"], name: "index_bulk_exports_on_collection_id"
     t.index ["user_id"], name: "index_bulk_exports_on_user_id"
     t.index ["work_id"], name: "index_bulk_exports_on_work_id"

--- a/lib/tasks/bulk_export.rake
+++ b/lib/tasks/bulk_export.rake
@@ -18,7 +18,8 @@ namespace :fromthepage do
     bulk_export = BulkExport.find bulk_export_id
     
     print "found bulk_export for \n\tuser=#{bulk_export.user.login}, \n\tfrom collection=#{bulk_export.collection.title}\n"
-    
+    pp bulk_export.attributes
+        
     bulk_export.status = BulkExport::Status::PROCESSING
     bulk_export.save
     


### PR DESCRIPTION
This PR attempts the following:
* Provide an easier way for project owners to launch exports (issue #2395)
* Improve the usability for bulk exports (issue #2426)
* Make work-specific field/table CSV exports run in the background (TNA)
* Fix problems with email clients that won't download zip files (issue #2551)
* Deliver the facing edition export feature by backgrounding it (issue #2436)

To test:
* The download tab should be available to project owners regardless of whether the feature flag is enabled
* If the feature flag is enabled and the collection allows, it, non-owners should see the download tab but not see the new zip export flags
* The bulk export UI should be more usable; launching a bulk export should send the user to a new "exports" tab.
* Work-specific bulk exports launched from the download tab should work
* Emails about work-specific bulk exports and collection exports should send the user to their exports tab.