### PR TITLE
Preserve edit area focus

### DIFF
--- a/app/views/shared/_osd_div.html.slim
+++ b/app/views/shared/_osd_div.html.slim
@@ -31,6 +31,8 @@
   javascript:
     OpenSeadragon.DEFAULT_SETTINGS.timeout = 60000;
     var viewer = 'foo'; // global variable
+    var lastFocused = null; // last focused field in the edit area
+
     $(function() {
       viewer = OpenSeadragon({
         id: "image_container",
@@ -77,6 +79,20 @@
         } else {
           viewer.raiseEvent('reset-bounds');
         }
+      });
+
+      viewer.addHandler('canvas-press', function() {
+        lastFocused = $('.page-editarea :focus')[0];
+      });
+
+      viewer.addHandler('canvas-release', function() {
+        setTimeout(function() {
+          if (lastFocused) {
+            lastFocused.focus();
+            lastFocused.setSelectionRange(lastFocused.selectionStart, lastFocused.selectionEnd);
+            lastFocused = null;
+          }
+        }, 100);
       });
 
       $('[data-filter]').on('input', updateFilters);


### PR DESCRIPTION
To be honest, I wasn't sure it is possible so it took some time to research, but I think the final result is fine.
This is how it works:
1. When user press a mouse button (or touch started) in the OSD area it tries to find any focused element inside the edit area. It could be an input, text area, CodeMirror editor, spreadsheet cell.
2. If a focused element found, it will store in a variable until the mouse button (or touch) released.
3. Once released (means, user finished interaction with OSD), it will restore the focus to the element. It will even restore the caret position and text selection (if something was selected).

This should work fine for image panning, accidental clicks on image area, and OSD toolbar buttons like zoom in, zoom out (except our custom filters button)