### PR TITLE
check intercom variable not empty

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -294,7 +294,7 @@ class Work < ApplicationRecord
   end
 
   def alert_intercom
-    if (defined? INTERCOM_ACCESS_TOKEN) && INTERCOM_ACCESS_TOKEN
+    if (defined? INTERCOM_ACCESS_TOKEN) && INTERCOM_ACCESS_TOKEN != ''
       if self.owner.owner_works.count == 1
         intercom=Intercom::Client.new(token:INTERCOM_ACCESS_TOKEN)
         intercom.events.create(event_name: "first-upload", email: self.owner.email, created_at: Time.now.to_i)


### PR DESCRIPTION
When INTERCOM_ACCESS_TOKEN = '' this code fails. This check ensures there's actually value set.