### PR TITLE
Fixes #2676 by deleting work-level exports when deleting a work

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -21,6 +21,7 @@ class Work < ApplicationRecord
   has_many :document_set_works
   has_many :document_sets, through: :document_set_works
   has_one :work_facet, :dependent => :destroy
+  has_many :bulk_exports, :dependent => :delete_all
 
   after_save :update_statistic
   after_save :update_next_untranscribed_pages


### PR DESCRIPTION
When we delete a work that has had work-level bulk exports, we need to delete the (child) bulk export records as well.