### PR TITLE
Fix OSD prev / next controls

### DIFF
--- a/app/views/shared/_osd_div.html.slim
+++ b/app/views/shared/_osd_div.html.slim
@@ -24,8 +24,9 @@
         span.filter_label Threshold
         =range_field_tag 'filter-threshold', 0, min: -10, max: 10, step: 1, 'data-filter': 'threshold'
         span.filter_value 0
-  a#osd_prev =svg_symbol "#icon-arrow-left", class: 'icon'
-  a#osd_next =svg_symbol "#icon-arrow-right", class: 'icon'
+  -if @page.nil?
+    a#osd_prev =svg_symbol "#icon-arrow-left", class: 'icon'
+    a#osd_next =svg_symbol "#icon-arrow-right", class: 'icon'
 
 .image-container(id="image_container")
 


### PR DESCRIPTION
Re #2792

Seems like I can't figure out how to enable the feature. What I did:
1. Took the latest `development` branch (it seems that the 2096 branch is already merged into)
2. Enabled the feature by the URL provided
3. Enabled the Metadata Description option in the settings / right column
4. In the collection settings I now see the Metadata Fields tab, there I've chosen Users only create metadata, added three fields and saved
5. When opening the collection page, I don't see the Describe tab, and I don't see the broken icons on the Overview tab.

This is my settings page for the collection:
![image](https://user-images.githubusercontent.com/4656448/138546137-d8bc7f5c-512b-4423-89f4-0f1b42bd7046.png)

This is the overview tab for a page from this collection:
![image](https://user-images.githubusercontent.com/4656448/138546271-11f3c6b4-3507-4d2f-a14e-bbc294f3390a.png)

----------------------------------

Nevertheless, I believe there also should be multiple images for a single page to see the prev / next controls, and I don't have it in my local environment. So I simply enabled the `showReferenceStrip` and `sequenceMode` options to fix the buttons. This is how it should look now:

![image](https://user-images.githubusercontent.com/4656448/138548799-ff398168-e499-4177-a67b-b9a5b08d9466.png)
