### PR TITLE
Export document sets for #2504

### DIFF
--- a/app/controllers/bulk_export_controller.rb
+++ b/app/controllers/bulk_export_controller.rb
@@ -12,12 +12,22 @@ class BulkExportController < ApplicationController
 
   def new
     @bulk_export = BulkExport.new
-    @bulk_export.collection = @collection
+    if @collection.is_a? DocumentSet
+      @bulk_export.document_set = @collection
+      @bulk_export.collection = @collection.collection    
+    else
+      @bulk_export.collection = @collection
+    end
   end
 
   def create
     @bulk_export = BulkExport.new(bulk_export_params)
-    @bulk_export.collection = @collection
+    if @collection.is_a? DocumentSet
+      @bulk_export.document_set = @collection
+      @bulk_export.collection = @collection.collection    
+    else
+      @bulk_export.collection = @collection
+    end
     @bulk_export.user = current_user
     @bulk_export.status = BulkExport::Status::NEW
 
@@ -31,7 +41,12 @@ class BulkExportController < ApplicationController
 
   def create_for_work
     @bulk_export = BulkExport.new(bulk_export_params)
-    @bulk_export.collection = @collection
+    if @collection.is_a? DocumentSet
+      @bulk_export.document_set = @collection
+      @bulk_export.collection = @collection.collection    
+    else
+      @bulk_export.collection = @collection
+    end
     @bulk_export.work = @work
     @bulk_export.user = current_user
     @bulk_export.status = BulkExport::Status::NEW

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -8,7 +8,7 @@ class ExportController < ApplicationController
   layout Proc.new { |controller| controller.request.xhr? ? false : nil } #, :only => [:update, :update_profile]
 
   def index
-    @collection = Collection.friendly.find(params[:collection_id])
+    # @collection = Collection.friendly.find(params[:collection_id])
     #check if there are any translated works in the collection
     if @collection.works.where(supports_translation: true).exists?
       @header = "Translated"

--- a/app/models/bulk_export.rb
+++ b/app/models/bulk_export.rb
@@ -4,6 +4,7 @@ class BulkExport < ApplicationRecord
 
   belongs_to :user
   belongs_to :collection
+  belongs_to :document_set, optional: true
   belongs_to :work, optional: true
 
 
@@ -33,7 +34,9 @@ class BulkExport < ApplicationRecord
     begin
       if self.work
         works=[self.work]
-      else
+      elsif self.document_set
+        works = self.document_set.works.includes(pages: [:notes, {page_versions: :user}])
+      elsif
         works = Work.includes(pages: [:notes, {page_versions: :user}]).where(collection_id: self.collection.id)
       end
 

--- a/app/models/document_set.rb
+++ b/app/models/document_set.rb
@@ -19,6 +19,8 @@ class DocumentSet < ApplicationRecord
 
   has_and_belongs_to_many :collaborators, :class_name => 'User', :join_table => :document_set_collaborators
 
+  has_many :bulk_exports, :dependent => :delete_all
+
   after_save :set_next_untranscribed_page
 
   validates :title, presence: true, length: { minimum: 3, maximum: 255 }
@@ -90,6 +92,19 @@ class DocumentSet < ApplicationRecord
   def editor_buttons
     self.collection.editor_buttons
   end
+
+  def export_subject_index_as_csv
+    subject_link = SubjectExporter::Exporter.new(self)
+
+    subject_link.export
+  end
+
+  def export_subject_details_as_csv
+    subjects = SubjectDetailsExporter::Exporter.new(self)
+
+    subjects.export
+  end
+
 
   def articles
     Article.joins(:pages).where(pages: {work_id: self.works.ids}).distinct

--- a/app/views/dashboard/exports.html.slim
+++ b/app/views/dashboard/exports.html.slim
@@ -22,6 +22,9 @@
             td
               -if bulk_export.collection.present?
                 =link_to(bulk_export.collection.title, collection_url(bulk_export.user, bulk_export.collection))
+              -if bulk_export.document_set.present?
+                br
+                =link_to(bulk_export.document_set.title, collection_url(bulk_export.user, bulk_export.document_set.slug))
               -if bulk_export.work.present?
                 br
                 =link_to(bulk_export.work.title, collection_read_work_path(bulk_export.collection.owner, bulk_export.collection, bulk_export.work))

--- a/app/views/export/index.html.slim
+++ b/app/views/export/index.html.slim
@@ -3,14 +3,14 @@
 h2.nomargin =t('.export_all_works')
 p.big
   span.fright(style="margin-left: 30px")
-    =link_to(bulk_export_new_path(:collection_id => @collection.id), class: 'button btnExport', id: 'btnExportAll')
+    =link_to(bulk_export_new_path(:collection_id => @collection.slug), class: 'button btnExport', id: 'btnExportAll')
       =svg_symbol '#icon-export', class: 'icon'
       span =t('.export_all_works')
 
   span =t('.export_all_works_description')
 
 
--if ContentdmTranslator.collection_is_cdm?(@collection) && @collection.text_entry?
+-if ContentdmTranslator.collection_is_cdm?(@collection) && @collection.text_entry? && @collection.is_a?(Collection)
   h2 =t('.export_to_contentdm')
   p.big
     span.fright(style="margin-left: 30px")
@@ -86,28 +86,29 @@ p.big
     h2 =t('.export_subject_index')
     p.big
       span.fright(style="margin-left: 30px")
-        =link_to(export_subject_csv_path(:collection_id => @collection.id), class: 'button btnExport', id: 'btnCsvExport')
+        =link_to(export_subject_csv_path(:collection_id => @collection.slug), class: 'button btnExport', id: 'btnCsvExport')
           =svg_symbol '#icon-export', class: 'icon'
           span =t('.export_subjects_as_csv')
       span =t('.export_subject_index_description')
     p.big
       span.fright(style="margin-left: 30px")
-        =link_to(export_subject_details_csv_path(:collection_id => @collection.id), class: 'button btnExport', id: 'btnCsvDetailExport')
+        =link_to(export_subject_details_csv_path(:collection_id => @collection.slug), class: 'button btnExport', id: 'btnCsvDetailExport')
           =svg_symbol '#icon-export', class: 'icon'
           span =t('.export_subject_details_as_csv')
       span =t('.export_subject_details_description')
-    p.big
-      span.fright(style="margin-left: 30px")
-        =link_to(export_subject_coocurrence_csv_path(:collection_id => @collection.id), class: 'button btnExport', id: 'btnCsvCoocurrenceExport')
-          =svg_symbol '#icon-export', class: 'icon'
-          span =t('.export_subject_coocurrence_as_csv')
-      span =t('.export_subject_coocurrence_description')
+    -if @collection.is_a? Collection
+      p.big
+        span.fright(style="margin-left: 30px")
+          =link_to(export_subject_coocurrence_csv_path(:collection_id => @collection.slug), class: 'button btnExport', id: 'btnCsvCoocurrenceExport')
+            =svg_symbol '#icon-export', class: 'icon'
+            span =t('.export_subject_coocurrence_as_csv')
+        span =t('.export_subject_coocurrence_description')
 
   -unless @table_export.blank?
     h2 =t('.export_all_tables')
     p.big
       span.fright(style="margin-left: 30px")
-        =link_to(export_export_all_tables_path(:collection_id => @collection.id), class: 'button btnExport', id: 'btnExportTables')
+        =link_to(export_export_all_tables_path(:collection_id => @collection.slug), class: 'button btnExport', id: 'btnExportTables')
           =svg_symbol '#icon-export', class: 'icon'
           span =t('.export_all_table_data_as_csv')
       span =t('.export_all_tables_description')

--- a/app/views/shared/_collection_tabs.html.slim
+++ b/app/views/shared/_collection_tabs.html.slim
@@ -34,11 +34,7 @@
       :name => t('.settings'),
       :selected => 5,
       :path => "#{edit_collection_path(@collection.owner, @collection)}",
-    },{\
-        :name => t('.export'),
-        :selected => 6,
-        :path => "#{collection_export_path(@collection.owner, @collection)}",
-     }]
+    }]
      
   -else
     -tabs += [{\
@@ -46,6 +42,12 @@
     :selected => 5,
     :path => "#{collection_settings_path(@collection.owner, @collection)}",
     }]
+
+  -tabs += [{\
+        :name => t('.export'),
+        :selected => 6,
+        :path => "#{collection_export_path(@collection.owner, @collection)}",
+     }]
     
   -if @collection.is_a?(Collection) && @collection.active?
     -tabs += [{\

--- a/app/views/user_mailer/bulk_export_finished.html.erb
+++ b/app/views/user_mailer/bulk_export_finished.html.erb
@@ -2,6 +2,10 @@
 <p>
   Your export of 
   <%= @bulk_export.collection.title %> 
+  <% if @bulk_export.document_set %>
+    --
+    <%= @bulk_export.document_set.title %>
+  <% end %>
   <% if @bulk_export.work %>
     --
     <%= @bulk_export.work.title %>

--- a/db/migrate/20211102194016_add_document_set_to_bulk_export.rb
+++ b/db/migrate/20211102194016_add_document_set_to_bulk_export.rb
@@ -1,0 +1,5 @@
+class AddDocumentSetToBulkExport < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :bulk_exports, :document_set, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_22_134925) do
+ActiveRecord::Schema.define(version: 2021_11_02_194016) do
 
   create_table "ahoy_activity_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "date"
@@ -100,7 +100,9 @@ ActiveRecord::Schema.define(version: 2021_10_22_134925) do
     t.boolean "text_pdf_work"
     t.boolean "text_docx_work"
     t.boolean "static"
+    t.integer "document_set_id"
     t.index ["collection_id"], name: "index_bulk_exports_on_collection_id"
+    t.index ["document_set_id"], name: "index_bulk_exports_on_document_set_id"
     t.index ["user_id"], name: "index_bulk_exports_on_user_id"
     t.index ["work_id"], name: "index_bulk_exports_on_work_id"
   end
@@ -835,6 +837,7 @@ ActiveRecord::Schema.define(version: 2021_10_22_134925) do
   end
 
   add_foreign_key "bulk_exports", "collections"
+  add_foreign_key "bulk_exports", "document_sets"
   add_foreign_key "bulk_exports", "users"
   add_foreign_key "bulk_exports", "works"
   add_foreign_key "cdm_bulk_imports", "users"


### PR DESCRIPTION
This adds the export tab to document sets.  It does not implement set-specific coocurrence or CONTENTdm exports, but should support everything else.