### PR TITLE
2875 lines or records stats

### DIFF
--- a/app/models/collection_statistic.rb
+++ b/app/models/collection_statistic.rb
@@ -7,6 +7,10 @@ module CollectionStatistic
     Collection.count_by_sql("SELECT COUNT(*) FROM pages p INNER JOIN works w ON p.work_id = w.id WHERE w.collection_id = #{self.id}")
   end
 
+  def line_count
+    self.works.includes(:work_statistic).sum(:line_count)
+  end
+
   def subject_count(last_days=nil)
     self.articles.where("#{timeframe_clause(last_days, 'created_on')}").count
   end
@@ -58,7 +62,8 @@ module CollectionStatistic
       :subjects     => self.articles.where(timeframe(start_date, end_date, 'created_on')).count,
       :mentions     => self.articles.joins(:page_article_links).where(timeframe(start_date, end_date, 'page_article_links.created_on')).count,
       :contributors => self.deeds.where(timeframe(start_date, end_date)).select('user_id').distinct.count,
-      :descriptions => self.works.where(description_status: Work::DescriptionStatus::DESCRIBED).count
+      :descriptions => self.works.where(description_status: Work::DescriptionStatus::DESCRIBED).count,
+      :line_count   => self.line_count
     }
 
     stats.merge(deeds)

--- a/app/models/document_set_statistic.rb
+++ b/app/models/document_set_statistic.rb
@@ -11,6 +11,11 @@ module DocumentSetStatistic
     pages.count
   end
 
+  def line_count
+    self.works.includes(:work_statistic).sum(:line_count)
+  end
+
+
   def subject_count(last_days=nil)
     self.articles.where("#{last_days_clause(last_days, 'articles.created_on')}").count
   end
@@ -64,6 +69,7 @@ module DocumentSetStatistic
     end
     return clause
   end
+
   def get_stats_hash(start_date=nil, end_date=nil)
     deeds = DeedType.generate_zero_counts_hash
     deeds.merge!(self.deeds.where(timeframe(start_date, end_date)).group('deed_type').count)
@@ -75,6 +81,7 @@ module DocumentSetStatistic
       :subjects     => self.articles.where(timeframe(start_date, end_date, 'articles.created_on')).count,
       :mentions     => self.articles.joins(:page_article_links).where(timeframe(start_date, end_date, 'page_article_links.created_on')).count,
       :contributors => self.deeds.where(timeframe(start_date, end_date)).select('user_id').distinct.count,
+      :line_count   => self.line_count
     }
 
     stats.merge(deeds)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -8,6 +8,7 @@ class Page < ApplicationRecord
   before_update :validate_blank_page
   before_update :process_source
   before_update :populate_search
+  before_save :update_line_count
   validate :validate_source, :validate_source_translation
 
   belongs_to :work, optional: true
@@ -272,6 +273,24 @@ class Page < ApplicationRecord
     self.tex_figures.each do |tex_figure|
       if tex_figure.changed?
         tex_figure.save!
+      end
+    end
+  end
+
+  def update_line_count
+    self.line_count = calculate_line_count
+  end
+
+  def calculate_line_count
+    if field_based
+      # count table rows
+      self.table_cells.pluck(:row).uniq.count
+    else
+      # count non-blank lines in the source
+      if self.source_text.nil?
+        0
+      else
+        self.source_text.lines.select{|line| line.match(/\S/)}.count
       end
     end
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -8,7 +8,7 @@ class Page < ApplicationRecord
   before_update :validate_blank_page
   before_update :process_source
   before_update :populate_search
-  before_save :update_line_count
+  before_update :update_line_count
   validate :validate_source, :validate_source_translation
 
   belongs_to :work, optional: true
@@ -282,16 +282,21 @@ class Page < ApplicationRecord
   end
 
   def calculate_line_count
-    if field_based
-      # count table rows
-      self.table_cells.pluck(:row).uniq.count
-    else
-      # count non-blank lines in the source
-      if self.source_text.nil?
-        0
+    if self.work && self.collection
+      if field_based
+        # count table rows
+        self.table_cells.pluck(:row).uniq.count
       else
-        self.source_text.lines.select{|line| line.match(/\S/)}.count
+        # count non-blank lines in the source
+        if self.source_text.nil?
+          0
+        else
+          self.source_text.lines.select{|line| line.match(/\S/)}.count
+        end
       end
+    else
+      # intermediary format -- collection is probably being imported
+      0
     end
   end
 

--- a/app/models/work_statistic.rb
+++ b/app/models/work_statistic.rb
@@ -98,6 +98,7 @@ class WorkStatistic < ApplicationRecord
 
     self[:complete]             = pct_completed
     self[:translation_complete] = pct_translation_completed
+    self[:line_count]           = stats[:line_count]
 
     save!
   end
@@ -106,7 +107,8 @@ class WorkStatistic < ApplicationRecord
     {
       transcription: work.pages.group(:status).count,
       translation: work.pages.group(:translation_status).count,
-      total: work.pages.count
+      total: work.pages.count,
+      line_count: work.pages.sum(:line_count)
     }
   end
   private

--- a/app/views/statistics/_collection_statistics.html.slim
+++ b/app/views/statistics/_collection_statistics.html.slim
@@ -18,3 +18,10 @@
         .counter(data-prefix="#{number_with_delimiter stats[DeedType::OCR_CORRECTED]}") #{t('.ocr_correction').pluralize(stats[DeedType::OCR_CORRECTED])}
       -if @collection.metadata_entry?      
         .counter(data-prefix="#{number_with_delimiter stats[:descriptions]}") #{t('.works_described').pluralize(stats[:descriptions])}
+      -if stats[:line_count] > 0
+        -if @collection.field_based?
+          .counter(data-prefix="#{number_with_delimiter stats[:line_count]}") #{t('.records_indexed').pluralize(stats[:line_count])}
+        -else
+          .counter(data-prefix="#{number_with_delimiter stats[:line_count]}") #{t('.lines_transcribed').pluralize(stats[:line_count])}
+
+

--- a/config/locales/statistics/statistics-en.yml
+++ b/config/locales/statistics/statistics-en.yml
@@ -21,6 +21,8 @@ en:
       page_edits: "Page edits"
       ocr_correction: "OCR Correction"
       works_described: "Described work"
+      records_indexed: Indexed record
+      lines_transcribed: Text line
     collaborators:
       collaborators: "Collaborators"
       mailing_list_export: "Mailing List Export"

--- a/db/migrate/20211103155043_add_line_count_to_pages.rb
+++ b/db/migrate/20211103155043_add_line_count_to_pages.rb
@@ -1,0 +1,6 @@
+class AddLineCountToPages < ActiveRecord::Migration[5.0]
+  def change
+    add_column :pages, :line_count, :integer unless column_exists?(:pages, :line_count)
+    add_column :work_statistics, :line_count, :integer unless column_exists?(:work_statistics, :line_count)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_22_134925) do
+ActiveRecord::Schema.define(version: 2021_11_03_155043) do
 
   create_table "ahoy_activity_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "date"
@@ -100,7 +100,9 @@ ActiveRecord::Schema.define(version: 2021_10_22_134925) do
     t.boolean "text_pdf_work"
     t.boolean "text_docx_work"
     t.boolean "static"
+    t.integer "document_set_id"
     t.index ["collection_id"], name: "index_bulk_exports_on_collection_id"
+    t.index ["document_set_id"], name: "index_bulk_exports_on_document_set_id"
     t.index ["user_id"], name: "index_bulk_exports_on_user_id"
     t.index ["work_id"], name: "index_bulk_exports_on_work_id"
   end
@@ -539,6 +541,7 @@ ActiveRecord::Schema.define(version: 2021_10_22_134925) do
     t.text "metadata"
     t.datetime "edit_started_at"
     t.integer "edit_started_by_user_id"
+    t.integer "line_count"
     t.index ["edit_started_by_user_id"], name: "index_pages_on_edit_started_by_user_id"
     t.index ["search_text"], name: "pages_search_text_index", type: :fulltext
     t.index ["status", "work_id"], name: "index_pages_on_status_and_work_id"
@@ -790,6 +793,7 @@ ActiveRecord::Schema.define(version: 2021_10_22_134925) do
     t.integer "translated_annotated"
     t.integer "complete"
     t.integer "translation_complete"
+    t.integer "line_count"
   end
 
   create_table "works", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -835,6 +839,7 @@ ActiveRecord::Schema.define(version: 2021_10_22_134925) do
   end
 
   add_foreign_key "bulk_exports", "collections"
+  add_foreign_key "bulk_exports", "document_sets"
   add_foreign_key "bulk_exports", "users"
   add_foreign_key "bulk_exports", "works"
   add_foreign_key "cdm_bulk_imports", "users"

--- a/lib/tasks/update_line_counts.rake
+++ b/lib/tasks/update_line_counts.rake
@@ -1,0 +1,21 @@
+namespace :fromthepage do
+  desc "update line counts for pages and works [first_index,last_index]"
+  task :update_line_counts, [:first_index,:last_index] => :environment do |t,args|
+    first_index = args.first_index.to_i
+    last_index = args.last_index.to_i
+
+    Collection.all.to_a[first_index..last_index].each do |collection|
+      print "#{collection.slug}\n"
+      collection.works.each do |work|
+        print "\t#{work.slug}\n"
+        work.pages.each do |page|
+          print "\t\t#{page.id}\n"
+          page.update_column(:line_count, page.calculate_line_count)
+        end
+        work.work_statistic.recalculate_from_hash
+        GC.start
+      end
+    end
+
+  end #end task
+end #end namespace


### PR DESCRIPTION
Note that we will need to run `rake fromthepage:update_line_counts[100,105]` in batches for each of the 2000+ collections, ideally in reverse order.