### PR TITLE
Fix apostrophe in PDF metadata block for #2899

### DIFF
--- a/app/views/export/facing_edition.html.erb
+++ b/app/views/export/facing_edition.html.erb
@@ -11,7 +11,7 @@
 <% 
   xml_metadata = @work.merge_metadata.map{|e| "#{e['label']}: #{e['value']}"}.join("<lb/>\n")
 %>
-<%= xml_to_pandoc_md("<p>#{xml_metadata}</p>", true, true, nil, false) %>
+<%= raw(xml_to_pandoc_md("<p>#{xml_metadata}</p>", true, true, nil, false)) %>
 \newpage
 
 <% @work.pages.includes(:notes, :ia_leaf, :sc_canvas).each do |page| %>


### PR DESCRIPTION
This fixes the problem with apostrophes in metadata.  It does not address the (observed) back-slash in front of square braces.