### PR TITLE
Fixed #2892 by hiding image replacement for imports

### DIFF
--- a/app/views/page/edit.html.slim
+++ b/app/views/page/edit.html.slim
@@ -19,13 +19,14 @@
             td
               -option_array = Page::TRANSLATION_STATUSES.map {|stat| [t(".page_status_#{stat}"),stat]}
               =f.select :translation_status, options_for_select(option_array, @page.translation_status)
-        tr
-          th =f.label :base_image, t('.page_image')
-          td
-            .input-file
-              =f.file_field :base_image, tabindex: '-1', accept: 'image/*'
-              input(type="text" tabindex="-1" placeholder=t('.click_to_browse_a_file') aria-label=t('.click_to_browse_a_file') readonly)
-              button(type="button") #{t('.browse')}
+        -unless @page.base_image.blank?
+          tr
+            th =f.label :base_image, t('.page_image')
+            td
+              .input-file
+                =f.file_field :base_image, tabindex: '-1', accept: 'image/*'
+                input(type="text" tabindex="-1" placeholder=t('.click_to_browse_a_file') aria-label=t('.click_to_browse_a_file') readonly)
+                button(type="button") #{t('.browse')}
       .toolbar
         .toolbar_group.w100
           =link_to({ :action => 'delete', :page_id => @page.id }, data: { :confirm => t('.delete_confirm_message') }, class: 'button')


### PR DESCRIPTION
Hide page image replacement options if no image was uploaded.