### PR TITLE
Fixed #2927 by testing for deleted configs

### DIFF
--- a/app/controllers/concerns/export_service.rb
+++ b/app/controllers/concerns/export_service.rb
@@ -555,9 +555,11 @@ private
     # are we in row 1?  fill the running data with non-spreadsheet fields
     if rownum == 1
       cell_array.each do |cell|
-        unless cell.transcription_field.input_type == 'spreadsheet'
-          running_data << cell
-        end 
+        if cell.transcription_field
+          unless cell.transcription_field.input_type == 'spreadsheet'
+            running_data << cell
+          end 
+        end
       end
     else
       # are we in row 2 or greater?


### PR DESCRIPTION
This seemed to have come from exporting a spreadsheet that had been transcribed with 8 header fields, 4 of which had since been deleted.