### PR TITLE
Don't escape HTML in instruction fields #2961

### DIFF
--- a/app/views/transcription_field/_field_layout.html.slim
+++ b/app/views/transcription_field/_field_layout.html.slim
@@ -16,7 +16,7 @@
             -if field.input_type == "instruction"
               div id="fields[#{field.id}][#{field.label}]" class="field-instructions"
                 h5 =t('.instructions')
-                p =field.label
+                p ==field.label
             -else
               =label_tag field.label, field.label
               -content = cell.nil? ? nil : cell.content

--- a/app/views/transcription_field/_metadata_field_layout.html.slim
+++ b/app/views/transcription_field/_metadata_field_layout.html.slim
@@ -9,7 +9,7 @@
         -if field.input_type == "instruction"
           div id="fields[#{field.id}][#{field.label}]" class="field-instructions"
             h5 =t('.instructions')
-            p =field.label
+            p ==field.label
         -else
           =label_tag field.label, field.label
           -if (defined? owner_preview) && owner_preview


### PR DESCRIPTION
Fixes #2961 

To reproduce:
In a field-based project, add an Instruction field with HTML tags.
Verify that the preview renders the HTML instead of escaping the tags.

Repeat in a metadata project.  (Separate code paths; sigh.)