### PR TITLE
Added project-owner specific sign-up for #2983

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -4,6 +4,11 @@ class RegistrationsController < Devise::RegistrationsController
     super
   end
 
+  def owner_new
+    @owner = User.where(slug: params[:user_slug]).first
+    new
+  end
+
   def new_trial
     new
   end
@@ -17,6 +22,10 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   def create
+    unless params[:owner_slug].blank?
+      @owner = User.where(slug: params[:owner_slug]).first
+    end
+
     #merge the new user information into the guest user id to change into normal user
     if current_user && current_user.guest?
       @user = current_user
@@ -88,7 +97,13 @@ class RegistrationsController < Devise::RegistrationsController
       "#{dashboard_owner_path}#freetrial" 
     else
       # New users should be returned to where they were or to their dashboard/watchlist
-      session[:user_return_to] || dashboard_watchlist_path
+      if session[:user_return_to]
+        session[:user_return_to]
+      elsif @owner
+        user_profile_path(@owner)
+      else
+        dashboard_watchlist_path
+      end
     end
   end
 

--- a/app/views/devise/registrations/owner_new.html.slim
+++ b/app/views/devise/registrations/owner_new.html.slim
@@ -1,0 +1,38 @@
+-content_for :page_title, "Sign Up"
+
+section.signon
+  h1 Sign Up
+  =form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+    =devise_error_messages!
+    .signon_field
+      =f.label :login, 'User Name'
+      =f.text_field :login, autofocus: true
+      small
+        i You'll use this name to log in. It will be shown publicly.
+    .signon_field
+      =f.label :email, 'Email Address'
+      =f.email_field :email
+    .signon_field
+      =f.label :password
+      =f.password_field :password, autocomplete: 'off'
+    .signon_field
+      =f.label :password_confirmation, 'Confirm Password'
+      =f.password_field :password_confirmation, autocomplete: 'off'
+    .signon_field
+      =f.label :real_name, 'Real Name'
+      =f.text_field :real_name
+      small
+        i Projects may use this when giving you credit. Leave this blank if you do not want to be credited.
+    .signon_field
+    =hidden_field_tag :owner_slug, @owner.slug
+    -if RECAPTCHA_ENABLED
+      .signon_field
+        =recaptcha_tags
+    .signon_field
+      =f.check_box :activity_email, checked: true
+      =f.label :receive_activity_emails
+    =f.button 'Create Account', class: 'big'
+  hr
+  =render 'devise/shared/links'
+-unless MIXPANEL_ID.blank?
+  javascript:  mixpanel.track("Sign Up");

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -52,7 +52,12 @@ html lang="en-US"
           -if user_signed_in?
             =link_to t('dashboard.plain'), dashboard_role_path, class: 'header_link'
           -if (user_signed_in? && current_user.guest) || !user_signed_in?
-            =link_to 'Sign Up To Transcribe', new_user_registration_path, class: 'header_link'
+            -if @collection 
+              =link_to 'Sign Up To Transcribe', new_for_owner_path(@collection.owner), class: 'header_link'              
+            -elsif @user && @user.owner?
+              =link_to 'Sign Up To Transcribe', new_for_owner_path(@user), class: 'header_link'              
+            -else
+              =link_to 'Sign Up To Transcribe', new_user_registration_path, class: 'header_link'
 
           -if user_signed_in?
             dl.dropdown.right

--- a/app/views/user/update_profile.html.slim
+++ b/app/views/user/update_profile.html.slim
@@ -32,6 +32,9 @@
           th URL: 
           td www.#{Rails.application.routes.default_url_options[:host]}/#{@user.slug}
         tr
+          th Sign-up URL: 
+          td www.#{Rails.application.routes.default_url_options[:host]}/#{@user.slug}/sign_up
+        tr
           th =f.label :slug, "URL"
           td =f.text_field :slug, value: @user.slug
         tr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Fromthepage::Application.routes.draw do
 
   devise_scope :user do
     get "users/new_trial" => "registrations#new_trial"
+    get ":user_slug/sign_up", to: "registrations#owner_new", as: 'new_for_owner'
     post "registrations/choose_provider", to: 'registrations#choose_saml'
     post "registrations/set_provider", to: 'registrations#set_saml'
     match '/users/auth/saml/:identity_provider_id/callback',


### PR DESCRIPTION
This creates a new user account flow that takes users back to an owner profile page after they have created an account.  The owner can see the sign-up URL when they edit their profile, underneath the place we display their profile URL.

