### PR TITLE
change owner dashboard work links to open read tab for #2953

### DIFF
--- a/app/views/dashboard/owner.html.slim
+++ b/app/views/dashboard/owner.html.slim
@@ -13,7 +13,7 @@
             ==c.intro_block
             -unless @works.empty?
               -@works.each do |w|
-                li =link_to w.title, edit_collection_work_path(c.owner, c, w.id)
+                li =link_to w.title, collection_read_work_path(c.owner, c, w)
               -more_works = link_to t('.see_all_works'), collection_works_list_path(c.owner, c)
               -start_project = link_to t('.start_a_project'), dashboard_startproject_path(:collection_id => c.id)
               p.nodata_text = t('.total_work_count', count: @count)

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -286,7 +286,6 @@ describe "collection spec (isolated)" do
       visit dashboard_owner_path
 
       page.find('.collections').click_link('Stats Test Work')
-      page.find('.tabs').click_link('Read')
       page.find('.maincol h4').click_link('Page 1')
       fill_in_editor_field('Transcription')
       page.find('#finish_button_top').click

--- a/spec/features/owner_actions_spec.rb
+++ b/spec/features/owner_actions_spec.rb
@@ -167,6 +167,7 @@ describe "owner actions", :order => :defined do
   it "moves a work to another collection" do
     visit dashboard_owner_path
     page.find('.maincol').find('a', text: @title).click
+    page.find('.tabs').click_link('Settings')
     expect(page).to have_content(@title)
     expect(page).to have_content("Work title")
     expect(page.find('.breadcrumbs')).to have_selector('a', text: @collections.second.title)
@@ -230,6 +231,7 @@ describe "owner actions", :order => :defined do
   it "deletes a work" do
     visit dashboard_owner_path
     page.find('.maincol').find('a', text: @title).click
+    page.find('.tabs').click_link('Settings')
     expect(page).to have_content(@title)
     expect(page).to have_content("Work title")
     click_link("Delete Work")

--- a/spec/features/zz_deletion_spec.rb
+++ b/spec/features/zz_deletion_spec.rb
@@ -55,7 +55,6 @@ describe "testing deletions" do
     visit dashboard_owner_path
     page.find('.maincol').find_all('a', text: work.title).first.click
     expect(page).to have_content(work.title)
-    page.find('.tabs').click_link("Read")
     expect(page).to have_content(test_page.title)
     page.find('.work-page_title', text: test_page.title).click_link(test_page.title)
     page.find('.tabs').click_link("Settings")
@@ -78,6 +77,7 @@ describe "testing deletions" do
     expect(Dir.exist?(path)).to be true
     visit dashboard_owner_path
     page.find('.maincol').find('a', text: work.title).click
+    page.find('.tabs').click_link('Settings')
     expect(page).to have_content(work.title)
     expect(page).to have_selector('a', text: 'Delete Work')
     page.find('a', text: 'Delete Work').click


### PR DESCRIPTION
_Resolves #2953_ 

Originally, the links to specific works on the [owner dashboard](https://fromthepage.com/dashboard/owner) would link to the work's settings page instead of the work's "read" page, which is not the expected behavior.

These are the work links, and in the bottom left corner you can see it's taking you to the "edit" page.
![owner dashboard links](https://user-images.githubusercontent.com/35716893/152590206-358e1c11-c16f-4928-88a8-2198d3d9eded.png)

This pull changes the links to open the "read" page instead.