### PR TITLE
add english translations to the preview, edit, and autolink buttons and their tooltips for #2871

### DIFF
--- a/config/locales/transcribe/transcribe-en.yml
+++ b/config/locales/transcribe/transcribe-en.yml
@@ -19,7 +19,12 @@ en:
       save_to_transcribed_tooltip: "Save your changes"
       save_to_needs_review_tooltip: "Save your changes"
       save_to_incomplete_tooltip: "Save an incomplete page"
-
+      preview: "Preview"
+      edit: "Edit"
+      autolink: "Autolink"
+      preview_tooltip: "Preview this page"
+      edit_tooltip: "Edit this page"
+      autolink_tooltip: "Suggest subject tags automatically"
     display_page:
       fullscreen: "Fullscreen"
       image_at_the_left: "Image at the left"


### PR DESCRIPTION
_Resolves #2871_

Currently, the "preview", "edit", and "autolink" buttons on the transcription page are missing their translations. Their tooltips are missing translations as well. This is true for English, Spanish, and Portuguese. 

This is what the "preview" button currently look like on hover, and the other two look smiliar.
![preview translation missing](https://user-images.githubusercontent.com/35716893/152611344-41a95b98-3633-4b15-b186-8de1e8d58fe6.jpg)
![preview tooltip translation missing](https://user-images.githubusercontent.com/35716893/152611351-f4bce084-dd1e-41c6-83e7-0f078b8fb50a.jpg)

This pull adds the six English translations for these buttons.

The Spanish and Portuguese translations still need to be added as well.