### PR TITLE
Change how tags are stripped for #2939

### DIFF
--- a/app/views/dashboard/landing_page.html.slim
+++ b/app/views/dashboard/landing_page.html.slim
@@ -3,7 +3,7 @@
     -@collections.each do |c|
       -cache c do
         -link_page = c.next_untranscribed_page
-        -snippet = truncate(strip_tags(c.intro_block), length: 300, separator: ' ') || ''
+        -snippet = truncate(Loofah.fragment(c.intro_block).text(encode_special_chars: false), length: 300, separator: ' ') || ''
         .carousel_slide
           =link_to image_tag(c.picture_url, alt: c.title), collection_path(c.owner, c), class: 'carousel_slide_image'
           .carousel_slide_content
@@ -31,7 +31,7 @@
                 h5
                   =link_to sr.title, collection_path(sr.owner.slug, sr.id)
                 .projects_collection_snippet
-                  = truncate(strip_tags(sr.intro_block), length: 300, separator: ' ') || ''
+                  = truncate(Loofah.fragment(sr.intro_block).text(encode_special_chars: false), length: 300, separator: ' ') || ''
     -@owners.each do |owner|
       -if params[:search]
         -projects = @search_results.select{ |p| p.owner_user_id == owner.id}
@@ -47,7 +47,7 @@
                 =owner.about
           .projects
             -projects.each do |project|
-              -snippet = truncate(strip_tags(project.intro_block), length: 300, separator: ' ') || ''
+              -snippet = truncate(Loofah.fragment(project.intro_block).text(encode_special_chars: false), length: 300, separator: ' ') || ''
               div.projects_details
                 -unless project.picture.blank?
                   .projects_details_image


### PR DESCRIPTION
_Resolves #2393_

### The problem
Previously, HTML entities like ampersands in collection descriptions in the Find a Project page were incorrectly escaped (i.e `&amp;` is shown instead of `&`). 

![escaped html](https://user-images.githubusercontent.com/35716893/153270459-44468049-f1c8-48b4-8fce-22a5f267f59d.png)

However, the ampersands show up as expected (`&`) on the Collection overview page and owner dashboard. The difference is that on the Find a Project page, `strip_tags` is called on the description, which [is escaping special characters](https://github.com/rails/rails/issues/28060).

### The solution
To change this behavior, we use `Loofah.fragment(desc).text(encode_special_chars: false)` instead of `strip_tags(desc)`, which does the same thing (removes HTML tags) without escaping special characters ([here's the documentation](https://www.rubydoc.info/github/flavorjones/loofah/Loofah/TextBehavior)). 

`strip_tags` is in three places in the Find a Project page, so they are all changed to use Loofah instead.

### Further Problems

`strip_tags` is still used in [other places in the code](https://github.com/benwbrum/fromthepage/search?q=strip_tags), and if what it's displaying has any HTML entities, they will not be shown correctly. We should change these to use `Loofah` as well (if it applies).