### PR TITLE
changed disable subject linking to enable for #2872

### DIFF
--- a/app/controllers/collection_controller.rb
+++ b/app/controllers/collection_controller.rb
@@ -357,6 +357,8 @@ class CollectionController < ApplicationController
   end
 
   def update
+    @collection.subjects_disabled = (params[:collection][:subjects_enabled] == "0") #:subjects_enabled is "0" or "1"
+    
     if params[:collection][:slug] == ""
       @collection.update(collection_params.except(:slug))
       title = @collection.title.parameterize

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -70,6 +70,10 @@ class Collection < ApplicationRecord
   def metadata_entry?
     self.data_entry_type == DataEntryType::TEXT_AND_METADATA || self.data_entry_type == DataEntryType::METADATA_ONLY
   end
+  
+  def subjects_enabled
+    !subjects_disabled
+  end
 
   module ReviewType 
     OPTIONAL = 'optional'

--- a/app/views/collection/edit.html.slim
+++ b/app/views/collection/edit.html.slim
@@ -41,16 +41,16 @@
               =f.text_area :link_help, rows: 10, value: @collection.link_help
           tr
             td(colspan="2")
-              =f.check_box :subjects_disabled, value: @collection.subjects_disabled
-              =f.label :subjects_disabled, t('.subjects_disabled')
+              =f.check_box :subjects_enabled
+              =f.label :subjects_enabled, t('.subjects_enabled')
         tr
           td(colspan="2")
-            =f.check_box :hide_completed, value: @collection.hide_completed
+            =f.check_box :hide_completed
             =f.label :hide_completed, t('.hide_completed')
         -if @collection.text_entry?
           tr
             td(colspan="2")
-              =f.check_box :user_download, value: @collection.user_download
+              =f.check_box :user_download
               =f.label :user_download, t('.user_download')
           tr
             td(colspan="2")
@@ -65,7 +65,7 @@
         -if @ssl && !@collection.field_based && @collection.text_entry?
           tr
             td(colspan="2")
-              =f.check_box :voice_recognition, value: @collection.voice_recognition, onchange: 'showLang(event)'
+              =f.check_box :voice_recognition, onchange: 'showLang(event)'
               =f.label :voice_recognition, t('.voice_recognition')
         -if @collection.text_entry?
           tr

--- a/config/locales/collection/collection.en.yml
+++ b/config/locales/collection/collection.en.yml
@@ -80,7 +80,7 @@ en:
       help: "Basic Help Text"
       suggestions_help_tab: "Suggestions for your help tab."
       link_help: "Subject Linking Help Text (not displayed if subjects are disabled)"
-      subjects_disabled: "Disable subject indexing"
+      subjects_enabled: "Enable subject indexing"
       review_type: "Review Type"
       review_type_optional: " Optional: Collaborators may request review of their transcriptions."
       review_type_required: " Required: All initial transcriptions will be marked as needing review.  (Review may be performed by anyone.)"

--- a/spec/features/disable_subjects_spec.rb
+++ b/spec/features/disable_subjects_spec.rb
@@ -17,8 +17,8 @@ describe "disable subject linking", :order => :defined do
   it "disables subject indexing in a collection" do
     visit collection_path(@collection.owner, @collection)
     page.find('.tabs').click_link("Settings")
-    expect(page).to have_content("Disable subject indexing")
-    check('collection_subjects_disabled')
+    expect(page).to have_content("Enable subject indexing")
+    uncheck('collection_subjects_enabled')
     click_button('Save Changes')
     #have to find the collection again to make sure it's been updated
     collection = Collection.where(owner_user_id: @owner.id).first
@@ -90,8 +90,8 @@ describe "disable subject linking", :order => :defined do
   it "enables subject indexing" do
     visit collection_path(@collection.owner, @collection)
     page.find('.tabs').click_link("Settings")
-    expect(page).to have_content("Disable subject indexing")
-    uncheck('collection_subjects_disabled')
+    expect(page).to have_content("Enable subject indexing")
+    check('collection_subjects_enabled')
     click_button('Save Changes')
     #have to find the collection again to make sure it's been updated
     collection = Collection.where(owner_user_id: @owner.id).first


### PR DESCRIPTION
_Resolves #2872_

### The problem
Previously, the "subject linking" / "subject indexing" toggle in the Collection settings page had a double negative, which is counterintuitive and confusing.

![disable subject indexing](https://user-images.githubusercontent.com/35716893/153458224-0c18dfa8-e214-4d4c-86c2-dab672d626ca.jpg)

### The solution
Changing the wording to "Enable subject linking" and flipping the boolean going to the database solves this.

![enable subject indexing](https://user-images.githubusercontent.com/35716893/153458000-b5d964ed-ed01-4104-aa10-90a5b1c7d84f.jpg)

### Changes made

Previously, the `check_box`es were using a `value` parameter to set their state. However, we found this parameter is not doing anything as `check_box`es [use the `method` passed to them to set their state](https://www.rubydoc.info/docs/rails/4.1.7/ActionView%2FHelpers%2FFormBuilder:check_box). So, all uses of the `value` parameter in the `collection/edit` view were removed.


