### PR TITLE
Added collection, work, and document set slug validation for #2328

### DIFF
--- a/app/controllers/collection_controller.rb
+++ b/app/controllers/collection_controller.rb
@@ -358,15 +358,14 @@ class CollectionController < ApplicationController
 
   def update
     @collection.subjects_disabled = (params[:collection][:subjects_enabled] == "0") #:subjects_enabled is "0" or "1"
-    
-    if params[:collection][:slug] == ""
-      @collection.update(collection_params.except(:slug))
-      title = @collection.title.parameterize
-      @collection.update(slug: title)
-    else
-      @collection.update(collection_params)
-    end
+    params[:collection].delete(:subjects_enabled)
 
+    @collection.attributes = collection_params
+
+    if collection_params[:slug].blank?
+      @collection.slug = @collection.title.parameterize
+    end
+   
     if @collection.save
       flash[:notice] = t('.notice')
       redirect_to action: 'edit', collection_id: @collection.id
@@ -662,6 +661,6 @@ class CollectionController < ApplicationController
   end
 
   def collection_params
-    params.require(:collection).permit(:title, :slug, :intro_block, :footer_block, :transcription_conventions, :help, :link_help, :subjects_disabled, :review_type, :hide_completed, :text_language, :default_orientation, :voice_recognition, :picture, :user_download)
+    params.require(:collection).permit(:title, :slug, :intro_block, :footer_block, :transcription_conventions, :help, :link_help, :subjects_disabled, :subjects_enabled, :review_type, :hide_completed, :text_language, :default_orientation, :voice_recognition, :picture, :user_download)
   end
 end

--- a/app/controllers/document_sets_controller.rb
+++ b/app/controllers/document_sets_controller.rb
@@ -140,8 +140,8 @@ class DocumentSetsController < ApplicationController
         redirect_to request.referrer
       end
     else
-      edit
-      render :edit
+      settings
+      render :settings
     end
   end
 
@@ -153,7 +153,7 @@ class DocumentSetsController < ApplicationController
       @works = @collection.collection.works.where.not(id: @collection.work_ids).order(:title).paginate(page: params[:page], per_page: 20)
     end
     #document set edit needs the @document set variable
-    @document_set = @collection
+    @document_set = @collection unless @document_set
     @collaborators = @document_set.collaborators
     @noncollaborators = User.order(:display_name) - @collaborators
   end

--- a/app/controllers/document_sets_controller.rb
+++ b/app/controllers/document_sets_controller.rb
@@ -126,20 +126,22 @@ class DocumentSetsController < ApplicationController
   end
 
   def update
-    if params[:document_set][:slug] == ""
-      @document_set.update(document_set_params.except(:slug))
-      title = @document_set.title.parameterize
-      @document_set.update(slug: title)
-    else
-      @document_set.update(document_set_params)
+    @document_set.attributes = document_set_params
+    
+    if document_set_params[:slug].blank?
+      @document_set.slug = @document_set.title.parameterize
     end
 
-    @document_set.save!
-    flash[:notice] = t('.document_updated')
-    unless request.referrer.include?("/settings")
-      ajax_redirect_to({ action: 'index', collection_id: @document_set.collection_id })
+    if @document_set.save
+      flash[:notice] = t('.document_updated')
+      unless request.referrer.include?("/settings")
+        ajax_redirect_to({ action: 'index', collection_id: @document_set.collection_id })
+      else
+        redirect_to request.referrer
+      end
     else
-      redirect_to request.referrer
+      edit
+      render :edit
     end
   end
 

--- a/app/controllers/work_controller.rb
+++ b/app/controllers/work_controller.rb
@@ -165,16 +165,16 @@ class WorkController < ApplicationController
     collection_convention = @work.collection.transcription_conventions
 
     if params_convention == collection_convention
-      @work.assign_attributes(work_params.except(:transcription_conventions))
+      @work.attributes = work_params.except(:transcription_conventions)
     else
-      @work.assign_attributes(work_params)
+      @work.attributes = work_params
     end
 
     #if the slug field param is blank, set slug to original candidate
-    if params[:work][:slug] == ""
-      title = @work.title.parameterize
-      @work.assign_attributes(slug: title)
+    if work_params[:slug].blank?
+      @work.slug = @work.title.parameterize
     end
+    
     if params[:work][:collection_id] != id.to_s
       if @work.save
         change_collection(@work)

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -32,6 +32,7 @@ class Collection < ApplicationRecord
   has_and_belongs_to_many :reviewers, :class_name => 'User', :join_table => :collection_reviewers
 
   validates :title, presence: true, length: { minimum: 3, maximum: 255 }
+  validates :slug, format: { with: /[[:alpha:]]/ }
 
   before_create :set_transcription_conventions
   before_create :set_help

--- a/app/models/document_set.rb
+++ b/app/models/document_set.rb
@@ -24,6 +24,7 @@ class DocumentSet < ApplicationRecord
   after_save :set_next_untranscribed_page
 
   validates :title, presence: true, length: { minimum: 3, maximum: 255 }
+  validates :slug, format: { with: /[[:alpha:]]/ }
 
   scope :unrestricted, -> { where(is_public: true)}
   scope :restricted, -> { where(is_public: false)}

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -55,7 +55,7 @@ class Work < ApplicationRecord
   after_create :alert_intercom
 
   validates :title, presence: true, length: { minimum: 3, maximum: 255 }
-  validates :slug, uniqueness: { case_sensitive: true }
+  validates :slug, format: { with: /[[:alpha:]]/ }
   validate :document_date_is_edtf
 
   mount_uploader :picture, PictureUploader

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -55,7 +55,7 @@ class Work < ApplicationRecord
   after_create :alert_intercom
 
   validates :title, presence: true, length: { minimum: 3, maximum: 255 }
-  validates :slug, format: { with: /[[:alpha:]]/ }
+  validates :slug, uniqueness: { case_sensitive: true }, format: { with: /[[:alpha:]]/ }
   validate :document_date_is_edtf
 
   mount_uploader :picture, PictureUploader

--- a/app/views/document_sets/settings.html.slim
+++ b/app/views/document_sets/settings.html.slim
@@ -7,7 +7,9 @@
     =render 'edit'
 
     h2#manage =t('.manage_works')
-    =form_tag({:controller => 'document_sets', :action => 'settings'}, method: :get, enforce_utf8: false, class: 'collection-search') do
+    
+    =form_tag(collection_settings_path(@collection.owner, @collection), method: :get, enforce_utf8: false, class: 'collection-search') do
+      =validation_summary @collection.errors
       =hidden_field_tag('collection_id', @collection.slug)
       =search_field_tag :search, params[:search], placeholder: t('.search_for_works')
       =button_tag t('.search')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,3 +7,22 @@ en:
   es: "Español"
   pt: "Português"
   time_ago_in_words: "%{time} ago"
+  activerecord:
+    attributes:
+      collection:
+        slug: "URL"
+      work:
+        slug: "URL"
+    errors:
+      models:
+        collection:
+          attributes:
+            slug:
+              blank: "is required"
+              invalid: "must have at least one letter"
+        work:
+          attributes:
+            slug:
+              blank: "is required"
+              invalid: "must have at least one letter"
+  

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,8 @@ en:
         slug: "URL"
       work:
         slug: "URL"
+      document_set:
+        slug: "URL"
     errors:
       models:
         collection:
@@ -25,4 +27,8 @@ en:
             slug:
               blank: "is required"
               invalid: "must have at least one letter"
-  
+        document_set:
+          attributes:
+            slug:
+              blank: "is required"
+              invalid: "must have at least one letter"


### PR DESCRIPTION
_Resolves #2328_

Previously, the input for slugs/URLs for collections and works had no validation and could be set as just numbers, which causes problems.

Now, when a user tries to save an invalid slug (that has no letters in it, via the regex expression `/[[:alpha:]]/`), an error message will show and the slug will not save.

On the collection page:
![collection slug validation](https://user-images.githubusercontent.com/35716893/155046076-540ba777-c188-4115-8264-f2cdff52bbed.jpg)

On the work page:
![work slug validation](https://user-images.githubusercontent.com/35716893/155046080-5d5156fd-6bf0-4d47-a8e5-bb3a4476079a.jpg)

There's also a couple of changes related to #2995 (subject linking enabled) that were necessary to get this working.