### PR TITLE
Sorted owners, collaborators, and reviewers alphabetically for #2956

### DIFF
--- a/app/controllers/collection_controller.rb
+++ b/app/controllers/collection_controller.rb
@@ -110,10 +110,10 @@ class CollectionController < ApplicationController
 
   def load_settings
     @main_owner = @collection.owner
-    @owners = [@main_owner] + @collection.owners
+    @owners = ([@main_owner] + @collection.owners).sort_by { |owner| owner.display_name }
     @works_not_in_collection = current_user.owner_works - @collection.works
-    @collaborators = @collection.collaborators
-    @reviewers = @collection.reviewers
+    @collaborators = @collection.collaborators.sort_by { |collaborator| collaborator.display_name }
+    @reviewers = @collection.reviewers.sort_by { |reviewer| reviewer.display_name }
     if User.count > 100
       @nonowners = []
       @noncollaborators = []


### PR DESCRIPTION
_Resolves #2956_

Right now, collaborator and owner lists on the collection settings page are listed in the order that they were added, which is unhelpful in finding specific users to remove them. 

<img src="https://user-images.githubusercontent.com/35716893/158675607-a8426046-8876-41c6-a8b3-61962e60b232.jpg" width="50%">

These lists are now sorted alphabetically by the users' display name.

<img src="https://user-images.githubusercontent.com/35716893/158676359-61ac1e9f-928d-406e-8287-8ad572a3654c.jpg" width="50%"> 
