### PR TITLE
Remove whitespace to fix #3046

### DIFF
--- a/app/views/transcription_field/_metadata_field_layout.html.slim
+++ b/app/views/transcription_field/_metadata_field_layout.html.slim
@@ -25,7 +25,7 @@
           -elsif field.input_type == "date"
             =text_field_tag "fields[#{field.id}][#{field.label}]", content, class: 'field-input edtf', data: { inputmask: '"alias": "datetime", "inputFormat": "isoDate"'}
           -elsif field.input_type == "select"
-            -options = field.options.split(";") unless field.options.nil?
+            -options = field.options.split(";").map{|option| option.strip} unless field.options.nil?
             =select_tag("fields[#{field.id}][#{field.label}]", options_for_select(options, content), class: 'field-input')
           -elsif field.input_type == "multiselect"
             / add aria label


### PR DESCRIPTION
Previously, we were displaying the Wrangel Island select lists in the metadata form, but when the user chose them and saved the page, the values looked like they were not selected.

In fact, the values in the configuration screen hand been entered in a multi-line mode (which might be the way we do all options for metadata entry, not just the multi-select we designed it for), so the value for e.g. `Roald Amundsen` was `\nRoald Amundsen`.  This would be saved (probably without the whitespace), but when the form was re-loaded the whitespace mismatch meant the select box couldn't find the appropriate option.