### PR TITLE
Refactor search transformation to handle spreadsheet transcriptions f…

### DIFF
--- a/db/migrate/20220324010254_update_search_text_for_tables.rb
+++ b/db/migrate/20220324010254_update_search_text_for_tables.rb
@@ -1,0 +1,10 @@
+class UpdateSearchTextForTables < ActiveRecord::Migration[5.0]
+  def change
+    table_page_ids = TranscriptionField.where(input_type: 'spreadsheet').to_a.map { |tf| tf.table_cells.pluck(:page_id)}.flatten.uniq
+    print "updating search for #{table_page_ids.count} pages\n"
+    Page.find(table_page_ids).each do |page|
+      page.populate_search
+      page.update_column(:search_text, page.search_text)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_22_183841) do
+ActiveRecord::Schema.define(version: 2022_03_24_010254) do
 
   create_table "ahoy_activity_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "date"

--- a/lib/search_translator.rb
+++ b/lib/search_translator.rb
@@ -48,7 +48,19 @@ private
     doc.xpath("//div").each { |n| n.add_next_sibling("\n")}
     doc.xpath("//abbr").each { |n| n.replace(n['expan']) unless n['expan'].blank? }
     doc.xpath("//catchword").each { |n| n.remove }
-    
+
+    table_text="\n\n"
+    doc.xpath("//tr").each do |row|
+      row.xpath('td').each do |cell|
+        table_text << cell.text
+        table_text << " "
+      end
+      table_text << "\n"
+    end
+
+    doc.xpath("//table").each { |n| n.replace(table_text)}
+
+
     no_tags = doc.text
     no_linefeeds = no_tags.gsub(/\s/, ' ')
     single_spaces = no_linefeeds.gsub(/ +/, ' ').strip


### PR DESCRIPTION
Previously we were converting the XML table to text, which joined all the words in each table cell together: as a result, 

| Forename | Surname |
| ---- | -----| 
| Mary | Towler |
| Octavia | Shelton |

would be converted into a search text of `MaryTowlerOctaviaShelton` which would not match a search for `Octavia`.

The search text transformation has been changed to produce padding between cells, so that searches for individual words should now work correctly.

