### PR TITLE
Handle @id values ending with slash for #3066

### DIFF
--- a/app/helpers/transcribe_helper.rb
+++ b/app/helpers/transcribe_helper.rb
@@ -62,7 +62,8 @@ module TranscribeHelper
       sources
     else
       if page.sc_canvas
-        ["#{page.sc_canvas.sc_service_id}/info.json"]
+        service_id = page.sc_canvas.sc_service_id.sub(/\/$/,'')
+        ["#{service_id}/info.json"]
       elsif page.ia_leaf
         [page.ia_leaf.iiif_image_info_url]
       elsif browser.platform.ios? && browser.webkit?

--- a/app/models/sc_canvas.rb
+++ b/app/models/sc_canvas.rb
@@ -5,10 +5,11 @@ class ScCanvas < ApplicationRecord
   belongs_to :page, optional: true
 
   def thumbnail_url
+    service_id = sc_service_id.sub(/\/$/,'')
     if sc_service_context ==  "http://iiif.io/api/image/1/context.json"
-      "#{sc_service_id}/full/100,/0/native.jpg"
+      "#{service_id}/full/100,/0/native.jpg"
     else
-      "#{sc_service_id}/full/100,/0/default.jpg"
+      "#{service_id}/full/100,/0/default.jpg"
     end
   end
 


### PR DESCRIPTION
Quartex's canvases have images with service `@id`s that end with a slash, causing our attempts to append other URL elements to break.  This eliminates terminal slashes before appending a new slash for page thumbnails and OSD tiles.