### PR TITLE
Added work_id to metadata exports for #3005

### DIFF
--- a/app/controllers/concerns/export_service.rb
+++ b/app/controllers/concerns/export_service.rb
@@ -314,7 +314,8 @@ private
         'Pages Indexed',
         'Pages Translated',
         'Pages Needing Review',
-        'Pages Marked Blank'
+        'Pages Marked Blank',
+        'work_id'
       ]
 
       raw_metadata_strings = collection.works.pluck(:original_metadata)
@@ -343,7 +344,8 @@ private
           work.work_statistic.annotated_pages,
           work.work_statistic.translated_pages,
           work.work_statistic.needs_review,
-          work.work_statistic.blank_pages
+          work.work_statistic.blank_pages,
+          work.id
         ]
 
         unless work.original_metadata.blank?


### PR DESCRIPTION
_Resolves #3005_

### The issue

Wilford Woodruff asked for there to be a "work_id" column in the work metadata export so that the export would match the [metadata upload template](https://fromthepage.com/collection/metadata/32000095/example). This is probably so that users can export metadata, edit it, and upload it. This doesn't work right now because the metadata export & metadata upload are totally different. 

### The solution

Adding a "work_id" column to the metadata export after "Pages marked blank" and before all of the metadata fields makes the export match most closely to the upload (just columns A-Q have to be deleted).

![new metadata export](https://user-images.githubusercontent.com/35716893/160303043-45c8465c-337f-45b4-bd0c-2cdb4d3bd4b6.jpg)
