### PR TITLE
accept any work slug with alphabet characters or a dash or underscore

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -55,7 +55,7 @@ class Work < ApplicationRecord
   after_create :alert_intercom
 
   validates :title, presence: true, length: { minimum: 3, maximum: 255 }
-  validates :slug, uniqueness: { case_sensitive: true }, format: { with: /[-a-zA-Z_]+/ }
+  validates :slug, uniqueness: { case_sensitive: true }, format: { with: /[-_[:alpha:]]/ }
   validate :document_date_is_edtf
 
   mount_uploader :picture, PictureUploader

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -55,7 +55,7 @@ class Work < ApplicationRecord
   after_create :alert_intercom
 
   validates :title, presence: true, length: { minimum: 3, maximum: 255 }
-  validates :slug, uniqueness: { case_sensitive: true }, format: { with: /[[:alpha:]]/ }
+  validates :slug, uniqueness: { case_sensitive: true }, format: { with: /[-a-zA-Z_]+/ }
   validate :document_date_is_edtf
 
   mount_uploader :picture, PictureUploader


### PR DESCRIPTION
LVA has work titles with underscores or dashes, which were not allowed with the alpha regex matching.  Since they upload large zip files, we would get 80% of the way through, run into one of these, and then fail for the entire upload.