### PR TITLE
Make EDTF date input more intuitive for #2976

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -213,7 +213,20 @@ class Work < ApplicationRecord
   end
 
   def document_date
-    Date.edtf(self[:document_date])
+    date = Date.edtf(self[:document_date])
+    
+    if self[:document_date].nil? # there is no document date
+      return nil
+    elsif date.nil? # the document date is invalid
+      return self[:document_date]
+    # assign date precision based on length of document_date string (edtf-ruby does not do this automatically)
+    elsif self[:document_date].length == 7 # YYYY-MM
+      date.month_precision!
+    elsif self[:document_date].length == 4 and not self[:document_date].include? "x" # YYYY
+      date.year_precision!
+    end
+    
+    return date.edtf
   end
 
   def document_date_is_edtf

--- a/app/views/work/edit.html.slim
+++ b/app/views/work/edit.html.slim
@@ -97,7 +97,7 @@
           td =f.text_field :location_of_composition, value: @work.location_of_composition
         tr
           th =f.label :document_date, 'Document Date'
-          td =f.text_field :document_date, value: @work.document_date
+          td =f.text_field :document_date, value: @work.document_date, class: 'field-input edtf', data: { inputmask: '"alias": "datetime", "inputFormat": "isoDate"'}
         tr
           th =f.label :genre
           td =f.text_field :genre, value: @work.genre
@@ -189,6 +189,7 @@
 
 -content_for :javascript
   javascript:
+    $('.edtf').inputmask();
     $(function() {
       $('.user-select-form select').select2({
         placeholder: 'Add new collaborator...',

--- a/app/views/work/edit.html.slim
+++ b/app/views/work/edit.html.slim
@@ -97,7 +97,7 @@
           td =f.text_field :location_of_composition, value: @work.location_of_composition
         tr
           th =f.label :document_date, 'Document Date'
-          td =f.text_field :document_date, value: @work.document_date, class: 'field-input edtf', data: { inputmask: '"alias": "datetime", "inputFormat": "isoDate"'}
+          td =f.text_field :document_date, value: @work.document_date, placeholder: 'yyyy-mm-dd'
         tr
           th =f.label :genre
           td =f.text_field :genre, value: @work.genre
@@ -189,7 +189,6 @@
 
 -content_for :javascript
   javascript:
-    $('.edtf').inputmask();
     $(function() {
       $('.user-select-form select').select2({
         placeholder: 'Add new collaborator...',


### PR DESCRIPTION
_Resolves #2976_

### The problem

Currently, the "Document Date" field under "Additional Metadata" in work settings is required to be in ETDF format and a validation error pops up if it's not:

> 1 error prohibited the form from being saved:
> Document date must be in EDTF format

This works, but isn't very intuitive because some users (such as Molly of History Revealed, who emailed about this issue) don't know what EDTF format is or don't understand what the validation error means.

### The solution

A better way to restrict dates to EDTF format is to use an input mask (to `yyyy-mm-dd`), this pull adds that.

![input mask](https://user-images.githubusercontent.com/35716893/164525979-b5c614cb-047f-456a-bac1-4b86c320264b.jpg)

### An issue

Though this works perfectly with dates at one specific day, there are more possible date types. [EDTF allows](https://www.loc.gov/standards/datetime/):

- year, month, and day (e.g. 2016-05-10) _(what this allows)_
- year and month (e.g. 2016-10)
- year (e.g. 2016)
- date and time (e.g. 2001-02-03T09:30:01)
- interval (date range) (e.g. 1906-08/1910-12) _(this is what Molly of History Revealed was trying to input)_

The input mask doesn't allow any input outside of `yyyy-mm-dd`, so if we want to include other date types, this solution might not fit.