### PR TITLE
Added warning message if work restricted with no collaborators for #2952

### DIFF
--- a/app/assets/stylesheets/sections/work.scss
+++ b/app/assets/stylesheets/sections/work.scss
@@ -146,3 +146,10 @@
 .page_status {
   font-style: italic;
 }
+
+// Settings
+
+.warning {
+  font-style: italic;
+  color: $fgRed;
+}

--- a/app/views/work/edit.html.slim
+++ b/app/views/work/edit.html.slim
@@ -168,7 +168,7 @@
         =f.check_box :restrict_scribes
         |&nbsp;
         =f.label :restrict_scribes, 'Restrict collaborators'
-      -if @collection.restricted? && @work.restrict_scribes && @scribes.empty?
+      -if @work.restrict_scribes && @scribes.empty?
         p.warning =t('.restricted_work_no_collaborators_warning')
       small.legend =button_tag 'Apply', class: 'outline'
 

--- a/app/views/work/edit.html.slim
+++ b/app/views/work/edit.html.slim
@@ -168,6 +168,8 @@
         =f.check_box :restrict_scribes
         |&nbsp;
         =f.label :restrict_scribes, 'Restrict collaborators'
+      -if @work.restrict_scribes && @scribes.empty?
+        p.warning =t('.restricted_work_no_collaborators_warning')
       small.legend =button_tag 'Apply', class: 'outline'
 
     -if @work.restrict_scribes

--- a/app/views/work/edit.html.slim
+++ b/app/views/work/edit.html.slim
@@ -168,7 +168,7 @@
         =f.check_box :restrict_scribes
         |&nbsp;
         =f.label :restrict_scribes, 'Restrict collaborators'
-      -if @work.restrict_scribes && @scribes.empty?
+      -if @collection.restricted? && @work.restrict_scribes && @scribes.empty?
         p.warning =t('.restricted_work_no_collaborators_warning')
       small.legend =button_tag 'Apply', class: 'outline'
 

--- a/config/locales/work/work-en.yml
+++ b/config/locales/work/work-en.yml
@@ -31,6 +31,7 @@ en:
       work_updated: "Work updated successfully"
     edit:
       additional_metadata: "Additional Metadata"
+      restricted_work_no_collaborators_warning: "Only project owners can edit this work. Add collaborators to make the work editable by others."
     description_versions:
       help_description: "View and compare the changes that have been made in each revision to work metadata. The left column shows the metadata in the selected revision, right column shows what has been changed. Unchanged text is <span>highlighted in white</span>, deleted text is <del>highlighted in red</del>, and inserted text is <ins>highlighted in green</ins> color."
       revision: "revision"


### PR DESCRIPTION
_Resolves #2952_

### The problem

If a work is restricted, its collection is private, and there are no collaborators added, only project owners will be able to edit the work. There are some works that meet all these requirements but are probably unaware of this.

### The solution

This adds a warning message if a work is restricted, its collection is private, and there are no collaborators added. It looks like this:

<img src="https://user-images.githubusercontent.com/35716893/165594062-b82b7205-5e57-4418-ba72-480c32e9563f.jpg" width=450>

