### PR TITLE
Hide review tab if no pages need review for #3129

### DIFF
--- a/app/views/shared/_collection_tabs.html.slim
+++ b/app/views/shared/_collection_tabs.html.slim
@@ -15,7 +15,7 @@
   :path => "#{collection_subjects_path(@collection.owner, @collection)}",
 }]
 
--if @collection.active? && user_signed_in? && current_user.can_review?(@collection) && @collection.review_type
+-if @collection.active? && user_signed_in? && current_user.can_review?(@collection) && @collection.review_type && @collection.pages.where(status: Page::STATUS_NEEDS_REVIEW).count > 0
   -tabs +=[{\
   :name => t('.review'),
   :selected => 12,


### PR DESCRIPTION
_Resolves #3129_

If there are no pages to review in a collection, the "review" tab will not show up at all.