### PR TITLE
Changed current collection/work link to include protocol and env for #3130

### DIFF
--- a/app/views/collection/edit.html.slim
+++ b/app/views/collection/edit.html.slim
@@ -13,7 +13,7 @@
         tr
           th.hidden URL
           td
-            p.nomargin.settings =t('.current_url', current_url: "<b>www.#{Rails.application.routes.default_url_options[:host]}/#{@collection.owner.slug}/#{@collection.slug}</b>").html_safe
+            p.nomargin.settings =t('.current_url', current_url: "<b>#{collection_url}</b>").html_safe
         tr
           td(colspan="2")
             =f.label :intro_block, t('.description'), class: "above"
@@ -111,7 +111,7 @@
 
     -if @collection.text_entry?
       h3 =t('.collection_link')
-      p =t('.page_needing_transcription', current_url:  "<b>www.#{Rails.application.routes.default_url_options[:host]}/#{@collection.owner.slug}/#{@collection.slug}/start_transcribing</b>").html_safe
+      p =t('.page_needing_transcription', current_url:  "<b>#{collection_start_transcribing_url(collection_id: @collection.slug)}</b>").html_safe
 
     h3 =t('.collection_privacy')
     -if @collection.restricted

--- a/app/views/collection/edit.html.slim
+++ b/app/views/collection/edit.html.slim
@@ -13,7 +13,7 @@
         tr
           th.hidden URL
           td
-            p.nomargin.settings =t('.current_url', current_url: "<b>#{collection_url}</b>").html_safe
+            p.nomargin.settings =t('.current_url', current_url: "<b>#{collection_url(@collection.owner.slug,@collection.slug)}</b>").html_safe
         tr
           td(colspan="2")
             =f.label :intro_block, t('.description'), class: "above"
@@ -111,7 +111,7 @@
 
     -if @collection.text_entry?
       h3 =t('.collection_link')
-      p =t('.page_needing_transcription', current_url:  "<b>#{collection_start_transcribing_url(collection_id: @collection.slug)}</b>").html_safe
+      p =t('.page_needing_transcription', current_url:  "<b>#{collection_start_transcribing_url(@collection.owner.slug, @collection.slug)}</b>").html_safe
 
     h3 =t('.collection_privacy')
     -if @collection.restricted

--- a/app/views/work/edit.html.slim
+++ b/app/views/work/edit.html.slim
@@ -27,7 +27,7 @@
         tr
           th.hidden Current URL
           td
-            p.nomargin.settings =t('.current_url', current_url: "<b>#{collection_read_work_url}</b>").html_safe
+            p.nomargin.settings =t('.current_url', current_url: "<b>#{collection_read_work_url( @work.collection.owner.slug, @work.collection.slug, @work.slug)}</b>").html_safe
         tr
           th =f.label :identifier, 'Identifier'
           td =f.text_field :identifier, value: @work.identifier

--- a/app/views/work/edit.html.slim
+++ b/app/views/work/edit.html.slim
@@ -27,8 +27,7 @@
         tr
           th.hidden Current URL
           td
-            p.nomargin.settings The current URL for this work is <b>www.#{Rails.application.routes.default_url_options[:host]}/#{@collection.owner.slug}/#{@collection.slug}/#{@work.slug}</b>.  If you want to edit the work section of the URL, please use lowercase letters and dashes between any words.
-
+            p.nomargin.settings =t('.current_url', current_url: "<b>#{collection_read_work_url}</b>").html_safe
         tr
           th =f.label :identifier, 'Identifier'
           td =f.text_field :identifier, value: @work.identifier

--- a/config/locales/collection/collection.en.yml
+++ b/config/locales/collection/collection.en.yml
@@ -75,7 +75,7 @@ en:
     #next section is admin only
     edit:
       title: "Title"
-      current_url: "The current URL for this collection is %{current_url}. If you want to edit the work section of the URL, please use lowercase letters and dashes between any words."
+      current_url: "The current URL for this collection is %{current_url}. If you want to edit the collection section of the URL, please use lowercase letters and dashes between any words."
       description: "Description"
       footer: "Footer"
       learn_more_footer: "Learn more about configuring the footer."

--- a/config/locales/work/work-en.yml
+++ b/config/locales/work/work-en.yml
@@ -31,6 +31,7 @@ en:
       work_updated: "Work updated successfully"
     edit:
       additional_metadata: "Additional Metadata"
+      current_url: "The current URL for this work is %{current_url}. If you want to edit the work section of the URL, please use lowercase letters and dashes between any words."
     description_versions:
       help_description: "View and compare the changes that have been made in each revision to work metadata. The left column shows the metadata in the selected revision, right column shows what has been changed. Unchanged text is <span>highlighted in white</span>, deleted text is <del>highlighted in red</del>, and inserted text is <ins>highlighted in green</ins> color."
       revision: "revision"


### PR DESCRIPTION
_Resolves #3130_

On the collection settings page, the collection's URL is displayed as well as a URL to send to transcribers. On the work settings page, the work's URL is displayed as well.

These URLs look like `www.fromthepage.com/user/collection` but we want them to:
1. Include the HTTP/HTTPS protocol being used
2. Reflect the user's environment, like `fromthepage.com` or `localhost`

So, now on my AWS environment the URLs look like:

![aws url](https://user-images.githubusercontent.com/35716893/166801394-d6d6b0fb-eee5-4a3c-ae8c-869198d4fb2d.jpg)

On a FTP.com environment, it would look like: 

![ftp url](https://user-images.githubusercontent.com/35716893/166801565-6f70f98a-5a19-4324-8536-5a64dd3cca7d.jpg)
