### PR TITLE
New subject distribution URL and export for #2628

### DIFF
--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -79,6 +79,12 @@ class ExportController < ApplicationController
     cookies['download_finished'] = 'true'
   end
 
+  def subject_distribution_csv
+    send_data(@collection.export_subject_distribution_as_csv(@article),
+              :filename => "fromthepage_subject_distribution_export_#{@collection.id}_#{Time.now.utc.iso8601}.csv",
+              :type => "application/csv")
+    cookies['download_finished'] = 'true'
+  end
 
   def subject_index_csv
     send_data(@collection.export_subject_index_as_csv,

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -2,6 +2,7 @@ require 'csv'
 require 'subject_exporter'
 require 'subject_details_exporter'
 require 'subject_coocurrence_exporter'
+require 'subject_distribution_exporter'
 
 class Collection < ApplicationRecord
   include CollectionStatistic
@@ -134,6 +135,12 @@ class Collection < ApplicationRecord
 
   def export_subject_coocurrence_as_csv
     subjects = SubjectCoocurrenceExporter::Exporter.new(self)
+
+    subjects.export
+  end
+
+  def export_subject_distribution_as_csv(subject)
+    subjects = SubjectDistributionExporter::Exporter.new(self, subject)
 
     subjects.export
   end

--- a/app/models/document_set.rb
+++ b/app/models/document_set.rb
@@ -106,6 +106,11 @@ class DocumentSet < ApplicationRecord
     subjects.export
   end
 
+  def export_subject_distribution_as_csv(subject)
+    subjects = SubjectDistributionExporter::Exporter.new(self, subject)
+
+    subjects.export
+  end
 
   def articles
     Article.joins(:pages).where(pages: {work_id: self.works.ids}).distinct

--- a/app/views/article/show.html.slim
+++ b/app/views/article/show.html.slim
@@ -67,11 +67,16 @@
     p  Only search text of pages which do not link to <em>#{@article.title}</em>
     =button_to "Search Unlinked Pages", { :controller => 'display', :action => 'search', :article_id => @article.id, :unlinked_only => true, :collection_id => @collection}, { :rel => 'nofolllow' }
  
+    -if user_signed_in? && current_user.like_owner?(@collection)
+      h3 Export
+      p Download a spreadsheet of coocurring subjects and works they appear in.
+      =link_to "Download", collection_subject_distribution_path(@collection.owner, @collection, @article), class: 'button btnExport'
  
 
 -content_for :javascript
   javascript:
     $(function() {
+
       $('[data-graph-category]').select2({
         placeholder: 'Select categories...',
         templateResult: function(category) {
@@ -81,4 +86,14 @@
           return $category;
         }
       });
+
+      $('.btnExport').on('click', function() {
+        Cookies.remove('download_finished', {path: '/'});
+        var downloadCheckTimer = window.setInterval(function() {
+          var cookie = Cookies.get('download_finished');
+          if(cookie === 'true') {
+            $('html').removeClass('page-busy');
+            window.clearInterval(downloadCheckTimer);
+          }
+        }, 1000);
     });

--- a/app/views/article/show.html.slim
+++ b/app/views/article/show.html.slim
@@ -91,9 +91,11 @@
         Cookies.remove('download_finished', {path: '/'});
         var downloadCheckTimer = window.setInterval(function() {
           var cookie = Cookies.get('download_finished');
+
           if(cookie === 'true') {
             $('html').removeClass('page-busy');
             window.clearInterval(downloadCheckTimer);
           }
         }, 1000);
+      });
     });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -511,7 +511,7 @@ Fromthepage::Application.routes.draw do
       get 'article/:article_id/edit', to: 'article#edit', as: 'article_edit'
       get 'article_version/:article_id', to: 'article_version#list', as: 'article_version'
       patch 'article/update/:article_id', to: 'article#update', as: 'article_update'
-      get 'article/:article_id/subject_distribution', to: 'export#subject_distribution_csv'
+      get 'article/:article_id/subject_distribution', to: 'export#subject_distribution_csv', as: 'subject_distribution'
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -511,6 +511,7 @@ Fromthepage::Application.routes.draw do
       get 'article/:article_id/edit', to: 'article#edit', as: 'article_edit'
       get 'article_version/:article_id', to: 'article_version#list', as: 'article_version'
       patch 'article/update/:article_id', to: 'article#update', as: 'article_update'
+      get 'article/:article_id/subject_distribution', to: 'export#subject_distribution_csv'
     end
   end
 

--- a/lib/subject_distribution_exporter.rb
+++ b/lib/subject_distribution_exporter.rb
@@ -19,63 +19,47 @@ module SubjectDistributionExporter
         'Work Title',
         'Work FromThePage ID',
         'Work Identifier',
-        'Work URI'
+        'Work Original Metadata'
       ] # plus work metadata
     end
 
     def export
-
-
-
-        # sql =
-        #   'SELECT count(*) as link_count, '+
-        #   'a.title as title, '+
-        #   'a.id as article_id '+
-        #   'FROM page_article_links to_links '+
-        #   'INNER JOIN page_article_links from_links '+
-        #   '  ON to_links.page_id = from_links.page_id '+
-        #   'INNER JOIN articles a '+
-        #   '  ON from_links.article_id = a.id '+
-        #   "WHERE to_links.article_id = #{@article.id} "+
-        #   " AND from_links.article_id != #{@article.id} "
-        # sql += "GROUP BY a.title, a.id "
-
-
-
-
       # we actually want to find all the works this subject is mentioned in,
       # then get all the pages in those works and all the subjects in those pages.
       work_ids = @article.pages.pluck(:work_id)
       work_ids = work_ids & @collection.works.pluck("works.id")
       page_in_works_ids = Page.where(work_id: work_ids).pluck(:id)
 
+      if page_in_works_ids.empty?
+        article_links=[]
+      else
 
-      sql = 
-        'select count(*) as link_count, '+
-        '  works.id as work_id, '+
-        'works.original_metadata as work_original_metadata, '+
-        'works.title as work_title, '+
-        'works.identifier as work_identifier, '+
-        '  to_a.id, '+
-        'to_a.title as to_title, '+
-        'to_a.id as to_article_id, '+
-        'to_a.uri as to_article_uri, '+
-        'to_a.latitude as to_article_longitude, '+
-        'to_a.longitude as to_article_latitude '+
-        'from page_article_links to_links '+
-        'INNER JOIN articles to_a '+
-        '  ON to_links.article_id = to_a.id '+
-        'inner join pages p '+
-        'on to_links.page_id = p.id '+
-        'inner join works '+
-        'on works.id = p.work_id '+
-        "WHERE to_links.article_id != #{@article.id} " +
-        "  AND to_links.page_id IN (#{page_in_works_ids.join(',')}) " +
-        'group by works.id, to_a.id'
+        sql = 
+          'select count(*) as link_count, '+
+          '  works.id as work_id, '+
+          'works.original_metadata as work_original_metadata, '+
+          'works.title as work_title, '+
+          'works.identifier as work_identifier, '+
+          '  to_a.id, '+
+          'to_a.title as to_title, '+
+          'to_a.id as to_article_id, '+
+          'to_a.uri as to_article_uri, '+
+          'to_a.latitude as to_article_longitude, '+
+          'to_a.longitude as to_article_latitude '+
+          'from page_article_links to_links '+
+          'INNER JOIN articles to_a '+
+          '  ON to_links.article_id = to_a.id '+
+          'inner join pages p '+
+          'on to_links.page_id = p.id '+
+          'inner join works '+
+          'on works.id = p.work_id '+
+          "WHERE to_links.article_id != #{@article.id} " +
+          "  AND to_links.page_id IN (#{page_in_works_ids.join(',')}) " +
+          'group by works.id, to_a.id'
 
 
-      article_links = Article.connection.select_all(sql)
-
+        article_links = Article.connection.select_all(sql)
+      end
 
 
 
@@ -115,31 +99,13 @@ module SubjectDistributionExporter
             coocurrence['link_count'],
             coocurrence['work_title'],
             coocurrence['work_id'],
-            coocurrence['work_identifier']
+            coocurrence['work_identifier'],
+            coocurrence['work_original_metadata']
           ]            
         end
       end
       csv_string
 
-      # csv_string = CSV.generate(force_quotes: true) do |csv|
-      #   csv << @headers
-
-      #   @subjects.each do |subject|
-      #     row = []
-      #     row << subject.title
-      #     row << subject.uri
-      #     row << subject.categories.map { |category| category.title }.join("; ")
-      #     row << Rails.application.routes.url_helpers.collection_article_show_url(@collection.owner, @collection, subject.id)
-      #     row << subject.source_text.split(/\s/).count
-      #     row << subject.source_text.chars.count
-      #     row << subject.page_article_links.count
-      #     row << if subject.provenance.blank? then 'FromThePage' else subject.provenance end
-      #     row << subject.created_on.iso8601
-
-      #     csv << row
-      #   end
-      # end
-      # csv_string
     end
 
   end


### PR DESCRIPTION
Subject distribution export is different from subject coocurrence export these ways:

- Limited to a single subject, listing subjects that occur in the same work as that subject
- Lists coocurrences even if they do not appear on the same page, but are on another page in the work
- Aggregated by subject _and work_