### PR TITLE
Added EDTF hint for document dates for #2976

### DIFF
--- a/app/views/work/edit.html.slim
+++ b/app/views/work/edit.html.slim
@@ -98,6 +98,9 @@
           th =f.label :document_date, 'Document Date'
           td =f.text_field :document_date, value: @work.document_date
         tr
+          th.hidden 'Document Date'
+          td =t('.document_date_hint')
+        tr
           th =f.label :genre
           td =f.text_field :genre, value: @work.genre
         tr

--- a/config/locales/work/work-en.yml
+++ b/config/locales/work/work-en.yml
@@ -32,6 +32,7 @@ en:
     edit:
       additional_metadata: "Additional Metadata"
       current_url: "The current URL for this work is %{current_url}. If you want to edit the work section of the URL, please use lowercase letters and dashes between any words."
+      document_date_hint: "Document Date is in the EDTF format (e.g. 1843, 2001-02, 1643-06-30)"
     description_versions:
       help_description: "View and compare the changes that have been made in each revision to work metadata. The left column shows the metadata in the selected revision, right column shows what has been changed. Unchanged text is <span>highlighted in white</span>, deleted text is <del>highlighted in red</del>, and inserted text is <ins>highlighted in green</ins> color."
       revision: "revision"


### PR DESCRIPTION
_Resolves #2976, related to #3115_

This adds a hint for the Document Date input in a work's additional metadata that the date should be in EDTF format.

![document date hint](https://user-images.githubusercontent.com/35716893/169834149-d63391a6-b087-4d30-bd9a-7f6bc9855c35.jpg)

We'd previously discussed either adding this hint or adding (EDTF) after the "Document Date" label; I think the hint is more helpful.