### PR TITLE
Removed options for changing subject graph for #3166

### DIFF
--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -93,12 +93,6 @@ class ArticleController < ApplicationController
   end
 
   def show
-    @categories = []
-    if params[:category_ids]
-      @categories = Category.find(params[:category_ids])
-      @article.graph_image = nil
-    end
-
     #if @article.graph_image && !params[:force]
     #   return
     #end
@@ -113,12 +107,6 @@ class ArticleController < ApplicationController
       '  ON from_links.article_id = a.id '+
       "WHERE to_links.article_id = #{@article.id} "+
       " AND from_links.article_id != #{@article.id} "
-    if params[:category_ids]
-      sql += " AND from_links.article_id IN "+
-        "(SELECT article_id "+
-        "FROM articles_categories "+
-        "WHERE category_id IN (#{params[:category_ids].join(',')}))"
-    end
     sql += "GROUP BY a.title, a.id "
     logger.debug(sql)
     article_links = Article.connection.select_all(sql)
@@ -179,7 +167,6 @@ class ArticleController < ApplicationController
 
     @map = File.read(dot_out_map)
     @article.graph_image = dot_out
-    @min_rank = min_rank
     @article.save!
     session[:col_id] = @collection.slug
   end

--- a/app/views/article/show.html.slim
+++ b/app/views/article/show.html.slim
@@ -21,26 +21,6 @@
       ==@map
     p.fglight =="The graph displays the other subjects mentioned on the same pages as the subject &ldquo;#{@article.title}&rdquo;. If the same subject occurs on a page with &ldquo;#{@article.title}&rdquo; more than once, it appears closer to &ldquo;#{@article.title}&rdquo; on the graph, and is colored in a darker shade. The closer a subject is to the center, the more &quot;related&quot; the subjects are."
 
-    =form_for(@article, method: 'post', url: { action: 'show', article_id: @article.id }) do |f|
-      =hidden_field_tag(:force, true)
-      table.form
-        tr
-          td(colspan="3")
-            span Limit the graph to subjects in these categories (leave blank to show all):
-            =label_tag "category-select", 'Select categories', class: 'hidden'
-            select(name="category_ids[]" size="10" id="category-select" aria-label="Select categories" multiple data-graph-category)
-              -@collection.categories.walk_tree do |c, level|
-                -selected = true if @categories.include?(c)
-                option(data-level=level value=c.id selected=selected) =c.title
-        tr
-          =label_tag 'min_rank', "Minimum number of subjects", class: 'hidden'
-          td
-            =text_field_tag('min_rank', @min_rank, type: 'number', min: 1, style: 'width:50px', "aria-label" => 'minimum number of subjects')
-          td.w100.fglight.small =="Show related subjects that appear on at least this number of pages in common with #{@article.title}."
-          th =button_tag
-            =svg_symbol '#icon-refresh', class: 'icon'
-            span Update Graph
-
   aside.sidecol
     -if user_signed_in? && @article.possible_duplicates.present?
       h5

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -513,7 +513,7 @@ Fromthepage::Application.routes.draw do
       get ':work_id/annotation/:page_id/html/translation', to: 'annotation#page_translation_html', as: 'annotation_page_translation_html'
 
       #article related routes
-      match 'article/:article_id', to: 'article#show', via: [:get, :post], as: 'article_show'
+      get 'article/:article_id', to: 'article#show', as: 'article_show'
       get 'article/:article_id/edit', to: 'article#edit', as: 'article_edit'
       get 'article_version/:article_id', to: 'article_version#list', as: 'article_version'
       patch 'article/update/:article_id', to: 'article#update', as: 'article_update'


### PR DESCRIPTION
_Resolves #3166_

This removes the options to change the subject graph on a subject page [like this one](https://fromthepage.com/benwbrum/jeremiah-white-graves-diaries/article/66587) because they don't pass accessibility testing & we don't know how to fix it.

![image](https://user-images.githubusercontent.com/35716893/172646473-605c54d5-deea-41b3-aa12-00ecf4757660.png)

It also removes all related code in the controller and routing.