### PR TITLE
Made subject list organized vertically instead of horizontally for #2385

### DIFF
--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -33,10 +33,10 @@ class ArticleController < ApplicationController
     # Create a 2D array of articles/subjects for each category
     # where the articles are sorted alphabetically vertically
     # instead of horizontally -- so, going down each column
-    @vertical_articles = Array.new(@categories.length()) # Holds articles for each category
-    @categories.each_with_index do |category, i|
+    @vertical_articles = {} # Holds articles for each category
+    @categories.each do |category|
       articles = category.articles_list(@collection) # The articles for this category
-      @vertical_articles[i] = sort_vertically(articles)
+      @vertical_articles[category] = sort_vertically(articles)
     end
 
     # Do the same for uncategorized articles
@@ -347,7 +347,7 @@ class ArticleController < ApplicationController
   end
 
   def sort_vertically(articles)
-    rows = (articles.length() % LIST_NUM_COLUMNS == 0) ? (articles.length() / LIST_NUM_COLUMNS) : (articles.length()  / LIST_NUM_COLUMNS + 1)
+    rows = (articles.length().to_f / LIST_NUM_COLUMNS).ceil
     vertical_articles = Array.new(rows) { Array.new(LIST_NUM_COLUMNS) } # 2D array of articles
 
     row = 0

--- a/app/views/article/list.html.slim
+++ b/app/views/article/list.html.slim
@@ -18,7 +18,7 @@
           li: a.tree-item(href="#category-none") Uncategorized
 
     .category-articles
-      -@categories.each_with_index do |category, i|
+      -@categories.each do |category|
         dl.category-article(id="category-#{category.id}")
           dt
             .headline
@@ -47,8 +47,8 @@
             -if category.articles_list(@collection).empty?
               p.acenter.fglight There are no subjects for the category selected
             -else
-              -@vertical_articles[i].each do |l|
-                -l.each do |article|
+              -@vertical_articles[category].each do |row|
+                -row.each do |article|
                   -unless article.nil?
                     p[*language_attrs(@collection)]
                       =link_to article.title, collection_article_show_path(@collection.owner, @collection, article.id)

--- a/app/views/article/list.html.slim
+++ b/app/views/article/list.html.slim
@@ -18,7 +18,7 @@
           li: a.tree-item(href="#category-none") Uncategorized
 
     .category-articles
-      -@categories.each do |category|
+      -@categories.each_with_index do |category, i|
         dl.category-article(id="category-#{category.id}")
           dt
             .headline
@@ -47,16 +47,26 @@
             -if category.articles_list(@collection).empty?
               p.acenter.fglight There are no subjects for the category selected
             -else
-              -category.articles_list(@collection).each do |article|
-                p[*language_attrs(@collection)]
-                  =link_to article.title, collection_article_show_path(@collection.owner, @collection, article.id)
+              -@vertical_articles[i].each do |l|
+                -l.each do |article|
+                  -unless article.nil?
+                    p[*language_attrs(@collection)]
+                      =link_to article.title, collection_article_show_path(@collection.owner, @collection, article.id)
+                  -else
+                    p.hidden
+                      a.hidden a
       -if @uncategorized_articles.present?
         dl.category-article#category-none
           dt: h3 Uncategorized subjects
           dd
-            -@uncategorized_articles.each do |article|
-              p[*language_attrs(@collection)]
-                =link_to article.title, collection_article_show_path(@collection.owner, @collection, article.id)
+            -@uncategorized_articles.each do |l|
+              -l.each do |article|
+                -unless article.nil?
+                  p[*language_attrs(@collection)]
+                    =link_to article.title, collection_article_show_path(@collection.owner, @collection, article.id)
+                -else
+                  p.hidden
+                    a.hidden a
 -else
   -add_category = link_to 'Create the first category', category_add_new_path(:collection_id => @collection.slug), 'data-litebox' => ''
   .nodata


### PR DESCRIPTION
_Resolves #2385_

### The problem

> On the subjects pages, subject terms would be easier to read and identify if they were organized alphabetically vertically in the column, rather than horizontally.

This is how the subject list was previously displayed, with subjects alphabetically going across and then down.

<img src="https://user-images.githubusercontent.com/35716893/173403878-2f9a7410-09ec-4f54-b226-c8a646327b0c.jpg" alt="horizontal subjects" width="80%">

### The solution

The subjects are now listed alphabetically going down and then across.

<img src="https://user-images.githubusercontent.com/35716893/173404649-3ef1e370-05d9-400e-987c-f7fff72adda3.jpg" alt="vertical subjects" width="80%">

### Method

Because the subjects are showed in 3 columns using `float: left`, they are inherently sorted horizontally and cannot easily be organized vertically (there is no `float: down`). So, to organize them vertically, I could either: (1) change how the subject list is displayed, or (2) place the subjects into the list in an order in which they would be organized vertically. Because I didn't quickly find a way to implement the first, I decided the second option was the best solution.

For each category, there is a 2D array containing the subjects in the order they will be displayed. The array is 3 across and however long it needs to be. In the controller, each subject is placed into this array going down each column. Then, in the view, each subject in the array is placed, going across each row. 