### PR TITLE
Fix #3172 by reducing double square braces in IA ocr text

### DIFF
--- a/app/models/ia_work.rb
+++ b/app/models/ia_work.rb
@@ -87,7 +87,6 @@ class IaWork < ApplicationRecord
       page.base_width = leaf.page_w
       page.title = leaf.page_number
       page.source_text = leaf.ocr_text if self.use_ocr
-      binding.pry unless page.valid?
       work.pages << page #necessary to make acts_as_list work here
       work.save!
 
@@ -241,7 +240,7 @@ class IaWork < ApplicationRecord
     # clean any angle braces -- this source won't be HTML
     title.gsub!("<", "&lt;")
     title.gsub!(">", "&gt;")
-    title.gsub!(/\[\[+/, "[")
+    title.gsub!(/\[\[+/, "[") #this
 
     title
   end


### PR DESCRIPTION
The underlying problem was a page with three lines of text containing `[[`, an OCR artifact which we were interpreting as the beginning of a wiki-link.  This reduces any repeated `[` characters in imported OCR to a single `[`.