### PR TITLE
Extracted Devise string literals to keys for #3174

### DIFF
--- a/app/views/devise/confirmations/new.html.slim
+++ b/app/views/devise/confirmations/new.html.slim
@@ -1,13 +1,13 @@
--content_for :page_title, "Resend Confirmation"
+-content_for :page_title, t('.resend_confirmation')
 
 section.signon
-  h1 Resend Confirmation
-  p Please enter the email address associated with your FromThePage account and we will resend the confirmation instructions at your email address in a few minutes.
+  h1= t('.resend_confirmation')
+  p= t('.message')
   =form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
     =devise_error_messages!
     .signon_field
-      =f.label :email, 'Email address'
+      =f.label :email, t('devise.email_address')
       =f.email_field :email, autofocus: true
-    =f.button 'Resend Instructions', class: 'big'
+    =f.button t('.resend_instructions'), class: 'big'
   hr
   =render 'devise/shared/links'

--- a/app/views/devise/passwords/edit.html.slim
+++ b/app/views/devise/passwords/edit.html.slim
@@ -1,17 +1,17 @@
--content_for :page_title, "Change Password"
+-content_for :page_title, t('.change_password')
 
 section.signon
-  h1 Change Password
-  p Create a new password for your account. Password must be at least 8 characters long and contain both letters and numbers. Please don't use the same password you use for your online bank or email account!
+  h1= t('.change_password')
+  p= t('.change_password_message')
   =form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
     =devise_error_messages!
     =f.hidden_field :reset_password_token
     .signon_field
-      =f.label :password, 'New password'
+      =f.label :password, t('.new_password')
       =f.password_field :password, autofocus: true, autocomplete: 'off'
     .signon_field
-      =f.label :password_confirmation
+      =f.label :password_confirmation, t('devise.confirm_password')
       =f.password_field :password_confirmation, autocomplete: 'off'
-    =f.button 'Change Password', class: 'big'
+    =f.button t('.change_password'), class: 'big'
   hr
   =render 'devise/shared/links'

--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -1,13 +1,13 @@
--content_for :page_title, "Password Recovery"
+-content_for :page_title, t('.password_recovery')
 
 section.signon
-  h1 Password Recovery
-  p Please enter the email address associated with your FromThePage account. If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes.
+  h1= t('.password_recovery')
+  p= t('.message')
   =form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
     =devise_error_messages!
     .signon_field
-      =f.label :email, 'Email address'
+      =f.label :email, t('devise.email_address')
       =f.email_field :email, autofocus: true
-    =f.button 'Recover Password', class: 'big'
+    =f.button t('.recover_password'), class: 'big'
   hr
   =render 'devise/shared/links'

--- a/app/views/devise/registrations/choose_saml.html.slim
+++ b/app/views/devise/registrations/choose_saml.html.slim
@@ -1,11 +1,11 @@
--content_for :page_title, "Sign In"
+-content_for :page_title, t('devise.sign_in')
 
 section.signon
-  h1 Sign in with your Institution
+  h1= t('.sign_in_with_institution')
   =form_tag(registrations_set_provider_path) do
     fieldset.signon_fieldset
-      =label_tag :institution, class: 'signon_label'
-        =select_tag(:institution, options_for_select([['Church of Jesus Christ of Latter Day Saints', 'lds'],['Harvard University','harvard']]), autofocus: true)
+      =label_tag :institution, t('.institution'), class: 'signon_label'
+        =select_tag(:institution, options_for_select([[t('.lds_full_name'), 'lds'],[t('.harvard_university'),'harvard']]), autofocus: true)
     .toolbar
       .toolbar_group
-        =button_tag 'Sign In', class: 'strong signin'
+        =button_tag t('devise.sign_in'), class: 'strong signin'

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -1,38 +1,38 @@
--content_for :page_title, "Edit Account"
+-content_for :page_title, t('.edit_account')
 
 section.signon
-  h1 Edit Account
-  p Here you can change your account information. If you don't want to change your password, leave the password fields blank. You're required to enter your current password to confirm changes.
+  h1= t('.edit_account')
+  p= t('.message')
 
   -if devise_mapping.confirmable? && resource.pending_reconfirmation?
-    p Currently waiting confirmation for #{resource.unconfirmed_email}
+    p= t('.waiting_confirmation_message', resource: (resource.unconfirmed_email))
 
   =form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
     =devise_error_messages!
     .signon_field
-      =f.label :login, 'User Name'
+      =f.label :login, t('devise.user_name')
       =f.text_field :login, autofocus: true
     .signon_field
-      =f.label :email, 'Email Address'
+      =f.label :email, t('devise.email_address')
       =f.email_field :email
     .signon_field
-      =f.label :password, 'New Password'
+      =f.label :password, t('.new_password')
       =f.password_field :password, autocomplete: 'off'
     .signon_field
-      =f.label :password_confirmation, 'Confirm Password'
+      =f.label :password_confirmation, t('devise.confirm_password')
       =f.password_field :password_confirmation, autocomplete: 'off'
     .signon_field
-      =f.label :current_password, 'Current Password'
+      =f.label :current_password, t('.current_password')
       =f.password_field :current_password, autocomplete: 'off'
     .signon_field
-      =f.label :real_name, 'Real Name'
+      =f.label :real_name, t('devise.real_name')
       =f.text_field :real_name
       small
-        i Projects may use this when giving you credit. Leave this blank if you do not want to be credited.
+        i= t('devise.real_name_message')
     .toolbar
       .toolbar_group
-        =f.button 'Save Changes', class: 'big'
+        =f.button t('.save_changes'), class: 'big'
       .toolbar_group.aright
-        =link_to registration_path(resource_name), data: { confirm: 'Are you sure you want to delete your account? After deleting the account you won\'t be able to recover it!' }, method: :delete
+        =link_to registration_path(resource_name), data: { confirm: t('.confirm_delete_account') }, method: :delete
           =svg_symbol '#icon-remove-sign', class: 'icon'
-          span Delete Account
+          span= t('.delete_account')

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -1,28 +1,28 @@
--content_for :page_title, "Sign Up"
+-content_for :page_title, t('devise.sign_up')
 
 section.signon
-  h1 Sign Up
+  h1= t('devise.sign_up')
   =form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
     =devise_error_messages!
     .signon_field
-      =f.label :login, 'User Name'
+      =f.label :login, t('devise.user_name')
       =f.text_field :login, autofocus: true
       small
-        i You'll use this name to log in. It will be shown publicly.
+        i= t('devise.user_name_message')
     .signon_field
-      =f.label :email, 'Email Address'
+      =f.label :email, t('devise.email_address')
       =f.email_field :email
     .signon_field
-      =f.label :password
+      =f.label :password, t('devise.password')
       =f.password_field :password, autocomplete: 'off'
     .signon_field
-      =f.label :password_confirmation, 'Confirm Password'
+      =f.label :password_confirmation, t('devise.confirm_password')
       =f.password_field :password_confirmation, autocomplete: 'off'
     .signon_field
-      =f.label :real_name, 'Real Name'
+      =f.label :real_name, t('devise.real_name')
       =f.text_field :real_name
       small
-        i Projects may use this when giving you credit. Leave this blank if you do not want to be credited.
+        i= t('devise.real_name_message')
     .signon_field
       =f.hidden_field :owner
       =f.hidden_field :paid_date
@@ -31,8 +31,8 @@ section.signon
         =recaptcha_tags
     .signon_field
       =f.check_box :activity_email, checked: true
-      =f.label :receive_activity_emails
-    =f.button 'Create Account', class: 'big'
+      =f.label :receive_activity_emails, t('devise.receive_activity_emails')
+    =f.button t('devise.create_account'), class: 'big'
   hr
   =render 'devise/shared/links'
 -unless MIXPANEL_ID.blank?

--- a/app/views/devise/registrations/new_trial.html.slim
+++ b/app/views/devise/registrations/new_trial.html.slim
@@ -1,32 +1,29 @@
--content_for :page_title, "Sign Up for a Trial"
+-content_for :page_title, t('.sign_up_for_trial')
 
 section.signon
-  h1 Sign Up for a Trial
+  h1= t('.sign_up_for_trial')
   p
-    'Please fill in the following information to create a two hundred page trial
-    'FromThePage project owner account.  Have questions?  
-    a href='https://calendly.com/fromthepage/30-minute-meeting/' Schedule a kickoff call.
+    ==t('.message', schedule_a_kickoff_call: (link_to t('.schedule_a_kickoff_call'), 'https://calendly.com/fromthepage/30-minute-meeting/'))
     <br><br>
-    'Just want to transcribe?  
-    =link_to 'Sign Up Here', new_user_registration_path
+    ==t('.just_want_to_transcribe', sign_up_here: (link_to t('.sign_up_here'), new_user_registration_path))
 
 
   =form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
     =devise_error_messages!
     .signon_field
-      =f.label :login
+      =f.label :login, t('.login')
       =f.text_field :login, autofocus: true
     .signon_field
-      =f.label :email, 'Email address'
+      =f.label :email, t('devise.email_address')
       =f.email_field :email
     .signon_field
-      =f.label :password
+      =f.label :password, t('devise.password')
       =f.password_field :password, autocomplete: 'off'
     .signon_field
-      =f.label :password_confirmation
+      =f.label :password_confirmation, t('devise.confirm_password')
       =f.password_field :password_confirmation, autocomplete: 'off'
     .signon_field
-      =f.label :display_name
+      =f.label :display_name, t('devise.display_name')
       =f.text_field :real_name
     .signon_field
       =f.hidden_field :owner, value: true
@@ -36,9 +33,9 @@ section.signon
         =recaptcha_tags
     .signon_field
       =f.check_box :activity_email, checked: true
-      =f.label :receive_activity_emails
+      =f.label :receive_activity_emails, t('devise.receive_activity_emails')
     <br>
-    =f.button 'Create Account', class: 'big'
+    =f.button t('devise.create_account'), class: 'big'
 
   javascript:  mixpanel.track("Sign Up");
 

--- a/app/views/devise/registrations/owner_new.html.slim
+++ b/app/views/devise/registrations/owner_new.html.slim
@@ -1,28 +1,28 @@
--content_for :page_title, "Sign Up"
+-content_for :page_title, t('devise.sign_up')
 
 section.signon
-  h1 Sign Up
+  h1= t('devise.sign_up')
   =form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
     =devise_error_messages!
     .signon_field
-      =f.label :login, 'User Name'
+      =f.label :login, t('devise.user_name')
       =f.text_field :login, autofocus: true
       small
-        i You'll use this name to log in. It will be shown publicly.
+        i= t('devise.user_name_message')
     .signon_field
-      =f.label :email, 'Email Address'
+      =f.label :email, t('devise.email_address')
       =f.email_field :email
     .signon_field
-      =f.label :password
+      =f.label :password, t('devise.password')
       =f.password_field :password, autocomplete: 'off'
     .signon_field
-      =f.label :password_confirmation, 'Confirm Password'
+      =f.label :password_confirmation, t('devise.confirm_password')
       =f.password_field :password_confirmation, autocomplete: 'off'
     .signon_field
-      =f.label :real_name, 'Real Name'
+      =f.label :real_name, t('devise.real_name')
       =f.text_field :real_name
       small
-        i Projects may use this when giving you credit. Leave this blank if you do not want to be credited.
+        i= t('devise.real_name_message')
     .signon_field
     =hidden_field_tag :owner_slug, @owner.slug
     -if RECAPTCHA_ENABLED
@@ -30,8 +30,8 @@ section.signon
         =recaptcha_tags
     .signon_field
       =f.check_box :activity_email, checked: true
-      =f.label :receive_activity_emails
-    =f.button 'Create Account', class: 'big'
+      =f.label :receive_activity_emails, t('devise.receive_activity_emails')
+    =f.button t('devise.create_account'), class: 'big'
   hr
   =render 'devise/shared/links'
 -unless MIXPANEL_ID.blank?

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,48 +1,48 @@
--content_for :page_title, "Sign In"
+-content_for :page_title, t('devise.sign_in')
 
 section.signon
   h1 
-    |Sign in 
+    =t('devise.sign_in')
   =form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
     =devise_error_messages!
     fieldset.signon_fieldset
       =f.label :login_id, class: 'signon_label'
-        =f.text_field :login_id, autofocus: true, placeholder: 'Login'
+        =f.text_field :login_id, autofocus: true, placeholder: t('devise.login')
         =svg_symbol '#icon-user', class: 'signon_label_icon'
       =f.label :password, class: 'signon_label'
-        =f.password_field :password, autocomplete: 'off', placeholder: 'Password'
+        =f.password_field :password, autocomplete: 'off', placeholder: t('devise.password')
         =svg_symbol '#icon-key', class: 'signon_label_icon'
     .toolbar
       .toolbar_group
-        =f.button 'Sign In', class: 'strong signin'
+        =f.button t('devise.sign_in'), class: 'strong signin'
       -if devise_mapping.rememberable?
         .toolbar_group.aright
           =f.label :remember_me
             =f.check_box :remember_me
-            |&nbsp;Remember me
+            =t('.remember_me')
 
   - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-    =link_to 'Forgot your password?', new_password_path(resource_name), class: 'forgot'
+    =link_to t('.forgot_your_password'), new_password_path(resource_name), class: 'forgot'
 
   -if ENABLE_SAML  
     hr
-    h4 or
-    =button_to('Sign in with your Institution (SSO)', registrations_choose_provider_path, class: 'strong signin')
+    h4= t('.or')
+    =button_to(t('.sign_in_with_institution'), registrations_choose_provider_path, class: 'strong signin')
 
   hr
 
 
   section#sign_up.signup-links
-    h2 Sign Up
-    p Want to join an existing project as a transcriber? Sign up as a transcriber.
+    h2= t('devise.sign_up')
+    p= t('.sign_up_as_transcriber_message')
 
-    = link_to "Sign Up Now", new_user_registration_path, class: 'button big'
+    = link_to t('.sign_up_now'), new_user_registration_path, class: 'button big'
 
   section#free_trial.signup-links
-    h2 Start Free Trial
-    p Want to begin a new transcription project? Start a free trial.
+    h2= t('.start_free_trial')
+    p= t('.start_free_trial_message')
 
-    =link_to 'Start Free Trial', users_new_trial_path, class: 'button big'
+    =link_to t('.start_free_trial'), users_new_trial_path, class: 'button big'
 
   hr.clearfix
 

--- a/app/views/devise/shared/_links.html.slim
+++ b/app/views/devise/shared/_links.html.slim
@@ -1,21 +1,21 @@
 ul.signon_links
   -if controller_name != 'sessions'
-    li =link_to 'Sign in existing account', new_session_path(resource_name)
+    li =link_to t('.sign_in_existing_account'), new_session_path(resource_name)
 
   -if devise_mapping.registerable? && controller_name != 'registrations'
-    li =link_to 'Sign up for a new account', new_registration_path(resource_name)
+    li =link_to t('.sign_up_new_account'), new_registration_path(resource_name)
 
   -if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-    li =link_to 'Forgot your password?', new_password_path(resource_name)
+    li =link_to t('.forgot_your_password'), new_password_path(resource_name)
 
   -if devise_mapping.confirmable? && controller_name != 'confirmations'
-    li =link_to 'Didn\'t receive confirmation instructions?', new_confirmation_path(resource_name)
+    li =link_to t('.no_confirmation_instructions'), new_confirmation_path(resource_name)
 
   -if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
-    li =link_to 'Didn\'t receive unlock instructions?', new_unlock_path(resource_name)
+    li =link_to t('.no_unlock_instructions'), new_unlock_path(resource_name)
 
   -if devise_mapping.omniauthable?
     -if ENABLE_GOOGLEOAUTH
-      li = link_to "Sign in with Google", user_omniauth_authorize_path(:google_oauth2)
+      li = link_to t('.sign_in_with_google'), user_omniauth_authorize_path(:google_oauth2)
     -if ENABLE_SAML
-      p =button_to('Sign in with your Institution (SSO)', registrations_choose_provider_path, class: 'strong signin')
+      p =button_to(t('.sign_in_with_institution'), registrations_choose_provider_path, class: 'strong signin')

--- a/app/views/devise/unlocks/new.html.slim
+++ b/app/views/devise/unlocks/new.html.slim
@@ -1,13 +1,13 @@
--content_for :page_title, "Resend Unlock Instructions"
+-content_for :page_title, t(".resend_unlock_instructions")
 
 section.signon
-  h1 Resend Unlock Instructions
-  p Please enter the email address associated with your FromThePage account and we will resend the unlock instructions at your email address in a few minutes.
+  h1= t('.resend_unlock_instructions')
+  p= t('.message')
   =form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
     =devise_error_messages!
     .signon_field
-      =f.label :email, 'Email address'
+      =f.label :email, t('devise.email_address')
       =f.email_field :email, autofocus: true
-    =f.button 'Resend Instructions', class: 'big'
+    =f.button t('.resend_instructions'), class: 'big'
   hr
   =render 'devise/shared/links'

--- a/config/locales/devise/devise-en.yml
+++ b/config/locales/devise/devise-en.yml
@@ -1,10 +1,18 @@
 ---
 en:
   devise:
+    confirm_password: Confirm password
     confirmations:
       confirmed: Your account has been successfully confirmed.
+      new:
+        message: Please enter the email address associated with your FromThePage account and we will resend the confirmation instructions at your email address in a few minutes.
+        resend_confirmation: Resend Confirmation
+        resend_instructions: Resend Instructions
       send_instructions: You will receive an email with instructions for how to confirm your account in a few minutes.
       send_paranoid_instructions: If your email address exists in our database, you will receive an email with instructions for how to confirm your account in a few minutes.
+    create_account: Create Account
+    display_name: Display name
+    email_address: Email address
     failure:
       already_authenticated: You are already signed in.
       inactive: Your account is not activated yet.
@@ -15,6 +23,7 @@ en:
       timeout: Your session expired. Please sign in again to continue.
       unauthenticated: You need to sign in or sign up before continuing.
       unconfirmed: You have to confirm your email address before continuing.
+    login: Login
     mailer:
       confirmation_instructions:
         subject: Confirmation instructions
@@ -29,14 +38,53 @@ en:
     omniauth_callbacks:
       failure: Could not authenticate you from %{kind} because "%{reason}".
       success: Successfully authenticated from %{kind} account.
+    password: Password
     passwords:
+      edit:
+        change_password: Change password
+        change_password_message: Create a new password for your account. Password must be at least 8 characters long and contain both letters and numbers. Please don't use the same password you use for your online bank or email account!
+        new_password: New password
+      new:
+        message: Please enter the email address associated with your FromThePage account. If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes.
+        password_recovery: Password Recovery
+        recover_password: Recover Password
       no_token: You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided.
       send_instructions: You will receive an email with instructions on how to reset your password in a few minutes.
       send_paranoid_instructions: If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes.
       updated: Your password has been changed successfully. You are now signed in.
       updated_not_active: Your password has been changed successfully.
+    real_name: Real name
+    real_name_message: Projects may use this when giving you credit. Leave this blank if you do not want to be credited.
+    receive_activity_emails: Receive activity emails
     registrations:
+      choose_saml:
+        harvard_university: Harvard University
+        institution: Institution
+        lds_full_name: Church of Jesus Christ of Latter Day Saints
+        sign_in_with_institution: Sign in with your Institution
       destroyed: Bye! Your account has been successfully cancelled. We hope to see you again soon.
+      edit:
+        confirm_delete_account: Are you sure you want to delete your account? After deleting the account you won't be able to recover it!
+        current_password: Current password
+        delete_account: Delete Account
+        edit_account: Edit Account
+        message: Here you can change your account information. If you don't want to change your password, leave the password fields blank. You're required to enter your current password to confirm changes.
+        new_password: New password
+        save_changes: Save Changes
+        waiting_confirmation_message: Currently waiting confirmation for %{resource}
+      new_trial:
+        fill_in_the_following: Please fill in the following information to create a two hundred page trial
+        just_want_to_transcribe: Just want to transcribe? %{sign_up_here}
+        login: Login
+        message: Please fill in the following information to create a two hundred page trial FromThePage project owner account.  Have questions?  %{schedule_a_kickoff_call}
+        project_owner_account_have: FromThePage project owner account. Have questions?
+        schedule_a_kickoff_call: Schedule a kickoff call.
+        sign_up_for_trial: Sign Up for a Trial
+        sign_up_here: Sign Up Here
+        want_to_transcribe: want to transcribe?
+      owner_new:
+        projects_may_use_this: Projects may use this when giving you credit. Leave this blank if you do not want to be credited.
+        you_ll_use_this: You'll use this name to log in. It will be shown publicly.
       signed_up: Welcome! You have signed up successfully.
       signed_up_but_inactive: You have signed up successfully. However, we could not sign you in because your account is not yet activated.
       signed_up_but_locked: You have signed up successfully. However, we could not sign you in because your account is locked.
@@ -46,12 +94,38 @@ en:
       updated_but_not_signed_in: Your account has been updated successfully, but since your password was changed, you need to sign in again
     sessions:
       already_signed_out: Signed out successfully.
+      new:
+        forgot_your_password: Forgot your password?
+        or: or
+        remember_me: " Remember me"
+        sign_in_with_institution: Sign in with your Institution (SSO)
+        sign_up_as_transcriber_message: Want to join an existing project as a transcriber? Sign up as a transcriber.
+        sign_up_now: Sign Up Now
+        start_free_trial: Start Free Trial
+        start_free_trial_message: Want to begin a new transcription project? Start a free trial.
       signed_in: Signed in successfully.
       signed_out: Signed out successfully.
+    shared:
+      links:
+        forgot_your_password: Forgot your password?
+        no_confirmation_instructions: Didn't receive confirmation instructions?
+        no_unlock_instructions: Didn't receive unlock instructions?
+        sign_in_existing_account: Sign in existing account
+        sign_in_with_google: Sign in with Google
+        sign_in_with_institution: Sign in with your Institution (SSO)
+        sign_up_new_account: Sign up for a new account
+    sign_in: Sign In
+    sign_up: Sign Up
     unlocks:
+      new:
+        message: Please enter the email address associated with your FromThePage account and we will resend the unlock instructions at your email address in a few minutes.
+        resend_instructions: Resend Instructions
+        resend_unlock_instructions: Resend Unlock Instructions
       send_instructions: You will receive an email with instructions for how to unlock your account in a few minutes.
       send_paranoid_instructions: If your account exists, you will receive an email with instructions for how to unlock it in a few minutes.
       unlocked: Your account has been unlocked successfully. Please sign in to continue.
+    user_name: User name
+    user_name_message: You'll use this name to log in. It will be shown publicly.
   errors:
     messages:
       already_confirmed: was already confirmed, please try signing in


### PR DESCRIPTION
_Resolves #3174, helps #3165_

This extracts all string literals in Devise views into keys with the help of [Slimkeyfy](https://github.com/phrase/slimkeyfy) so that our Devise views are internationalized.

I skipped the mailer views for now, I'll go back to them when I have a way to test mailers.