### PR TITLE
Test translation to French

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,7 @@ group :development, :test do
   gem 'bullet'
   gem 'listen'
   gem 'i18n-tasks', '~> 0.9.31'
+  gem 'easy_translate'
 end
 
 # Use SassC for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,6 +183,9 @@ GEM
       railties (>= 5.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
+    easy_translate (0.5.1)
+      thread
+      thread_safe
     edtf (3.0.8)
       activesupport (>= 3.0, < 8.0)
     edtf-humanize (2.0.1)
@@ -471,6 +474,7 @@ GEM
       unicode-display_width (>= 1.1.1, < 3)
     text (1.3.1)
     thor (1.2.1)
+    thread (0.2.2)
     thread_safe (0.3.6)
     tilt (2.0.10)
     tins (1.31.1)
@@ -528,6 +532,7 @@ DEPENDENCIES
   devise
   devise-encryptable
   devise_masquerade (~> 1.2.0)
+  easy_translate
   edtf
   edtf-humanize
   factory_bot_rails

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module Fromthepage
 
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**/*.{rb,yml}').to_s]
     config.i18n.default_locale = :en
-    config.i18n.available_locales = [:en, :es, :pt]
+    config.i18n.available_locales = [:en, :es, :pt, :fr]
     config.i18n.fallbacks = true
     config.i18n.fallbacks = [:en]
   end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -3,7 +3,7 @@
 # The "main" locale.
 base_locale: en
 ## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
-locales: [en, es, pt]
+locales: [en, es, pt, fr]
 ## Reporting locale, default: en. Available: en, ru.
 # internal_locale: en
 

--- a/config/locales/article_version/article_version-fr.yml
+++ b/config/locales/article_version/article_version-fr.yml
@@ -1,0 +1,14 @@
+---
+fr:
+  article_version:
+    show:
+      description: Ici, vous pouvez voir toutes les révisions de sujet et comparer les modifications apportées à chaque révision. La colonne de gauche affiche le titre et la description du sujet dans la révision sélectionnée, la colonne de droite indique ce qui a été modifié. Le texte inchangé est <span>surligné en blanc</span>, le texte supprimé est <del>surligné en rouge</del> et le texte inséré est <ins>surligné en vert</ins>.
+      n_revisions:
+        one: 1 révision
+        other: "%{count} révisions"
+      no_description_provided: Aucune description fournie
+      no_versions_to_compare: Il n'y a pas de versions à comparer
+      no_versions_to_compare_description: Ce sujet n'a pas été décrit, c'est pourquoi nous n'avons pas de versions d'articles à comparer.
+      revision_changes: Changements de révision
+      untitled: Sans titre
+      user_at_time: "%{user} à %{time}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,5 +7,6 @@ en:
   en: English
   es: Español
   pt: Português
+  fr: Français
   time_ago_in_words: "%{time} ago"
   unauthorized_collection: You do not have access to %{project}.  Please log in or contact the project owner to be added.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -6,4 +6,5 @@ es:
   en: English
   es: Español
   pt: Português
+  fr: Français
   time_ago_in_words: Hace %{time}

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -6,4 +6,5 @@ pt:
   en: English
   es: Español
   pt: Português
+  fr: Français
   time_ago_in_words: Há %{time}


### PR DESCRIPTION
_For #3165_ 

Before translating all of our locales to French, we should test the translation on one small group. I used `article_version` for this as it only has 9 keys and around 600 characters.