### PR TITLE
Translated the UI to French

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -103,8 +103,16 @@ search:
 
 ## Do not consider these keys missing:
 ignore_missing:
-  - '{!, !0, next, throw}'
-  - 'deed.deed.*'
+  en: 
+    - '{!, !0, next, throw}'
+    - 'deed.deed.*'
+  es: &NOT_EN
+    - '{!, !0, next, throw}'
+    - 'deed.deed.*'
+    - 'admin.*'
+    - 'admin_mailer.*'
+  pt: *NOT_EN
+  fr: *NOT_EN
 
 ## Consider these keys used:
 ignore_unused:

--- a/config/locales/activerecord/activerecord-fr.yml
+++ b/config/locales/activerecord/activerecord-fr.yml
@@ -1,0 +1,46 @@
+---
+fr:
+  activerecord:
+    attributes:
+      collection:
+        slug: URL
+        title: Titre
+      document_set:
+        slug: URL
+        title: Titre
+      work:
+        slug: URL
+        title: Titre
+    errors:
+      models:
+        collection:
+          attributes:
+            slug:
+              blank: est requis
+              invalid: doit avoir au moins une lettre
+        document_set:
+          attributes:
+            slug:
+              blank: est requis
+              invalid: doit avoir au moins une lettre
+        work:
+          attributes:
+            slug:
+              blank: est requis
+              invalid: doit avoir au moins une lettre
+        xml_source_processor:
+          blank_subject_in: Sujet vide dans %{tag}
+          blank_tag_in: Balise vide dans %{tag}
+          blank_text_in: Texte vide dans %{tag}
+          subject_linking_error: 'Erreur de lien de sujet :'
+          tags_should_not_use_3_brackets: Les balises doivent être créées en utilisant 2 crochets, pas 3
+          unclosed_bracket_within: Parenthèse non fermée dans %{tag}
+          wrong_number_of_closing_braces: Mauvais nombre d'accolades fermantes après %{tag}
+  errors:
+    messages:
+      expired: a expiré, veuillez en demander un nouveau
+      not_found: pas trouvé
+      not_saved:
+        one: '1 erreur interdit la sauvegarde du %{resource} :'
+        other: 'Les erreurs %{count} ont empêché la sauvegarde du %{resource} :'
+      not_signed: 'Impossible de se connecter en raison de l''erreur suivante :'

--- a/config/locales/article/article-fr.yml
+++ b/config/locales/article/article-fr.yml
@@ -1,0 +1,101 @@
+---
+fr:
+  article:
+    article_links:
+      n_pages_refer_to:
+        one: 1 page fait référence à %{article}
+        other: "%{count} pages renvoient à %{article}"
+      n_subjects_refer_to:
+        one: 1 sujet fait référence à %{article}
+        other: "%{count} sujets font référence à %{article}"
+      show_pages_that_mention: Afficher les pages qui mentionnent %{article} dans tous les travaux
+    combine_duplicate:
+      selected_subjects_combined: Sujets sélectionnés combinés avec %{title}
+    delete:
+      must_remove_referring_links: Vous devez supprimer tous les liens de référence avant de supprimer ce sujet.
+    edit:
+      autolink: Lien automatique
+      categories: Catégories
+      combine_selected: Combiner la sélection
+      confirm_delete_subject: Voulez-vous vraiment supprimer ce sujet ? Après la suppression, vous ne pourrez pas le récupérer !
+      delete_subject: Supprimer le sujet
+      description: La description
+      latitude: Latitude
+      longitude: Longitude
+      microphone: Microphone
+      n_pages:
+        one: 1 page
+        other: "%{count}pages"
+      no_duplicates_found: Aucun doublon trouvé
+      no_duplicates_found_description: Le sujet est unique dans la collection, aucun doublon possible du sujet "%{article}" n'a été trouvé.
+      possible_duplicates:
+        one: Doublon possible
+        other: Doublons possibles
+      possible_duplicates_description: Veuillez consulter la liste ci-dessous et sélectionner les sujets à combiner. Les doublons seront remappés afin que tous les liens existants pointent vers le sujet "%{article}".
+      save_changes: Sauvegarder les modifications
+      select_categories: Sélectionnez les catégories
+      title: Titre
+      uri: URI
+    list:
+      actions: Actions
+      add_child_category: Ajouter une catégorie enfant
+      add_root_category: Ajouter une catégorie racine
+      categories: Catégories
+      category_back_message: Une fois que vous avez fini de modifier les catégories, %{page_link} pour revenir à la page "%{page}".
+      click_here: Cliquez ici
+      confirm_delete_category: Voulez-vous vraiment supprimer cette catégorie et toutes ses sous-catégories ? Après la suppression, vous ne pourrez pas le récupérer !
+      create_category_message: "%{link} que vous utiliserez pour regrouper les sujets."
+      create_the_first_category: Créer la première catégorie
+      delete_category: Supprimer la catégorie
+      disable_gis_for_category: Désactiver le SIG pour la catégorie
+      edit_category: Modifier la catégorie
+      enable_gis_for_category: Activer le SIG pour la catégorie
+      no_categories: Aucune catégorie
+      no_categories_message: Il n'y a pas de catégories de sujets dans la collection.<br>
+      there_are_no_subjects: Il n'y a pas de sujets pour la catégorie sélectionnée
+      uncategorized: Non classé
+      uncategorized_subjects: Sujets non classés
+      upload_subjects: Télécharger des sujets
+    show:
+      all_uncategorized_subjects: Tous les sujets non catégorisés de la collection
+      categories: Catégories
+      description: La description
+      download: Télécharger
+      download_description: Téléchargez une feuille de calcul des sujets et des œuvres concomitants dans lesquels ils apparaissent.
+      edit_description_description: Modifiez la description dans l'onglet Paramètres.
+      export: Exporter
+      n_possible_duplicates:
+        one: 1 doublon possible
+        other: "%{count} Doublons possibles"
+      no_category_message: Ce sujet n'appartient à aucune catégorie
+      references: Références
+      related_subjects: Sujets connexes
+      related_subjects_1: Sujets connexes
+      related_subjects_description: Le graphique affiche les autres sujets mentionnés sur les mêmes pages que le sujet "%{article}". Si le même sujet apparaît plus d'une fois sur une page avec "%{article}", il apparaît plus proche de "%{article}" sur le graphique et est coloré dans une teinte plus foncée. Plus un sujet est proche du centre, plus les sujets sont "liés".
+      search_all_pages: Rechercher toutes les pages
+      search_all_pages_description: Rechercher dans le texte de %{collection} les pages contenant des mots utilisés pour créer un lien vers <em>%{article}</em>
+      search_unlinked_pages: Rechercher des pages non liées
+      search_unlinked_pages_description: Rechercher uniquement le texte des pages qui ne renvoient pas à <em>%{article}</em>
+      see_also: 'Voir également:'
+      text_search: Recherche de texte
+    subject_upload:
+      csv_file_must_contain_headers: Le fichier CSV doit contenir des en-têtes pour HEADING, ARTICLE, URI et CATEGORY
+    tooltip:
+      category:
+        one: 'Catégorie :'
+        other: 'Catégories :'
+      explore_this_subject: Explorer ce sujet
+    update:
+      gis_coordinates_truncated:
+        one: " (Coordonnées SIG tronquées à la décimale %{precision})"
+        other: " (Coordonnées SIG tronquées à %{precision} décimales)"
+      subject_successfully_updated: Le sujet a été mis à jour avec succès
+      subjects_auto_linking: Processus de liaison automatique des sujets terminé
+    upload_form:
+      browse: Parcourir
+      click_to_browse: Cliquez pour parcourir un fichier...
+      csv_file_with: Fichier CSV avec une ligne par sujet
+      example_csv: Exemple de CSV
+      upload: Télécharger
+      upload_subjects: Télécharger des sujets
+      upload_subjects_description: Pour créer des sujets à partir d'un fichier d'autorité externe, téléchargez un fichier %{link}.

--- a/config/locales/bulk_export/bulk_export-fr.yml
+++ b/config/locales/bulk_export/bulk_export-fr.yml
@@ -1,0 +1,53 @@
+---
+fr:
+  bulk_export:
+    create:
+      export_running_message: Exportation en cours. Un e-mail sera envoyé à %{email} à la fin.
+    create_for_work:
+      export_running_message: Exportation en cours. Un e-mail sera envoyé à %{email} à la fin.
+    download:
+      download_cleaned_message: Ce téléchargement d'exportation a été nettoyé. Veuillez en commencer un nouveau.
+    index:
+      actions: Actions
+      collection: 'Le recueil:'
+      date: Date
+      file_name: 'Nom de fichier:'
+      show_details: Afficher les détails
+      status: Statut
+      upload_details: Télécharger les détails
+      user: Utilisateur
+    new:
+      download: Télécharger
+      expanded_plaintext: Texte en clair étendu
+      expanded_plaintext_description: Comme le texte brut verbatim, ce fichier de texte brut représentera les sauts de ligne avec un seul saut de ligne, les sauts de paragraphe avec un double saut de ligne et les sauts de page avec un triple saut de ligne. Il diffère du texte verbatim, en ce que la normalisation sera appliquée à tous les sujets mentionnés, de sorte que si le texte verbatim peut se lire "J'ai salué M. Jones et sa femme ce matin.", le texte en clair modifié se lira "J'ai salué James Jones et Elizabeth Smith Jones ce matin ». Ce texte artificiel est utile pour l'analyse programmatique, mais n'est pas destiné à être lu par des humains.
+      export_all_works: Exporter toutes les œuvres
+      facing_edition_pdf: Face à l'édition PDF
+      facing_edition_pdf_description: Un fichier PDF contenant des images et des transcriptions sur les pages opposées.
+      html: HTML
+      html_description: Cela peut être utile pour la conservation dans d'autres systèmes ou comme point de départ pour l'affichage sur un autre site Web.
+      one_file_per_collection: Un fichier par collection
+      one_file_per_page: Un fichier par page
+      one_file_per_work: Un fichier par œuvre
+      one_site_per_collection: Un site par collection
+      previous_exports: Exportations précédentes
+      search_optimized_plaintext: Texte brut optimisé pour la recherche
+      search_optimized_plaintext_description: Une version en clair de l'œuvre optimisée pour la recherche en texte intégral. Cette version contient une transcription textuelle en clair de chaque page (comme décrit ci-dessus), sauf que les mots coupés par des sauts de ligne sont joints ensemble, et une liste des noms canoniques mentionnés dans chaque page est ajoutée à la fin de la page.
+      start_export: Démarrer l'exportation
+      static_site: Site statique
+      static_site_description: Un site Jekyll statique contenant l'intégralité de l'édition
+      status: Statut
+      subject_csv: Objet CSV
+      subject_csv_description: Une feuille de calcul répertoriant chaque endroit où un sujet est mentionné dans une page de la collection
+      table_field_csv: Tableau/Champ CSV
+      table_field_csv_description: Exporte une feuille de calcul avec des données basées sur des champs ou tabulaires.
+      tei_xml: XML TEI
+      tei_xml_description: Cela peut être utile aux éditeurs qui envisagent de faire un balisage supplémentaire dans les éditeurs TEI-XML comme oXygen.
+      text_docx: Texte DOCX
+      text_docx_description: Un fichier MS-Word (.docx) contenant des transcriptions de texte.
+      text_pdf: Texte PDF
+      text_pdf_description: Un fichier PDF contenant des transcriptions de texte.
+      time: Temps
+      verbatim_plaintext: Texte brut textuel
+      verbatim_plaintext_description: Ce fichier en clair représentera les sauts de ligne avec une seule nouvelle ligne, les sauts de paragraphe avec une double nouvelle ligne et les sauts de page avec une triple nouvelle ligne. Il contiendra le texte textuel, avec tous les formatages, corrections et liens de sujet supprimés.
+      work_metadata_csv: Métadonnées professionnelles CSV
+      work_metadata_csv_description: Une feuille de calcul répertoriant chaque travail avec le nombre de pages et les métadonnées.

--- a/config/locales/category/category-fr.yml
+++ b/config/locales/category/category-fr.yml
@@ -1,0 +1,22 @@
+---
+fr:
+  category:
+    add_new:
+      create_category: Créer une catégorie
+      enable_gis: Activer le SIG
+      title: Titre
+    create:
+      category_created: La catégorie a été créée
+    delete:
+      category_deleted: La catégorie a été supprimée
+    disable_gis:
+      gis_disabled_for: SIG désactivé pour %{title}
+    edit:
+      edit_category: Modifier la catégorie
+      enable_gis: Activer le SIG
+      save_changes: Enregistrer la modification
+      title: Titre
+    enable_gis:
+      gis_enabled_for: SIG activé pour %{title}
+    update:
+      category_updated: La catégorie a été mise à jour

--- a/config/locales/collection/collection-fr.yml
+++ b/config/locales/collection/collection-fr.yml
@@ -1,0 +1,307 @@
+---
+fr:
+  collection:
+    approve_all:
+      approved_n_pages: "%{page_count} pages approuvées."
+    collection_works:
+      n_pages:
+        one: '1 page :'
+        other: "%{count} pages :"
+      progress: Progrès
+      work_title: Titre de travail
+    contributor_activity:
+      recent_notes: Remarques récentes
+      recent_ocr_correction: Correction OCR récente
+      recent_pages_needing_review: Pages récentes à revoir
+      recent_subject_indexing: Indexation des sujets récents
+      recent_subjects: Sujets récents
+      recent_transcriptions: Transcriptions récentes
+      recent_translation_subject_indexing: Indexation par sujet des traductions récentes
+      recent_translations: Traductions récentes
+      recent_translations_needing_review: Traductions récentes nécessitant une révision
+      recent_works_added: Travaux récents ajoutés
+    contributors:
+      contributions: Cotisations entre %{start_deed} et %{end_deed}
+      end_date: Date de fin
+      select_new_date: Sélectionnez une nouvelle plage de dates
+      start_date: Date de début
+      update: Mise à jour
+    contributors_body:
+      active_collaborators: Collaborateurs actifs
+      all_collaborator_emails: Tous les e-mails des collaborateurs
+      collaborator_stats: Statistiques des collaborateurs %{start_deed} à %{end_deed}
+      collaborators: Collaborateurs
+      collection: " (Collecte : %{collection_time} minutes | Total : %{total_time} minutes)"
+      detailed_spreadsheet_export: Une exportation détaillée de la feuille de calcul de tous les collaborateurs est disponible sur votre tableau de bord propriétaire.
+      export_activity_as_csv: Exporter l'activité au format CSV
+      export_as_csv: Exporter au format CSV
+      find_project_newsletters_recommendations: Trouvez des recommandations pour les newsletters du projet.
+      new_collaborators: Nouveaux collaborateurs
+      no_activity_this_time_frame: Aucune activité pendant cette période
+      no_collaborators: Aucun collaborateur
+      total_time: 'Durée totale : %{hours} heures, %{minutes} minutes.'
+      view_activity: Afficher l'activité
+    corrected: corrigée
+    create:
+      notice: La collection a été créée
+    disable_ocr:
+      notice: La correction OCR a été désactivée pour toutes les œuvres.
+    edit:
+      add_a_new_work: Ajouter une nouvelle œuvre
+      add_another_work_under: Vous pouvez ajouter une autre œuvre sous %{start_project}
+      add_button: Ajouter
+      alert: Veuillez configurer les champs ou choisir la transcription basée sur le document sous Type de transcription.
+      api_access: Accès API
+      api_access_description: Autoriser l'accès aux transcriptions via l'API IIIF
+      authorized_reviewers: Examinateurs autorisés
+      blank_collection: Collecte vierge
+      blank_collection_description: Appuyer sur ce bouton réinitialisera la collection à un état vide. Il supprimera toutes les transcriptions et autres travaux sur la collection, comme si elle venait d'être importée.
+      close_api: Fermer l'API
+      collection_active_message: Ceci est une collection active. Rendre une collection inactive empêche les utilisateurs de modifier le contenu de la collection. L'état de la collection n'affecte pas le paramètre de confidentialité de la collection.
+      collection_collaborators: Collaborateurs de collecte
+      collection_collaborators_description: Les collaborateurs peuvent transcrire et éditer des collections privées.
+      collection_image: Image de la collection
+      collection_inactive_message: Il s'agit d'une collection inactive. Activer une collection permet aux utilisateurs de modifier le contenu de cette collection. L'état de la collection n'affecte pas le paramètre de confidentialité de la collection.
+      collection_link: Lien de collecte
+      collection_owners: Propriétaires de collections
+      collection_owners_description: Les propriétaires peuvent ajouter des œuvres à la collection et télécharger des images de page ainsi que transcrire et lire des œuvres de la collection.
+      collection_privacy: Confidentialité des collections
+      collection_public_message: La collection peut être consultée par n'importe qui sur Internet. Vous pouvez rendre la collection privée pour limiter sa visibilité aux propriétaires.
+      collection_restricted_message: La collection ne peut être vue que par les propriétaires listés ci-dessous. Vous pouvez rendre la collection lisible publiquement.
+      collection_reviewers: Examinateurs autorisés
+      collection_reviewers_description: Ces utilisateurs pourront réviser et approuver les transcriptions, ainsi que les modifier.
+      collection_status: État de la collecte
+      confirm_blank_collection: Êtes-vous sûr?
+      confirm_delete_collection: Voulez-vous vraiment supprimer cette collection ? Après la suppression, vous ne pourrez pas le récupérer !
+      current_url: L'URL actuelle de cette collection est %{current_url}. Si vous souhaitez modifier la section de collection de l'URL, veuillez utiliser des lettres minuscules et des tirets entre les mots.
+      default_orientation: Sélectionnez l'orientation de transcription de page par défaut
+      delete_collection: Supprimer la collection
+      description: La description
+      disable_document_sets: Désactiver les ensembles de documents
+      disable_facets: Désactiver les facettes
+      disable_ocr: Désactiver la ROC
+      document_sets: Jeux de documents
+      document_sets_description: Les ensembles de documents sont des sous-ensembles des œuvres de cette collection, qui peuvent être utilisés pour cibler un projet d'édition ou pour créer une exposition publique sur un thème particulier des documents.
+      done: Fait
+      edit_authorized_reviewers: Modifier les réviseurs autorisés
+      edit_buttons: Configurer les boutons
+      edit_collaborators: Modifier les collaborateurs
+      edit_fields: Des champs
+      edit_metadata_fields: Modifier les champs
+      edit_owners: Modifier les propriétaires
+      editor_buttons: Boutons de l'éditeur
+      editor_buttons_description: Choisissez les boutons de balisage à afficher dans l'éditeur de transcription.
+      enable_document_sets: Activer les ensembles de documents
+      enable_facets: Activer les facettes
+      enable_field_based_transcription: Activer la transcription basée sur les champs
+      enable_metadata_description: Activer la description des métadonnées
+      enable_ocr: Activer la ROC
+      field_based_transcription: Transcription basée sur le champ
+      footer: Bas de page
+      help: Texte d'aide de base
+      hide_completed: Masquer les travaux terminés par défaut
+      learn_more_footer: En savoir plus sur la configuration du pied de page.
+      link_help: Texte d'aide sur la liaison par sujet (non affiché si les sujets sont désactivés)
+      make_collection_active: Rendre la collecte active
+      make_collection_inactive: Rendre la collecte inactive
+      make_collection_private: Rendre la collection privée
+      make_collection_public: Rendre la collecte publique
+      metadata: Métadonnées
+      metadata_description: Chargez les métadonnées des éléments de cette collection de manière groupée.
+      metadata_entry: Description des métadonnées
+      metadata_facets: Facettes des métadonnées
+      metadata_facets_description: Autoriser les utilisateurs à parcourir les œuvres de cette collection via les métadonnées.
+      n_contributions:
+        one: 1 cotisation
+        other: "%{count} cotisations"
+      no_document_sets_in_collection: Cette collection ne contient aucun ensemble de documents.
+      no_image: Pas d'image
+      ocr_correction: Correction OCR
+      ocr_correction_description: Activez ou désactivez la correction OCR pour toutes les œuvres de cette collection.
+      open_api: Ouvrir l'API
+      page_needing_transcription: 'Ce lien enverra les transcripteurs directement vers une page nécessitant une transcription : %{current_url}'
+      page_on_the_bottom: Page en bas
+      page_on_the_left: Page à gauche
+      page_on_the_right: Page de droite
+      page_on_the_top: Page en haut
+      picture_to_be_used_message: Une image à utiliser pour illustrer la description de la collection.
+      remove_collaborator: Supprimer un collaborateur
+      remove_owner: Supprimer le propriétaire
+      remove_reviewer: Supprimer l'examinateur
+      restrict_completed_works: Restreindre les travaux terminés
+      restricted_completed_works: Travaux terminés restreints
+      restricted_completed_works_description: Ce bouton limitera les travaux %{work_count} qui sont terminés mais non actuellement restreints aux maîtres d'ouvrage ou collaborateurs désignés. Vous pouvez modifier ce paramètre et ajouter des collaborateurs dans la page des paramètres de chaque travail.
+      revert_document_based_transcription: Revenir à la transcription basée sur des documents
+      revert_metadata_description: Désactiver Description
+      review_type: Type d'examen
+      review_type_optional: " Facultatif : les collaborateurs peuvent demander la révision de leurs transcriptions."
+      review_type_required: " Obligatoire : toutes les transcriptions initiales seront marquées comme nécessitant une révision. (La révision peut être effectuée par n'importe qui.)"
+      review_type_restricted: " Restreint : toutes les transcriptions doivent être révisées, et seuls les réviseurs autorisés peuvent approuver les transcriptions."
+      save_changes: Sauvegarder les modifications
+      start_a_project: Démarrer un projet
+      subjects_enabled: Activer l'indexation des sujets
+      suggestions_help_tab: Suggestions pour votre onglet d'aide.
+      suggestions_transcription_conventions: Suggestions pour vos conventions de transcription.
+      text_language: Sélectionnez la langue du texte de transcription
+      title: Titre
+      transcription_conventions: Conventions de transcription
+      transcription_type: Type de transcription
+      transcription_type_description: Chaque page peut avoir une zone de saisie de texte libre (par défaut) ou plusieurs champs de saisie courts conçus pour les formulaires. Toutes les pages de la collection ont le même type d'entrées de transcription. La dictée vocale n'est pas prise en charge et sera désactivée.
+      upload_image: Télécharger une image
+      upload_metadata: Télécharger les métadonnées
+      url: URL
+      user_download: Autoriser les utilisateurs à télécharger des œuvres.
+      voice_recognition: Discours en texte disponible pour la transcription (non compatible avec l'éditeur avancé)
+    edit_buttons:
+      description: FromThePage peut prendre en charge le balisage dans les transcriptions dans les formulaires TEI-XML ou HTML. Nous vous recommandons de ne pas configurer plus de six boutons à afficher sur l'éditeur de transcription. Demandez-vous si d'autres systèmes pourront utiliser ce type de majoration ; si seul le texte brut est pris en charge, les projets doivent utiliser les conventions typographiques au lieu du balisage.
+      heading: Configuration de l'éditeur de transcription
+      html: "(HTML)"
+      markup_preference_description: Certaines balises ont des formes équivalentes en HTML et TEI-XML. Choisissez une préférence pour déterminer quelle forme de balise est insérée lorsqu'un utilisateur appuie sur le bouton.
+      markup_preference_label: Style de balisage
+      prefer_html: Préférez le HTML
+      prefer_tei: Préférer TEI
+      save: sauvegarder
+      tei: " (TEI-XML)"
+    enable_ocr:
+      notice: La correction OCR a été activée pour toutes les œuvres.
+    facet_form:
+      current_filters: Filtres actuels
+      filter: Filtre
+      reset_all_filters: Réinitialiser tous les filtres
+      search: Chercher
+    facets:
+      collection_facets_updated_successfully: Les facettes de la collection ont été mises à jour avec succès
+      field_label: Étiquette de champ
+      label: Étiquette
+      metadata_facets: Facettes des métadonnées
+      metadata_facets_description: Configurez les facettes des métadonnées en examinant les métadonnées de votre collection et en étiquetant les champs à afficher pour les transcripteurs.
+      occurrences: Occurrences
+      order: Ordre
+      translate: Traduire
+      type: Taper
+    indexed: indexé
+    localize:
+      label: Facette
+      metadata_facets_localize_description: Fournissez des étiquettes spécifiques à la langue pour chaque facette.
+      save: sauvegarder
+      translate_facets: Traduire les étiquettes de facette
+      translation: Traduction
+    needs_review: a besoin d'un examen
+    needs_review_pages:
+      pages_that_need_review: Pages à réviser
+      project_by: Projet par
+      return_to_collection: Retour à la collecte
+    needs_transcription_pages:
+      project_by: Projet par
+      return_to_collection: Retour à la collecte
+    new:
+      collection_description: Description de la collection
+      create_collection: Créer une collection
+      create_new_collection: Créer une nouvelle collection
+      enter_collection_title: Pour créer une nouvelle collection, commencez par entrer le titre de la collection. À l'étape suivante, vous pourrez ajouter des œuvres à la collection.
+      individual_researcher_limited_account: Les comptes de chercheurs individuels sont limités à une seule collection. Pour mettre à niveau votre compte, contactez support@fromthepage.com.
+      title: Titre
+    one_off_list:
+      date: Date
+      filter_contributions: Filtre
+      no_contributions_need_review: Aucune contribution n'a besoin d'être examinée
+      one_off_description: Ces contributions ont été faites par des utilisateurs qui n'ont édité qu'une seule page. Ils peuvent nécessiter une attention particulière.
+      one_off_title: Cotisations uniques
+      review: Examen
+      title: Page (Travail)
+      user: Utilisateur
+    quality_sampling: Échantillonnage de qualité
+    recent_contributor_list:
+      date: Date de la première cotisation
+      filter_users: Filtre
+      no_contributions_need_review: Aucune contribution n'a besoin d'être examinée
+      number_of_contributions: Cotisations totales
+      recent_contributor_description: Ces collaborateurs ont commencé à travailler sur le projet récemment, mais leur travail n'a jamais été revu.
+      recent_contributor_title: Contributeurs récents
+      review: Examen
+      user: Utilisateur
+    reviewer_dashboard:
+      one_off_contributions: Cotisations uniques
+      pages_needing_review: Pages à réviser
+      quality_sampling: Échantillonnage de qualité
+      quality_sampling_desc: Les échantillonnages de qualité vous permettent de vérifier les contributions de manière aléatoire, puis d'évaluer les pages à réviser en fonction de la quantité de texte corrigé pour un utilisateur ou un travail particulier.
+      total_page: Nombre total de pages
+      transcribed_page: Page transcrite
+      unreviewed_contributors: Nouveaux contributeurs
+      works_to_review: Travaux à revoir
+    show:
+      about: À propos de
+      add_a_new_work: Ajouter une nouvelle œuvre
+      all_complete: Toutes les œuvres sont entièrement transcrites.
+      help_create_metadata: Aidez-moi !
+      help_transcribe_or_correct: Aidez-moi !
+      n_pages:
+        one: '1 page :'
+        other: "%{count} pages :"
+      pages_need_correction: Pages à corriger
+      pages_need_correction_or_transcription: Pages nécessitant une correction ou une transcription
+      pages_need_review: Pages à réviser
+      pages_need_transcription: Pages nécessitant une transcription
+      project_by: Projet par
+      recent_edits: Modifications récentes
+      recent_notes: Remarques récentes
+      search: Chercher
+      search_by_title: Rechercher par titre ou métadonnées...
+      search_by_title_1: Rechercher par titre
+      search_the_text: Rechercher dans le texte...
+      search_the_text_1: Rechercher le texte
+      show_more: Montre plus
+      start_transcribing: Commencez à transcrire
+      subject_categories: Catégories de sujets
+      this_work_has_not_been_described: Ce travail a besoin de meilleures métadonnées.
+      this_work_has_pages_that_need_work: Certaines pages ont encore besoin de travail.
+      time_ago_in_words: Il y a %{time}
+      works: Œuvres
+    start_transcribing:
+      notice: Désolé, mais il n'y a pas de pages de qualification dans cette collection.
+    transcribed: transcrit
+    translated: traduit
+    update:
+      notice: La collection a été mise à jour
+    update_buttons:
+      editor_buttons_updated: Boutons de l'éditeur mis à jour
+    upload:
+      acceptable_image_files: Les fichiers PNG, GIF et JPG sont tous acceptables.
+      image_naming_guidelines: 'Les images doivent être nommées de manière à ce qu''un tri alphabétique aboutisse au bon ordre des pages.<br> (Cela peut nécessiter un "zéro remplissage" pour tous les numéros de page : <code>page_09.jpg, page_10.jpg</code> triera correctement, mais <code>page_9.jpg, page_10.jpg</code> ne le sera pas.)'
+      image_orientation_guidelines: Les images doivent être orientées de manière à ce qu'elles soient à l'endroit.
+      page_image_guidelines: Directives relatives aux images de page
+    user_contribution_list:
+      approve_all: Tout approuver
+      date: Date
+      email: 'Courriel : %{email}'
+      filter_contributions: Filtre
+      no_contributions: Aucune cotisation
+      notes: Remarques
+      quality_score: 'Niveau de qualité :'
+      real_name: 'Nom réel : %{user}'
+      review: Examen
+      title: Page (Travail)
+      user_contribution_description: Pages nécessitant une révision par l'utilisateur %{user_name}
+      user_profile: Profil de l'utilisateur
+    works_list:
+      alphabetical: Alphabétique
+      percent_complete: Pourcentage achevé
+      recent_activity: Activité récente
+      sort_works_by: Trier les œuvres par...
+      works: Œuvres
+    works_to_review:
+      and_n_more: et %{n} de plus
+      contributors: Contributeurs
+      description: Fonctionne avec les pages nécessitant une révision
+      filter_works: Filtre
+      incomplete: Incomplet
+      last_activity: Dernière Activité
+      no_works_need_review: Aucun travaux à revoir
+      notes: Remarques
+      review: Examen
+      title: Titre
+      total: Total
+  collection_helper:
+    link:
+      incomplete_works: Travaux incomplets
+      show_all: Afficher tout

--- a/config/locales/contact/contact-fr.yml
+++ b/config/locales/contact/contact-fr.yml
@@ -1,0 +1,24 @@
+---
+fr:
+  contact:
+    form:
+      contact_reason: Raison du contact
+      contact_us: Nous contacter
+      contact_us_description: Vous voulez plus d'informations sur FromThePage ? Laissez-nous savoir comment nous pouvons vous aider.
+      email_address: Adresse e-mail
+      event: Événement
+      first_name: Prénom
+      free_trial: Essai gratuit
+      large_institution_quote: Devis grande institution
+      last_name: Nom de famille
+      other: Autre
+      press: Presse
+      product_question: Question sur le produit
+      submit: Soumettre
+      tell_us_more: Dites-nous en plus sur votre projet
+    send_email:
+      get_started_right_away: Commencez tout de suite avec un essai gratuit de FromThePage.
+      start_free_trial: Commencer l'essai gratuit
+      thank_you: Merci
+      thank_you!: Merci!
+      will_follow_up: Un membre de l'équipe assurera le suivi avec vous.

--- a/config/locales/dashboard/dashboard-fr.yml
+++ b/config/locales/dashboard/dashboard-fr.yml
@@ -1,0 +1,149 @@
+---
+fr:
+  dashboard:
+    alphabetical_collections_and_document_sets:
+      project_by: Projet par %{author}
+      start_transcribing: Commencez à transcrire
+    collections_list:
+      collections: Collections
+      meta_description: Vous êtes libre de choisir parmi les nombreux projets intéressants hébergés sur FromThePage. Commencez à lire les écrits historiques qui ont déjà été transcrits par d'autres membres. Vous êtes les bienvenus pour aider l'un des grands projets à entrer dans l'ère numérique.
+      recent_activity: Activité récente
+    create_work:
+      work_created: Œuvre créée avec succès
+    editor:
+      activity_stream: Flux d'activité
+      article_in_the_work: "%{article} article dans la collection %{collection}"
+      page_in_the_work: "%{page} page dans l'ouvrage %{work}"
+      revision_version: Révision %{version}
+      view_page: Voir page
+      your_recent_article_edits: Vos modifications d'articles récentes
+      your_recent_notes: Vos notes récentes
+      your_recent_page_edits: Modifications récentes de votre page
+    editor_header:
+      your_projects: Tes projets
+    empty:
+      add_new_collection: Ajouter une nouvelle collection
+      create_empty_work: Créer un travail vide
+      create_empty_work_description: Utilisez cette option pour créer un travail vide. Vous pouvez ensuite télécharger des images de page individuelles dans le travail.
+      create_work: Créer un travail
+      description: La description
+      select_a_collection: "- Sélectionnez une collection -"
+      title: Titre
+    exports:
+      bulk_exports_description: Cela répertorie toutes les exportations en masse que vous avez exécutées. Les exportations sont nettoyées après quelques jours et ne sont plus disponibles au téléchargement
+      configuration: Configuration (niveau)
+      create_bulk_export_description: Créez une exportation en bloc à partir de l'onglet Exporter d'une collection ou de l'onglet Télécharger d'une œuvre.
+      date: Date d'exportation
+      download: Télécharger
+      exported_item: Collection/œuvre exportée
+      facing_edition_work: Face à l'édition PDF (travail)
+      html_page: HTML (page)
+      html_work: HTML (travail)
+      plaintext_emended_page: Texte en clair analytique (page)
+      plaintext_emended_work: Texte en clair analytique (travail)
+      plaintext_searchable_page: Texte en clair consultable (page)
+      plaintext_searchable_work: Texte en clair consultable (travail)
+      plaintext_verbatim_page: Texte brut textuel (page)
+      plaintext_verbatim_work: Texte brut textuel (travail)
+      refresh: Rafraîchir
+      reload_this_page_to: Recharger cette page pour mettre à jour la liste.
+      status: Statut
+      subject_csv_collection: Index des sujets CSV (collection)
+      table_csv_collection: Champ/Table CSV (collection)
+      table_csv_work: Champ/Table CSV (travail)
+      tei_work: TEX-XML (travail)
+      text_docx_work: MS Word .docx (travail)
+      text_pdf_work: Texte PDF (travail)
+      work_metadata_csv: Métadonnées de travail (collection)
+    guest_header:
+      recent_activity: Activité récente
+    hierarchical_collections_and_document_sets:
+      project_by: Projet par %{author}
+      start_transcribing: Commencez à transcrire
+    landing_page:
+      all_collections: Toutes les collections
+      more: Suite...
+      next_image: Image suivante
+      previous_image: Image précédente
+      recent_activity: Activité récente
+      search: Chercher
+      search_for_collections: Rechercher des collections
+      search_for_collections_or_owners: Rechercher des collections ou des propriétaires...
+      transcribe_a_page: Transcrire une page
+    new_upload:
+      document_uploaded: Le document a été téléchargé et sera traité sous peu. Nous vous enverrons un e-mail à %{email} lorsque vous serez prêt.
+      reload_this_page: Le document a été téléchargé et sera traité sous peu. Rechargez cette page dans quelques minutes pour la voir.
+    new_work:
+      acceptable_formats: Les fichiers PNG, GIF et JPG sont tous acceptables.
+      images_should_be_named: 'Les images doivent être nommées de manière à ce qu''un tri alphabétique aboutisse à l''ordre correct des pages.<br> (Cela peut nécessiter un "zéro remplissage" pour tous les numéros de page : <code>page_09.jpg, page_10.jpg</code> triera correctement, mais <code>page_9.jpg, page_10.jpg</code> ne le sera pas.)'
+      images_should_be_oriented: Les images doivent être orientées de manière à ce qu'elles soient à l'endroit.
+      import: Importer
+      import_a_iiif_manifest_or_collection: Importer un manifeste ou une collection IIIF
+      import_from_archive_dot_org: Importer depuis Archive.org
+      import_from_contentdm: Importer depuis CONTENTdm
+      import_from_the_internet_archive: Importer à partir des archives Internet
+      import_many_link: importer plusieurs objets composés individuels.
+      or_import_many: Ou
+      page_image_guidelines: Directives relatives aux images de page
+      paste_in_the_url: Collez l'URL d'un objet composé ou d'une collection sur votre site CONTENTdm.
+    owner:
+      create_a_collection: créer une collection
+      document_sets: Jeux de documents
+      see_all_works: Voir toutes les oeuvres...
+      start_a_project: Démarrer un projet
+      there_are_no_works: Il n'y a pas encore d'œuvres dans cette collection
+      total_work_count: 'Nombre total de travaux : %{count}'
+      you_can_add_another_work: Vous pouvez ajouter une autre œuvre sous %{start_project}
+      you_can_new_collection: Vous pouvez %{new_collection}
+      you_can_upload_documents: Vous pouvez télécharger des documents sous %{start_project}
+      you_dont_have_any_collections: Vous n'avez pas encore de collections
+      your_activity: Votre activité
+    owner_header:
+      account_type: "%{type} compte"
+      actions: Actions
+      collection:
+        one: Le recueil
+        other: Collections
+      create_a_collection: Créer une collection
+      current_subscription_expires: L'abonnement actuel expire %{date}
+      document_set:
+        one: Ensemble de documents
+        other: Jeux de documents
+      exports: Exportations
+      owner_dashboard: Tableau de bord du propriétaire
+      since: depuis %{date}
+      start_a_project: Démarrer un projet
+      summary: Sommaire
+      to_upgrade_contact: Pour mettre à niveau, contactez support@fromthepage.com
+      total_pages: 'Nombre total de pages : %{pages}'
+      work:
+        one: Travailler
+        other: Œuvres
+      your_collections: Vos collections
+    upload:
+      acceptable_image_files: Les fichiers PNG, GIF et JPG sont tous acceptables.
+      browse: Parcourir
+      click_to_browse_a_file: Cliquez pour parcourir un fichier...
+      click_to_browse_files: Cliquez pour parcourir les fichiers
+      each_folder_will_be_treated: Chaque dossier sera traité comme un document différent, ne mélangez donc pas les pages de différents documents dans le même dossier.
+      each_pdf_will_be_treated: Chaque PDF sera traité comme son propre document, donc ne divisez pas les pages du même document entre plusieurs PDF.
+      for_example_a_zip_file: 'Par exemple, un fichier ZIP avec 3 images, 2 PDF et 1 dossier contenant 5 images supplémentaires créerait 4 œuvres : les images de niveau supérieur en une, chaque PDF dans son propre travail et une dernière œuvre contenant les 5 images du dossier.'
+      image_naming_guidelines: 'Les images doivent être nommées de manière à ce qu''un tri alphabétique aboutisse à l''ordre correct des pages.<br> (Cela peut nécessiter un "zéro remplissage" pour tous les numéros de page : <code>page_09.jpg, page_10.jpg</code> triera correctement, mais <code>page_9.jpg, page_10.jpg</code> ne le sera pas.)'
+      image_orientation_guidelines: Les images doivent être orientées de manière à ce qu'elles soient à l'endroit.
+      import_form_message: En utilisant ce formulaire, vous pouvez importer vos images de page dans FromThePage. Vous devez sélectionner une collection cible dans laquelle importer et joindre un fichier ZIP ou PDF contenant des images de page à utiliser pour votre projet.
+      page_image_guidelines: Directives relatives aux images de page
+      select_a_collection: "- Sélectionnez une collection -"
+      to_specify_metadata: Pour spécifier les métadonnées avec les images, incluez un fichier %{link} dans chaque dossier en spécifiant les champs pour le travail.
+      trial_accounts_are_limited: Les comptes d'essai sont limités à 200 pages. Veuillez contacter support@fromthepage.com pour mettre à niveau votre compte.
+      upload_file: Téléverser un fichier
+      upload_pdf_or_zip_file: Télécharger un fichier PDF ou ZIP
+      use_image_filenames: " Utilisez des noms de fichiers d'image comme titres de page."
+      use_ocr_from_pdf: " Importez du texte à partir de calques de texte PDF, de fichiers texte ou de fichiers XML."
+      zip_files_may_contain: Les fichiers ZIP peuvent contenir des dossiers contenant des images, des fichiers PDF ou des dossiers contenant des fichiers PDF.
+    watchlist:
+      collections: collections
+      private_collections_you_belong_to: Projets privés
+      projects_you_have_contributed_to: Les projets auxquels vous avez contribué - en les transcrivant, en les modifiant ou en les commentant - seront répertoriés ici avec leur activité la plus récente afin que vous puissiez rester au courant de ce qui se passe.
+      time_ago_in_words: Il y a %{time}
+      try_transcribing_a_page: Vous n'avez encore participé à aucun projet. Essayez de transcrire une page de l'un de ces
+      your_activity: Votre activité

--- a/config/locales/deed/deed-fr.yml
+++ b/config/locales/deed/deed-fr.yml
@@ -1,0 +1,37 @@
+---
+fr:
+  deed:
+    deed:
+      html:
+        added_a_note_to_page: a ajouté une note à la page %{page}
+        added_work: ajouté %{work}
+        corrected_page: page corrigée %{page}
+        described_metadata: métadonnées décrites
+        edited_article: article %{article} modifié
+        edited_metadata: métadonnées modifiées
+        edited_page: page modifiée %{page}
+        edited_translation_of_page: édité la traduction de la page %{page}
+        in_collection: " dans la collection %{collection}"
+        in_the_work: " dans le travail %{work}"
+        indexed_page: page indexée %{page}
+        indexed_translation_of_page: indexé la traduction de la page %{page}
+        joined: rejoint
+        marked_page_as_blank: marqué la page %{page} comme vierge
+        marked_page_as_needing_review: a marqué la page %{page} comme nécessitant une révision
+        marked_translation_page_as_needing_review: a marqué la page de traduction %{page} comme nécessitant une révision
+        reviewed_page: page examinée %{page}
+        reviewed_translation: traduction révisée de la page %{page}
+        saying_deed: ", en disant &laquo;%{title}&rdquo;"
+        this_collection: cette collection
+        transcribed_page: page transcrite %{page}
+        translated_page: page traduite %{page}
+    deeds:
+      show_more: Montre plus
+      time_ago_in_words: Il y a %{time}
+    list:
+      activity_stream: Flux d'activité
+      collection_title: 'Collecte : %{title}'
+      newer_activity: Activité plus récente
+      older_activity: Activité plus ancienne
+      time_ago_in_words: Il y a %{time}
+      user_title: 'Utilisateur : %{title}'

--- a/config/locales/devise/devise-fr.yml
+++ b/config/locales/devise/devise-fr.yml
@@ -1,0 +1,102 @@
+---
+fr:
+  devise:
+    confirm_password: Confirmez le mot de passe
+    create_account: Créer un compte
+    display_name: Afficher un nom
+    email_address: Adresse e-mail
+    failure:
+      already_authenticated: Vous êtes déjà connecté.
+      inactive: Votre compte n'est pas encore activé.
+      invalid: "%{authentication_keys} ou mot de passe non valide."
+      not_found_in_database: "%{authentication_keys} ou mot de passe non valide."
+      timeout: Votre session a expiré. Veuillez vous reconnecter pour continuer.
+      unauthenticated: Vous devez vous connecter ou vous inscrire avant de continuer.
+    login: Connexion
+    mailer:
+      reset_password_instructions:
+        change_my_password: Changer mon mot de passe
+        greeting: Bonjour %{email} !
+        message_1: 'Quelqu''un a demandé un lien pour changer votre mot de passe. Vous pouvez le faire via le lien ci-dessous :'
+        message_2: Si vous ne l'avez pas demandé, veuillez ignorer cet e-mail.
+        message_3: Votre mot de passe ne changera pas tant que vous n'aurez pas accédé au lien ci-dessus et créé un nouveau.
+        subject: Instructions de réinitialisation du mot de passe
+    omniauth_callbacks:
+      failure: Impossible de vous authentifier à partir de %{kind} car "%{reason}".
+      success: Authentification réussie à partir du compte %{kind}.
+    password: Mot de passe
+    passwords:
+      edit:
+        change_password: Changer le mot de passe
+        change_password_message: Créez un nouveau mot de passe pour votre compte. Le mot de passe doit comporter au moins 8 caractères et contenir à la fois des lettres et des chiffres. Veuillez ne pas utiliser le même mot de passe que vous utilisez pour votre banque en ligne ou votre compte de messagerie !
+        new_password: Nouveau mot de passe
+      new:
+        message: Veuillez saisir l'adresse e-mail associée à votre compte FromThePage. Si votre adresse e-mail existe dans notre base de données, vous recevrez un lien de récupération de mot de passe à votre adresse e-mail dans quelques minutes.
+        password_recovery: Récupération de mot de passe
+        recover_password: Récupérer mot de passe
+      no_token: Vous ne pouvez pas accéder à cette page sans venir d'un e-mail de réinitialisation de mot de passe. Si vous venez d'un e-mail de réinitialisation de mot de passe, assurez-vous d'avoir utilisé l'URL complète fournie.
+      send_instructions: Vous recevrez un e-mail avec des instructions sur la façon de réinitialiser votre mot de passe en quelques minutes.
+      send_paranoid_instructions: Si votre adresse e-mail existe dans notre base de données, vous recevrez un lien de récupération de mot de passe à votre adresse e-mail dans quelques minutes.
+      updated: Votre mot de passe a été changé avec succès. Vous êtes maintenant inscrit.
+      updated_not_active: Votre mot de passe a été changé avec succès.
+    real_name: Vrai nom
+    real_name_message: Les projets peuvent l'utiliser lorsqu'ils vous accordent un crédit. Laissez ce champ vide si vous ne souhaitez pas être crédité.
+    receive_activity_emails: Recevoir des e-mails d'activité
+    registrations:
+      choose_saml:
+        harvard_university: Université de Harvard
+        institution: Institution
+        lds_full_name: Église de Jésus-Christ des Saints des Derniers Jours
+        sign_in_with_institution: Connectez-vous avec votre établissement
+      destroyed: Au revoir! Votre compte a été annulé avec succès. Nous espérons vous revoir bientôt.
+      edit:
+        confirm_delete_account: Êtes-vous sûr de vouloir supprimer votre compte ? Après avoir supprimé le compte, vous ne pourrez pas le récupérer !
+        current_password: Mot de passe actuel
+        delete_account: Supprimer le compte
+        edit_account: Modifier le compte
+        message: Ici, vous pouvez modifier les informations de votre compte. Si vous ne souhaitez pas modifier votre mot de passe, laissez les champs de mot de passe vides. Vous devez saisir votre mot de passe actuel pour confirmer les modifications.
+        new_password: Nouveau mot de passe
+        save_changes: Sauvegarder les modifications
+        waiting_confirmation_message: En attente de confirmation pour %{resource}
+      new_trial:
+        fill_in_the_following: Veuillez remplir les informations suivantes pour créer un essai de deux cents pages
+        just_want_to_transcribe: Vous souhaitez simplement transcrire ? %{sign_up_here}
+        login: Connexion
+        message: Veuillez remplir les informations suivantes pour créer un compte de propriétaire de projet FromThePage d'essai de deux cents pages. Avoir des questions? %{schedule_a_kickoff_call}
+        project_owner_account_have: Compte du propriétaire du projet FromThePage. Avoir des questions?
+        schedule_a_kickoff_call: Planifiez un appel de lancement.
+        sign_up_for_trial: Inscrivez-vous pour un essai
+        sign_up_here: Inscrivez-vous ici
+        want_to_transcribe: voulez-vous transcrire?
+      owner_new:
+        projects_may_use_this: Les projets peuvent l'utiliser lorsqu'ils vous accordent un crédit. Laissez ce champ vide si vous ne souhaitez pas être crédité.
+        you_ll_use_this: Vous utiliserez ce nom pour vous connecter. Il sera affiché publiquement.
+      signed_up: Accueillir! Vous vous êtes inscrit avec succès.
+      updated: Votre compte a été mis à jour avec succès.
+      updated_but_not_signed_in: Votre compte a été mis à jour avec succès, mais depuis que votre mot de passe a été changé, vous devez vous reconnecter
+    sessions:
+      already_signed_out: Déconnexion réussie.
+      new:
+        forgot_your_password: Mot de passe oublié?
+        or: ou
+        remember_me: " Souviens-toi de moi"
+        sign_in_with_institution: Connectez-vous avec votre établissement (SSO)
+        sign_up_as_transcriber_message: Vous souhaitez rejoindre un projet existant en tant que transcripteur ? Inscrivez-vous en tant que transcripteur.
+        sign_up_now: S'inscrire maintenant
+        start_free_trial: Commencer l'essai gratuit
+        start_free_trial_message: Vous voulez commencer un nouveau projet de transcription ? Commencez un essai gratuit.
+      signed_in: Connexion réussie.
+      signed_out: Déconnexion réussie.
+    shared:
+      links:
+        forgot_your_password: Mot de passe oublié?
+        no_confirmation_instructions: Vous n'avez pas reçu les instructions de confirmation ?
+        no_unlock_instructions: Vous n'avez pas reçu d'instructions de déverrouillage ?
+        sign_in_existing_account: Connectez-vous au compte existant
+        sign_in_with_google: Connectez-vous avec Google
+        sign_in_with_institution: Connectez-vous avec votre établissement (SSO)
+        sign_up_new_account: Inscrivez-vous pour un nouveau compte
+    sign_in: S'identifier
+    sign_up: S'inscrire
+    user_name: Nom d'utilisateur
+    user_name_message: Vous utiliserez ce nom pour vous connecter. Il sera affiché publiquement.

--- a/config/locales/display/display-fr.yml
+++ b/config/locales/display/display-fr.yml
@@ -1,0 +1,76 @@
+---
+fr:
+  display:
+    display_page:
+      collaboration_is_restricted: La collaboration est restreinte pour cette collection. Veuillez contacter le propriétaire du projet si vous souhaitez aider à la transcription.
+      collection_is_not_active: Ce projet n'est pas actif. Veuillez contacter le propriétaire du projet pour toute question.
+      corrected: corrigée
+      facsimile: Facsimilé
+      help_correct: aider à corriger
+      help_transcribe: aider à transcrire
+      help_translate: aider à traduire
+      mark_the_page_blank: marquer la page blanche
+      or_mark_blank: "<br>ou %{mark_blank}"
+      page_notes: Remarques et questions
+      please_help_this_page: Veuillez %{help_link} cette page
+      show_transcription: Afficher la transcription
+      show_translation: Afficher la traduction
+      this_page_is_blank: Cette page est vierge
+      this_page_is_not: Cette page n'est pas %{text_type}
+      transcribed: transcrit
+      transcription: Transcription
+      translated: traduit
+      translation: Traduction
+    list_pages:
+      actions: Actions
+      describe: Décris
+      metadata: Métadonnées
+      no_notes: Aucune remarque
+      no_pages_found: Aucune page trouvée
+      no_pages_in_work: Ce travail ne contient pas encore de pages, rendez-vous sur %{link} pour créer une nouvelle page
+      page_title: Titre de la page
+      pages_tab: Onglet Pages
+      user_notes: Remarques de l'utilisateur
+    multi_page:
+      categories: Catégories
+      describe: Créer des métadonnées
+      pages_need_indexing: Pages à indexer
+      pages_need_review: Pages à réviser
+      pages_need_transcription: Pages nécessitant une transcription
+      pages_need_translation: Pages à traduire
+      search: Chercher
+      search_for: Rechercher %{search_string}
+      search_in_collection: Rechercher dans la collection...
+      search_in_collection_1: Rechercher dans la collection
+      translations_need_indexing: Traductions nécessitant une indexation
+      translations_need_review: Traductions à revoir
+      view_all_pages: Afficher toutes les pages
+    pages_view:
+      collaboration_is_restricted: La collaboration est restreinte pour cette collection. Veuillez contacter le propriétaire du projet si vous souhaitez aider à la transcription.
+      corrected: corrigée
+      help_complete: Modifier cette page
+      help_correct: aider à corriger
+      help_transcribe: aider à transcrire
+      help_translate: aider à traduire
+      last_edit: Dernière modification il y a %{edit_time} par %{user_link}
+      no_pages_found: Aucune page trouvée
+      no_pages_needing_transcription_found_these_pages_are_incomplete: Aucune page n'a besoin d'être retranscrite à partir de zéro. Ces pages ont été partiellement transcrites mais doivent être complétées.
+      page_not_translated: Cette page n'est pas traduite, veuillez %{help_translate} cette page
+      pages_needing_completion: Pages à compléter
+      pages_that_need_transcription: Pages nécessitant une transcription
+      review_metadata: Examiner les métadonnées
+      this_page_is_blank: Cette page est vierge
+      this_page_is_incomplete: Cette page est incomplète
+      this_page_is_not: Cette page n'est pas %{status}, veuillez %{help} cette page
+      transcribed: transcrit
+      translation: Traduction
+      unable_to_find_pages: Nous n'avons trouvé aucune page correspondant à votre demande
+  display_helper:
+    page_action:
+      blank_page: Page blanche
+      completed: Complété
+      correct: Corriger
+      index: Indice
+      review: Examen
+      transcribe: Transcrire
+      translate: Traduire

--- a/config/locales/document_sets/document_sets-fr.yml
+++ b/config/locales/document_sets/document_sets-fr.yml
@@ -1,0 +1,105 @@
+---
+fr:
+  document_sets:
+    create:
+      document_created: Le jeu de documents a été créé
+    edit:
+      current_url_for_this_work: L'URL actuelle de ce travail est %{current_url}. Si vous souhaitez modifier la section de l'ensemble de documents de l'URL, veuillez utiliser des lettres minuscules et des tirets entre les mots.
+      description: La description
+      document_is_marked_public: Si le jeu de documents est marqué comme public, les œuvres qui y sont placées seront lisibles même si la collection est marquée comme privée.
+      save_document_set: Enregistrer le jeu de documents
+      title: Titre
+      url: URL
+    index:
+      actions: Actions
+      aggregating_works_thematic_exhibits: Regroupement des œuvres dans des expositions thématiques
+      assign_works_to_document_sets: Attribuer des œuvres à des ensembles de documents
+      create_a_document_set: Créer un ensemble de documents
+      delete: Effacer
+      delete_document_set_confirm_message: Voulez-vous vraiment supprimer ce jeu de documents ? Cela supprimera votre ensemble de documents, mais aucune des œuvres de l'ensemble de documents.
+      document_sets_are_sub_sets: 'Les ensembles de documents sont des sous-ensembles des documents d''une collection. Ils ont plusieurs utilisations, notamment :'
+      document_sets_for: Jeux de documents pour %{title}
+      edit: Éditer
+      focusing_transcriber_effort: Concentration des efforts du transcripteur sur un groupe particulier d'œuvres.
+      n_pages:
+        one: '1 page :'
+        other: "%{count} pages :"
+      no_document_sets: Cette collection n'a pas d'ensembles de documents
+      privacy: Intimité
+      private: Privé
+      public: Public
+      publishing_works_private_collection: Édition d'œuvres d'une collection privée. (Toutes les œuvres d'une collection privée ajoutées à un ensemble de documents publics seront visibles par le public.)
+      save: sauvegarder
+      search: Chercher
+      search_for_works: Rechercher des oeuvres...
+      status: Statut
+      title: Titre
+      toggle_work_in_document_set: Basculer %{work} dans le jeu de documents %{document_set}
+      transfer_works: Travaux de transfert
+      work: Travailler
+    new:
+      create_document_set: Créer un ensemble de documents
+      create_new_document_set: Créer un nouveau jeu de documents
+      description: La description
+      document_set_is_marked_public: Si le jeu de documents est marqué comme public, les œuvres qui y sont placées seront lisibles même si la collection est marquée comme privée.
+      public: Public
+      title: Titre
+    set_works:
+      collaboration: Collaboration
+      n_pages:
+        one: '1 page :'
+        other: "%{count} pages :"
+      progress: Progrès
+      remove_from_set: Supprimer de l'ensemble
+      remove_title_from_document_set: Supprimer %{title} du jeu de documents
+      remove_works: Supprimer les œuvres
+      restricted: Limité
+      unrestricted: Libre
+      work_title: Titre de travail
+    settings:
+      add: Ajouter
+      add_collaborator: Ajouter un collaborateur
+      add_work_title_to_document_set: Ajouter %{work_title} au jeu de documents
+      collaborators_may_transcribe: Les collaborateurs peuvent transcrire et éditer des ensembles de documents privés.
+      document_set_based_on: Il s'agit d'un ensemble de documents basé sur la collection <b>%{title}</b>. Vous pouvez gérer tous les travaux et ensembles de documents de cette collection en cliquant sur %{link}.
+      document_set_collaborators: Collaborateurs de l'ensemble de documents
+      document_set_image: Image du jeu de documents
+      document_set_privacy: Confidentialité de l'ensemble de documents
+      document_set_restricted: L'ensemble de documents ne peut être consulté que par les collaborateurs répertoriés ci-dessous. Vous pouvez rendre la collection lisible publiquement.
+      document_set_unrestricted: L'ensemble de documents peut être consulté par n'importe qui sur Internet. Toutes les œuvres placées dans un ensemble de documents publics seront lisibles, même si la collection parente est privée. Vous pouvez rendre le jeu de documents privé pour limiter sa visibilité aux collaborateurs.
+      here: ici
+      make_document_set_private: Rendre l'ensemble de documents privé
+      make_document_set_public: Rendre l'ensemble de documents public
+      manage_works: Gérer les travaux
+      n_contributions:
+        one: 1 cotisation
+        other: "%{count} cotisations"
+      n_pages:
+        one: '1 page :'
+        other: "%{count} pages : pl"
+      no_image: Pas d'image
+      picture_document_set_description: Image à utiliser pour illustrer la description du jeu de documents.
+      remove: Retirer
+      save: sauvegarder
+      search: Chercher
+      search_for_works: Rechercher des oeuvres...
+      status: Statut
+      upload_image: Télécharger une image
+      work: Travailler
+    transfer:
+      source_and_target_can_not_be_the_same: La source et la cible ne peuvent pas être identiques.
+    transfer_form:
+      all: Tous les travaux
+      cancel: Annuler
+      completed: Seuls les travaux achevés
+      copy: Copier (ne crée pas d'œuvres en double)
+      move: Déplacer
+      source_set: Ensemble de documents sources
+      status_filter: Qui fonctionne
+      target_set: Ensemble de documents cible
+      transfer: Transférer
+      transfer_type_label: Type de transfert
+      transfer_works: Travaux de transfert
+      transfer_works_description: Le transfert fonctionne entre les ensembles de documents. (La copie placera le même travail dans deux ensembles de documents en même temps.)
+    update:
+      document_updated: Le jeu de documents a été enregistré

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,7 +6,7 @@ en:
     plain: Dashboard
   en: English
   es: Español
-  pt: Português
   fr: Français
+  pt: Português
   time_ago_in_words: "%{time} ago"
   unauthorized_collection: You do not have access to %{project}.  Please log in or contact the project owner to be added.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -5,6 +5,6 @@ es:
     plain: Panel de Control
   en: English
   es: Español
-  pt: Português
   fr: Français
+  pt: Português
   time_ago_in_words: Hace %{time}

--- a/config/locales/export/export-fr.yml
+++ b/config/locales/export/export-fr.yml
@@ -1,0 +1,100 @@
+---
+fr:
+  export:
+    edit_contentdm_credentials:
+      connect: Relier
+      contentdm_credentials: CONTENUdm Identifiants
+      contentdm_credentials_description: Entrez votre clé de licence CONTENTdm et vos identifiants de connexion pour exporter vers CONTENTdm
+      contentdm_password: Mot de passe CONTENTdm
+      contentdm_user_name: nom d'utilisateur CONTENTdm
+      license_key: Clé de licence
+    facing_edition:
+      contributions_message: 'Ce document ne serait pas possible sans les contributions éditoriales des personnes suivantes :'
+      export_metadata: Exportation FromThePage de %{work} à partir de %{collection} effectuée sur %{time}.
+    index:
+      api: API
+      export_all_table_data_as_csv: Exporter toutes les données du tableau au format CSV
+      export_all_tables: Exporter tous les tableaux
+      export_all_tables_description: Cliquez sur le bouton pour exporter les données du tableau de toute la collection dans un seul fichier CSV. Veuillez noter que le processus d'exportation peut prendre un certain temps, veuillez donc patienter jusqu'à ce que la boîte de dialogue Enregistrer le fichier s'affiche.
+      export_all_works: Exporter toutes les œuvres
+      export_all_works_description: Choisissez les formats et les granularités pour exporter toute la collection dans un fichier zip.
+      export_as: Exporter sous
+      export_individual_works: Exporter des œuvres individuelles
+      export_individual_works_description: Vous pouvez choisir d'exporter des œuvres individuelles dans plusieurs formats de fichiers. XHTML exporte une œuvre sous la forme d'un fichier XHTML d'une seule page avec des transcriptions, des commentaires d'utilisateurs, des articles de sujet et des HREF internes reliant les sujets et les pages. TEI exporte une œuvre sous la forme d'un document TEI-XML conforme à P5. Le texte est en clair. L'export zip vous donnera tous les formats d'une œuvre et la granularité des pages.
+      export_subject_coocurrence_as_csv: Exporter les cooccurrences au format CSV
+      export_subject_coocurrence_description: Cliquez sur le bouton pour exporter un fichier CSV avec une ligne pour chaque combinaison de sujets de la collection qui sont mentionnés dans la même page. (Le processus d'exportation peut prendre un certain temps, veuillez donc patienter jusqu'à ce que la boîte de dialogue Enregistrer le fichier s'affiche.)
+      export_subject_details_as_csv: Exporter les sujets au format CSV
+      export_subject_details_description: Cliquez sur le bouton pour exporter un fichier CSV avec une ligne pour chaque sujet de la collection. (Le processus d'exportation peut prendre un certain temps, veuillez donc patienter jusqu'à ce que la boîte de dialogue Enregistrer le fichier s'affiche.)
+      export_subject_index: Exporter les sujets
+      export_subject_index_description: Cliquez sur le bouton pour exporter les index des sujets de toute la collection dans un seul fichier CSV. (Le processus d'exportation peut prendre un certain temps, veuillez donc patienter jusqu'à ce que la boîte de dialogue Enregistrer le fichier s'affiche.)
+      export_subjects_as_csv: Index d'exportation au format CSV
+      export_to_contentdm: Exporter vers CONTENTdm
+      export_to_contentdm_description: Cliquez sur le bouton pour exporter les transcriptions terminées de l'ensemble de la collection vers CONTENTdm.
+      export_work_metadata: Exporter les métadonnées de travail
+      export_work_metadata_as_csv: Exporter les métadonnées de travail au format CSV
+      export_work_metadata_description: Exportez une feuille de calcul contenant une ligne pour chaque œuvre de la collection, avec des colonnes pour les statistiques sur les pages transcrites et les métadonnées de l'œuvre.
+      here: ici
+      html: HTML
+      iiif: IIIF
+      iiif_api_description: Nous avons également une API basée sur IIIF pour exporter par programme les transcriptions de vos collections. En savoir plus %{link}
+      iiif_collection_api_endpoint: 'Point de terminaison de l''API de collecte IIIF : %{link}'
+      indexed: Indexé
+      more: Suite
+      more_export_formats: Formats d'exportation supplémentaires
+      n_pages:
+        one: 1 page
+        other: "%{count}pages"
+      pages: pages
+      plain_text: Texte brut
+      progress: Progrès
+      review: Examen
+      table_csv: Tableau CSV
+      tei: TEI
+      work_title: Titre de travail
+    show:
+      categories: 'Catégories :'
+      export_metadata: Exportation FromThePage de %{work} à partir de %{collection} effectuée sur %{time}.
+      fromthepage_version: 'Version de la page : %{version}'
+      identifier: 'Identifiant : %{work}'
+      notes: 'Remarques:'
+      page_edit_history: 'Historique des modifications de page :'
+      page_transcripts: Transcriptions de pages
+      page_translations: Traductions de pages
+      pages: 'Pages :'
+      subjects_and_indices: Sujets et indices
+    tei:
+      administrator: Administrateur du projet de transcription %{collection} sur FromThePage
+      changes_to_page_transcript: Modifications de la transcription de la page.
+      double_proof_by: 'Double preuve par :'
+      dynamic_tei_export: Export TEI dynamique depuis FromThePage (version %{version})
+      edition_created: Edition créée à partir de nouvelles transcriptions de ce manuscrit.
+      empty_transcript: Transcription vide – téléchargement initial du fac-similé de la page probablement.
+      initial_upload: Téléchargement initial des images en fac-similé et des métadonnées de cette œuvre sur FromThePage pour modification
+      made_edits_between: effectué %{count} modifications entre
+      made_one_edit_on: fait une modification sur
+      single_proof_by: 'Preuve unique par :'
+    text:
+      categories: 'Catégories :'
+      export_metadata: Exportation FromThePage de %{work} à partir de %{collection} effectuée sur %{time}.
+      fromthepage_version: 'Version de la page : %{version}'
+      identifier: 'Identifiant : %{work}'
+      notes: 'Remarques:'
+      page_transcripts: Transcriptions de pages
+      page_translations: Traductions de pages
+      pages: 'Pages :'
+      subjects_and_indices: Sujets et indices
+    transcript:
+      export_metadata: Exportation FromThePage de %{work} à partir de %{collection} effectuée sur %{time}.
+      fromthepage_version: 'Version de la page : %{version}'
+      identifier: 'Identifiant : %{work}'
+      notes: 'Remarques:'
+      page_transcripts: Transcriptions de pages
+      page_translations: Traductions de pages
+    translation:
+      export_metadata: Exportation FromThePage de %{work} à partir de %{collection} effectuée sur %{time}.
+      fromthepage_version: 'Version de la page : %{version}'
+      identifier: 'Identifiant : %{work}'
+      notes: 'Remarques:'
+      page_translations: Traductions de pages
+    update_contentdm_credentials:
+      updating_contentdm_message: Mise à jour de CONTENTdm. Vous devriez recevoir un e-mail une fois la synchronisation terminée, puis vous devrez reconstruire votre index pour que les modifications apparaissent.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,12 @@
+---
+fr:
+  authentication_failed: Authentification échouée
+  dashboard:
+    collaborator: Tableau de bord des collaborateurs
+    plain: Tableau de bord
+  en: English
+  es: Español
+  fr: Français
+  pt: Português
+  time_ago_in_words: Il y a %{time}
+  unauthorized_collection: Vous n'avez pas accès à %{project}. Veuillez vous connecter ou contacter le propriétaire du projet à ajouter.

--- a/config/locales/ia/ia-fr.yml
+++ b/config/locales/ia/ia-fr.yml
@@ -1,0 +1,50 @@
+---
+fr:
+  ia:
+    confirm_import:
+      book_already_imported_description: 'Les œuvres répertoriées ci-dessous peuvent avoir été importées de la même source :'
+      book_already_imported_warning: 'Avertissement : Ce livre a peut-être déjà été importé !'
+      book_was_imported: Livre d'archives Internet "%{book}" ; a été importé par %{user} sur %{date}
+      cancel_import: Annuler l'importation
+      import_anyway: Importer quand même
+      import_from_archive_org: Importer depuis Archive.org
+      not_converted_into_work: mais n'a pas été converti en une œuvre FromThePage.
+      please_enter_valid_url: Veuillez saisir une URL de livre Archive.org valide à importer
+      was_converted_into_work: et a été converti en travail FromThePage
+    convert:
+      converted_to_work: "%{title} a été converti en une œuvre FromThePage"
+    ia_book_form:
+      book_url: URL du livre
+      import_book_description: Pour importer un livre, veuillez ouvrir ce livre sur www.archive.org, puis copiez l'URL du livre à partir de la barre d'adresse du navigateur et collez-la ci-dessous.
+      import_from_archive_org: Importer depuis Archive.org
+      import_work: Importer le travail
+    import_work:
+      imported_into_staging: "%{title} a été importé dans votre zone de staging"
+    manage:
+      actions: Actions
+      book_imported_description: Ce livre a été importé des archives Internet mais n'a pas encore été converti en œuvre. Ci-dessous, vous voyez la liste des pages importées et leur texte OCR. Utilisez le menu actions pour définir la première page (masquer toutes les pages précédentes) et la dernière page (masquer toutes les pages suivantes). Vous pouvez également gérer les titres des pages à partir du texte OCR et enfin convertir cet import en œuvre en le publiant dans une collection. Pour plus d'informations sur cet écran, consultez l'article Wiki <a href="https://github.com/benwbrum/fromthepage/wiki/Importing-Works-from-the-Internet-Archive" target="_blank">Importation de travaux à partir des archives Internet</a>.
+      conceal_following_pages: Masquer les pages suivantes
+      conceal_preceding_pages: Masquer les pages précédentes
+      first_line_of_ocr: Première ligne d'OCR
+      first_line_of_ocr_description: "<b>La première ligne de l'OCR</b> remplace les titres de page par la première ligne du texte OCR sur chaque page. Ceci est utile pour les agendas et les livres de jour, puisque la première ligne est généralement une date."
+      last_line_of_ocr: Dernière ligne de l'OCR
+      last_line_of_ocr_description: "<b>La dernière ligne de l'OCR</b> remplace les titres de page par la dernière ligne du texte OCR sur chaque page. Ceci est utile pour les travaux imprimés dans lesquels les numéros de page apparaissent en bas."
+      manage_archive_org_import: Gérer l'importation Archive.org
+      ocr_for_page_contents: Utiliser le texte OCR pour le contenu de la page ?
+      ocr_for_page_contents_description: Cochez cette case pour remplir la transcription initiale de chaque page avec le contenu de l'OCR correspondant. (Ne le faites pas si vos pages contiennent une écriture manuscrite que vous souhaitez transcrire.)
+      ocr_page_titles_description: Ce processus prendra plusieurs secondes pour s'exécuter, car il nécessite l'analyse de l'intégralité du texte OCR du livre et la mise à jour de chaque titre de page. Une fois le livre converti en une œuvre FromThePage, vous pourrez corriger les titres de page manuellement.
+      page_n_of_n: Page %{n} sur %{total} (%{n2})
+      page_titles: Titres des pages
+      publish_to_collaborators: Publier aux collaborateurs
+      publish_work: Publier le travail
+      publish_work_description: Une fois que vous avez les titres et les feuilles prêts, cliquez sur Publier pour convertir le livre en une œuvre FromThePage prête à être transcrite. Ce processus prendra plusieurs minutes à s'exécuter.
+      select_a_collection: "- Sélectionnez une collection -"
+      select_a_collection_1: Sélectionnez une collection
+    mark_beginning:
+      preceding_the_beginning: Les pages précédant le début du texte ont été masquées
+    mark_end:
+      pages_following_the_end: Les pages suivant la fin du texte ont été masquées
+    title_from_ocr_bottom:
+      pages_has_been_renamed: Les pages ont été renommées avec la ligne inférieure du texte OCR
+    title_from_ocr_top:
+      pages_has_been_renamed: Les pages ont été renommées avec la ligne supérieure du texte OCR

--- a/config/locales/layouts/application-fr.yml
+++ b/config/locales/layouts/application-fr.yml
@@ -1,0 +1,31 @@
+---
+fr:
+  layouts:
+    application:
+      about: À propos de
+      admin_dashboard: Tableau de bord administrateur
+      all_rights_reserved: Tous les droits sont réservés.
+      blog: Blog
+      collaborator_dashboard: Tableau de bord des collaborateurs
+      contact_us: Nous contacter
+      create_an_account: Créer un compte
+      documentation: Documentation
+      find_a_project: Trouver un projet
+      home: Maison
+      internet_archive_difficulties: Internet Archive rencontre des difficultés. Veuillez réessayer plus tard.
+      owner_dashboard: Tableau de bord du propriétaire
+      pricing: Tarification
+      privacy_policy: Politique de confidentialité
+      projects: Projets
+      recaptcha_validation_failed: La validation ReCAPTCHA a échoué
+      sign_in: S'identifier
+      sign_out: Se déconnecter
+      sign_up_to_transcribe: Inscrivez-vous pour transcrire
+      signed_in_as: Connecté en tant que
+      terms_and_conditions: termes et conditions
+      transcription_for_archives_special_collections: Transcription pour les archives et les collections spéciales
+      transcription_for_digital_scholarship: Transcription pour la bourse numérique
+      transcription_for_linguists: Transcription pour les linguistes
+      transcription_for_state_provincial_archives: Transcription pour les archives d'État et provinciales
+      undo_login_as: Annuler la connexion en tant que
+      your_profile: Votre profil

--- a/config/locales/metadata/metadata-fr.yml
+++ b/config/locales/metadata/metadata-fr.yml
@@ -1,0 +1,10 @@
+---
+fr:
+  metadata:
+    upload:
+      browse: Parcourir
+      click_to_browse_a_file: Cliquez pour parcourir un fichier...
+      template_file_anchor: ce fichier modèle
+      upload: Télécharger
+      upload_metadata: Télécharger les métadonnées
+      upload_metadata_description: Pour mettre à jour les métadonnées de plusieurs œuvres de cette collection, téléchargez une feuille de calcul avec une ligne par œuvre. Veuillez télécharger %{link} pour commencer.

--- a/config/locales/notes/notes-fr.yml
+++ b/config/locales/notes/notes-fr.yml
@@ -1,0 +1,34 @@
+---
+fr:
+  notes:
+    create:
+      error_creating_note: Erreur lors de la création de la note
+      must_be_logged: Vous devez être connecté pour créer des notes
+      note_has_been_created: La note a été créée
+    destroy:
+      note_has_been_deleted: La note a été supprimée
+    note:
+      cancel: Annuler
+      confirm_delete_message: Voulez-vous vraiment supprimer cette note ?
+      delete: Effacer
+      edit: Éditer
+      html:
+        cancel: Annuler
+        confirm_delete_message: Voulez-vous vraiment supprimer cette note ?
+        delete: Effacer
+        edit: Éditer
+        microphone: Microphone
+        update: Mise à jour
+      microphone: Microphone
+      update: Mise à jour
+    notes:
+      microphone: Microphone
+      nobody_has_written_a_note: Personne n'a encore écrit de note pour cette page
+      note_body: Corps de la note
+      please_sign_in_to_write: Veuillez %{link} écrire une note pour cette page
+      save_note: Enregistrer la note
+      sign_in: s'identifier
+      write_a_new_note: Écrivez une nouvelle note ou posez une question...
+    update:
+      error_updating_note: Erreur lors de la mise à jour de la note
+      note_has_been_updated: La note a été mise à jour

--- a/config/locales/page/page-fr.yml
+++ b/config/locales/page/page-fr.yml
@@ -1,0 +1,43 @@
+---
+fr:
+  page:
+    create:
+      page_created: Page créée avec succès
+    delete:
+      page_deleted: La page a été supprimée
+    edit:
+      browse: Parcourir
+      click_to_browse_a_file: Cliquez pour parcourir un fichier...
+      created: Créé %{date}
+      delete_confirm_message: Voulez-vous vraiment supprimer cette page ? Après la suppression, vous ne pourrez pas le récupérer !
+      delete_page: Supprimer la page
+      dimensions: 'Dimensions : %{width}×%{height}'
+      here_you_can_edit: Ici, vous pouvez modifier le titre de la page et télécharger une nouvelle image. Si vous souhaitez modifier la transcription de la page ou le texte de traduction, veuillez passer à l'onglet approprié ci-dessus.
+      page_image: Image de la page
+      page_position: 'Position de la page : %{position}'
+      page_status: État de la page
+      page_status_: Pas commencé
+      page_status_blank: Page blanche
+      page_status_incomplete: Incomplet
+      page_status_indexed: Indexé
+      page_status_review: A besoin d'un examen
+      page_status_transcribed: Complet
+      page_status_translated: Traduit
+      page_title: Titre de la page
+      page_translation_status: État de la traduction de la page
+      rotate_clockwise: Le sens des aiguilles d'une montre
+      rotate_counterclockwise: Tourner dans le sens antihoraire
+      save_changes: Sauvegarder les modifications
+      status: 'Statut:'
+    new:
+      add_new_page: Ajouter une nouvelle page
+      browse: Parcourir
+      cancel: Annuler
+      choose_a_title: Choisissez un titre pour la page et sélectionnez une image de page à télécharger.
+      click_to_browse_a_file: Cliquez pour parcourir un fichier...
+      page_image: Image de la page
+      save_and_add_next_page: Enregistrer et ajouter la page suivante
+      save_and_new_work: Enregistrer et nouveau travail
+      title: Titre
+    update:
+      page_updated: Page mise à jour

--- a/config/locales/page_block/page_block-fr.yml
+++ b/config/locales/page_block/page_block-fr.yml
@@ -1,0 +1,12 @@
+---
+fr:
+  page_block:
+    edit:
+      html_block_for: Bloc HTML pour %{description}
+    html_block:
+      create_help_text: Créer un texte d'aide
+      edit_help_text: Modifier le texte d'aide
+    list:
+      action: Action
+      edit: Éditer
+      page_block: Bloc de page

--- a/config/locales/page_version/page_version-fr.yml
+++ b/config/locales/page_version/page_version-fr.yml
@@ -1,0 +1,12 @@
+---
+fr:
+  page_version:
+    show:
+      author_contributed_at: "%{author} à %{date}"
+      compared_with: Comparé à
+      help_description: Ici, vous pouvez voir toutes les révisions de page et comparer les modifications apportées à chaque révision. La colonne de gauche montre le titre de la page et la transcription dans la révision sélectionnée, la colonne de droite montre ce qui a été modifié. Le texte inchangé est <span>surligné en blanc</span>, le texte supprimé est <del>surligné en rouge</del> et le texte inséré est <ins>surligné en vert</ins>.
+      no_transcription_provided: Aucune transcription fournie
+      no_translation_provided: Aucune traduction fournie
+      revision: révision
+      translation: Traduction
+      untitled: Sans titre

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -5,6 +5,6 @@ pt:
     plain: Painel de Controle
   en: English
   es: Español
-  pt: Português
   fr: Français
+  pt: Português
   time_ago_in_words: Há %{time}

--- a/config/locales/quality_samplings/quality_samplings-fr.yml
+++ b/config/locales/quality_samplings/quality_samplings-fr.yml
@@ -1,0 +1,42 @@
+---
+fr:
+  quality_samplings:
+    destroy:
+      quality_sampling_destroyed: L'échantillonnage de qualité a été détruit avec succès.
+    index:
+      description: L'échantillonnage de qualité vous permet de vérifier ponctuellement les contributions, en recueillant des données sur la qualité lorsque vous examinez chaque contribution.
+      new_sampling: Commencer l'échantillonnage
+    show:
+      actions: Actions
+      approval_delta_display_0: Très lent
+      approval_delta_display_1: Bas
+      approval_delta_display_2: Moyen
+      approval_delta_display_3: Haute
+      approval_delta_display_4: Très haut
+      description: L'échantillonnage de qualité vous permet de vérifier les contributions de manière aléatoire, puis d'évaluer les pages à réviser en fonction de la quantité de texte corrigé pour un utilisateur ou un travail particulier. Ce nombre peut augmenter à mesure que d'autres pages sont transcrites.
+      not_applicable: N / A
+      not_fully_sampled_yet: Cet échantillon n'a pas encore été entièrement revu.
+      pages_corrected: Pages corrigées
+      pages_corrected_desc: Pages nécessitant une correction lors de l'approbation (faible, c'est mieux).
+      pages_in_sample: Pages dans l'échantillon
+      pages_in_sample_desc: Nombre de pages dans l'échantillon pour l'utilisateur ou le travail.
+      pages_sampled: Pages échantillonnées
+      pages_sampled_desc: Nombre de pages échantillonnées jusqu'à présent par rapport au champ total de l'échantillonnage.
+      pages_to_be_reviewed: Pages à réviser
+      pages_to_be_reviewed_desc: Nombre de pages qui doivent encore être révisées dans l'ensemble de la collection.
+      quality_score: Niveau de qualité
+      quality_score_desc: Pourcentage moyen de modifications nécessaires lors de l'approbation.
+      relative_corrections: Corrections relatives
+      relative_corrections_desc: Combien de corrections ont été nécessaires avant l'approbation, par rapport aux autres utilisateurs de cet échantillon ?
+      review: Examen
+      review_url: URL de révision
+      review_url_desc: URL qui permettra aux examinateurs d'approuver directement les contributions, sans afficher cet écran.
+      sample: Examiner l'échantillon
+      sample_field_size: 'Pages à réviser :'
+      sample_set_has_increased: L'ensemble d'échantillons a augmenté de %{increase} pages
+      sample_set_size: 'Taille du jeu d''échantillons :'
+      total_pages_desc: Nombre de pages dans cette collection.
+      user: Donateur
+      work: Travailler
+    update:
+      quality_sampling_updated: L'échantillonnage de qualité a été mis à jour avec succès.

--- a/config/locales/sc_collections/sc_collections-fr.yml
+++ b/config/locales/sc_collections/sc_collections-fr.yml
@@ -1,0 +1,51 @@
+---
+fr:
+  sc_collections:
+    cdm_bulk_import_create:
+      import_started: Votre importation a commencé. Une fois terminé, vous devriez recevoir un e-mail à %{email}.
+    cdm_bulk_import_new:
+      bulk_contentdm_import: Importation en masse de CONTENUdm
+      compound_object_urls: URL d'objet composé
+      import: Importer
+      import_ocr_text: Importer du texte OCR à partir de CONTENTdm
+      select_a_collection_to_import_into: "- Sélectionnez une collection dans laquelle importer -"
+      separate_urls_with: Séparez les URL par des espaces ou des retours à la ligne.
+    convert_manifest:
+      metadata_is_being_imported: Les métadonnées %{ocr_text} sont en cours d'importation depuis CONTENTdm et devraient apparaître sous peu.
+    explore_collection:
+      already_imported_into: Déjà importé dans
+      collection: 'Collecte : %{sc_collection}'
+      collections: 'Collections :'
+      first_page: Première page
+      id: 'Identifiant : %{id}'
+      import_checked_manifests: Importer les manifestes vérifiés
+      import_ocr_text: Importer du texte OCR à partir de CONTENTdm
+      manifests: 'Manifestes :'
+      next_page: Page suivante
+      no_label: pas de label
+      previous_page: Page précédente
+      select_a_collection: Sélectionnez une collection
+      select_a_collection_to_import_into: "- Sélectionnez une collection dans laquelle importer -"
+      select_all_manifests: Sélectionner tous les manifestes
+      this_collection_is_divided: Cette collection est divisée en plusieurs pages
+    explore_manifest:
+      canvases: 'Toiles :'
+      collection: 'Collecte : %{sc_collection}'
+      description: 'Descriptif : %{description}}'
+      id: 'Identifiant:'
+      import_manifest: Importer le manifeste
+      import_ocr_text: Importer du texte OCR à partir de CONTENTdm
+      license: 'Licence : %{license}'
+      manifest: 'Manifeste : %{sc_manifest}}'
+      metadata: 'Métadonnées : %{metadata}}'
+      select_a_collection_to_import_into: "- Sélectionnez une collection dans laquelle importer -"
+      select_a_collection_to_import_into_label: Sélectionnez une collection dans laquelle importer
+    import:
+      no_manifest_exist: Aucun manifeste IIIF n'existe pour l'élément CONTENTdm %{url}
+      please_enter_valid_url: Veuillez saisir une URL de manifeste IIIF valide.
+    import_cdm:
+      bad_contentdm_url: 'URL CONTENTdm incorrecte : %{url} ERREUR : %{message}'
+      please_enter_url: Veuillez saisir une URL pour un objet CONTENTdm.
+      using_manifest_for: Utilisation du manifeste CONTENTdm IIIF pour %{url}
+    import_collection:
+      import_is_processing: L'importation de la collection IIIF est en cours de traitement. Rechargez cette page dans quelques minutes pour voir les œuvres importées.

--- a/config/locales/shared/shared-fr.yml
+++ b/config/locales/shared/shared-fr.yml
@@ -1,0 +1,88 @@
+---
+fr:
+  shared:
+    article_tabs:
+      overview: Aperçu
+      settings: Réglages
+      subject: matière
+      versions: Versions
+    codemirror:
+      abbr_description: Marque les abréviations dans un texte avec des extensions dans l'attribut expan.
+      add_description: Marque le texte inséré après coup par l'auteur.
+      date_description: Marque les dates, avec une forme standardisée dans l'attribut quand.
+      del_description: Marque le texte qui a été supprimé par effacement ou barré.
+      expan_description: Marque les abréviations développées avec les formes originales dans l'attribut abbr.
+      fig_description: Indique un chiffre ou une ligne horizontale.
+      footnote_description: Entoure le corps d'une note de bas de page, avec le symbole de note de bas de page dans l'attribut marqueur.
+      gap_description: Marque un vide dans le texte, souvent dû à des dommages
+      head_description: Marque les titres dans le texte
+      marginalia_description: Marque le texte dans les marges du texte principal.
+      reg_description: Marque une forme régularisée du texte, avec des formes originales dans l'attribut orig.
+      s_description: Marque le texte qui a été barré pour une raison quelconque.
+      sub_description: Texte en indice.
+      sup_description: Texte en exposant.
+      u_description: Marque le texte souligné.
+      unclear_description: Marque le texte peu clair.
+    collection_tabs:
+      add_work: Ajouter un travail
+      collaborators: Collaborateurs
+      collection: le recueil
+      edit_fields: Des champs
+      edit_metadata_fields: Champs de métadonnées
+      export: Exporter
+      facets: Facettes
+      overview: Aperçu
+      review: Examen
+      sets: Ensembles
+      settings: Réglages
+      statistics: Statistiques
+      subjects: Sujets
+      works_list: Liste des travaux
+    description_tabs:
+      describe: Métadonnées
+      help: Aider
+      metadata: Métadonnées
+      nav_info: Travail %{position} sur %{size}
+      next_page: Page suivante
+      next_work: Travail suivant
+      overview: Aperçu
+      previous_page: Page précédente
+      previous_work: Précédent travail
+      versions: Versions
+    handsontable:
+      date_tooltip: Les dates doivent être au format AAAA-MM-JJ (année à quatre chiffres, mois à deux chiffres, jour à deux chiffres, avec des traits d'union entre eux).
+    markup_help:
+      markup_help_description: '"Lien automatique" suggérera des sujets auxquels certains mots pourraient être liés ou vous pouvez utiliser des accolades doubles pour lier des sujets. <code>[[Jane Doe]]</code> liera le texte "Jane Doe" au sujet Jane Doe, tandis que <code>[[Jane Doe|Jane]]</code> liera le texte "Jane" au sujet Jane Doe. Nous recommandons que la liaison soit laissée à un éditeur après la transcription initiale.'
+    osd_div:
+      brightness: Luminosité
+      contrast: Contraste
+      image_filters: Filtres d'images
+      open_seadragon_needs_js: OpenSeadragon n'est disponible que si JavaScript est activé.
+      threshold: Au seuil
+    page_tabs:
+      correct: Corriger
+      describe_work: Décrire le travail
+      help: Aider
+      nav_info: Page %{position} sur %{size}
+      next_page: Page suivante
+      overview: Aperçu
+      page: page
+      previous_page: Page précédente
+      settings: Réglages
+      transcribe: Transcrire
+      translate: Traduire
+      versions: Versions
+    review_breadcrumbs:
+      dashboard: Tableau de bord de révision
+      page: Page
+    validation_summary:
+      form: formulaire
+    work_tabs:
+      about: À propos de
+      contents: Contenu
+      download: Télécharger
+      help: Aider
+      pages: pages
+      read: Lis
+      settings: Réglages
+      work: Travailler

--- a/config/locales/statistics/statistics-fr.yml
+++ b/config/locales/statistics/statistics-fr.yml
@@ -1,0 +1,74 @@
+---
+fr:
+  statistics:
+    collaborator_time:
+      collaborator_time: Temps de collaboration
+      collaborator_time_for_dates: Heure du collaborateur pour les dates
+      end_date: Date de fin
+      export_activity_as_csv: Exporter l'activité détaillée au format CSV
+      no_activity_for_date_range: Il n'y a aucune activité pour cette plage de dates.
+      start_date: Date de début
+      update: Mise à jour
+      user_totals_for_dates: Totaux utilisateur pour les dates
+    collaborators:
+      collaborators: Collaborateurs
+      editing: Édition
+      indexing: Indexage
+      mailing_list_export: Exportation de la liste de diffusion
+      no_editors: Aucun éditeur
+      no_indexers: Aucun indexeur
+      no_transcribers: Aucun transcripteur
+      transcribing: Transcription
+    collection:
+      last_days_statistics: Statistiques des 7 derniers jours
+    collection_statistics:
+      collaborator: Collaborateur
+      edit: Éditer
+      incomplete_page: Page incomplète
+      indexed: indexé
+      lines_transcribed: Ligne de texte
+      needing_review: besoin d'un examen
+      note: Noter
+      ocr_correction: Correction OCR
+      page: Page
+      records_indexed: Notice indexée
+      reference: Référence
+      reviewed: revu
+      subject: Matière
+      transcribed: transcrit
+      translated: traduit
+      work: Travailler
+      works_described: Travail décrit
+    recent_statistics:
+      collaborator: Collaborateur
+      edit: Éditer
+      indexed: indexé
+      marked_needing_review: marqué comme nécessitant un examen
+      new_subject: Nouveau sujet
+      note: Noter
+      ocr_correction: Correction OCR
+      page: Page
+      reference: Référence
+      reviewed: revu
+      transcribed: transcrit
+      translated: traduit
+    statistics:
+      active_page: Page active
+      collaborator: Collaborateur
+      edit: Éditer
+      incomplete_page: Page incomplète
+      indexed: indexé
+      last_days_statistics: Statistiques des 7 derniers jours
+      marked_needing_review: marqué comme nécessitant un examen
+      needing_review: besoin d'un examen
+      new_subject: Nouveau sujet
+      note: Noter
+      ocr_correction: Correction OCR
+      page: Page
+      reference: Référence
+      reviewed: revu
+      subject: Matière
+      total_page: Page totale
+      transcribed: transcrit
+      translated: traduit
+      work: Travailler

--- a/config/locales/transcribe/transcribe-fr.yml
+++ b/config/locales/transcribe/transcribe-fr.yml
@@ -1,0 +1,86 @@
+---
+fr:
+  transcribe:
+    assign_categories:
+      assign_categories: Attribuer des catégories
+      continue: Continuer
+      manage_categories: Gérer les catégories
+      options: options
+      subject: 'Matière:'
+      uncategorized_subjects: Sujets non classés
+      uncategorized_subjects_mentioned: Vous avez des sujets non classés mentionnés dans la transcription de la page. Veuillez examiner les sujets ci-dessous et leur attribuer les catégories appropriées.
+    display_page:
+      alert: Cette page est en cours d'édition par un autre utilisateur !
+      always_show_fullscreen: Toujours afficher en plein écran
+      edit_transcription: Modifier la transcription
+      fullscreen: Plein écran
+      image_at_the_bottom: Image en bas
+      image_at_the_left: Image à gauche
+      image_at_the_right: Image à droite
+      image_at_the_top: Image en haut
+      layout: Disposition
+      mark_as_blank: Marquer comme vide
+      microphone: Microphone
+      more_help: Plus d'aide....
+      needs_review: A besoin d'un examen
+      notes_and_questions: Remarques et questions
+      this_page_marked_blank: Cette page est marquée vierge
+      this_page_marked_needs_review: Cette page a été marquée comme "nécessite une révision". Vous pouvez améliorer cette page en la relisant à l'original et en ajoutant ou en corrigeant le texte. Lorsque vous avez terminé, décochez « Nécessite un examen » et enregistrez la page.
+      this_page_marked_needs_review_workflow_version: Cette page doit être révisée. Vous pouvez améliorer cette page en la relussant par rapport à l'original et en ajoutant ou en corrigeant le texte, puis en approuvant le texte.
+      title: 'Titre:'
+    goto_next_untranscribed_page:
+      another_page_notice: Voici une autre page de cet ouvrage.
+      no_more_pages_notice: Il n'y a plus de pages à retranscrire dans cet ouvrage. Voici une autre page de cette collection.
+      notice: Il n'y a plus de pages à retranscrire dans cette collection.
+    guest:
+      collaboration_restricted_collection: La collaboration est restreinte pour cette collection. Veuillez contacter le propriétaire du projet si vous souhaitez aider à la transcription.
+      save_up_to_three_transcriptions: Vous pouvez enregistrer jusqu'à trois transcriptions en tant qu'invité ou vous inscrire maintenant.
+      sign_up_now: S'inscrire maintenant
+      sign_up_now_to_transcribe: Inscrivez-vous maintenant pour transcrire.
+      transcribe_as_guest: Transcrire en tant qu'invité
+    mark_page_blank:
+      saved_notice: Enregistré
+    save_buttons:
+      approve: Approuver
+      approve_to_transcribed_tooltip: Enregistrer et approuver cette page
+      autolink: Lien automatique
+      autolink_tooltip: Suggérer automatiquement des balises de sujet
+      done: Fait
+      edit: Éditer
+      edit_tooltip: Modifier cette page
+      finish_to_needs_review_tooltip: Enregistrer une page terminée
+      finish_to_transcribed_tooltip: Enregistrer une page terminée
+      preview: Aperçu
+      preview_tooltip: Aperçu de cette page
+      save_changes: sauvegarder
+      save_to_incomplete_tooltip: Enregistrer une page incomplète
+      save_to_needs_review_tooltip: Enregistrez vos modifications
+      save_to_transcribed_tooltip: Enregistrez vos modifications
+    save_transcription:
+      error_message: 'Une erreur s''est produite lors de l''analyse du balisage dans votre relevé de notes. Ce type d''erreur se produit souvent s''il manque un crochet angulaire ou si une balise HTML est laissée ouverte. Vérifiez toutes les occurrences des symboles < ou > dans votre texte. (L''erreur de l''analyseur était : %{error_message})'
+      saved_notice: Enregistré
+      you_may_save_notice: Vous pouvez enregistrer jusqu'à %{guest_deed_count} transcriptions en tant qu'invité.
+    save_translation:
+      error_message: 'Une erreur s''est produite lors de l''analyse du balisage dans votre traduction. Ce type d''erreur se produit souvent s''il manque un crochet angulaire ou si une balise HTML est laissée ouverte. Vérifiez toutes les occurrences des symboles < ou > dans votre texte. (L''erreur de l''analyseur était : %{error_message})'
+      notice: Vous pouvez enregistrer jusqu'à %{guest_deed_count} transcriptions en tant qu'invité.
+    translate:
+      autolink: Lien automatique
+      corrected: corrigée
+      edit: Éditer
+      edit_translation: Modifier la traduction
+      help_correct: aider à corriger
+      help_transcribe: aider à transcrire
+      mark_as_blank: Marquer comme vide
+      mark_the_page_blank: marquer la page blanche
+      microphone: Microphone
+      or_mark_blank: "<br>ou %{mark_blank}"
+      page_needs_review: La page doit être révisée
+      page_notes: Remarques et questions
+      please_help_this_page: Veuillez %{help_link} cette page
+      preview: Aperçu
+      save_changes: Sauvegarder les modifications
+      show_image: Afficher l'image
+      this_page_is_blank: Cette page est vierge
+      this_page_is_not: Cette page n'est pas %{text_type}
+      this_page_marked_needs_review: Cette page a été marquée comme "nécessite une révision". Vous pouvez améliorer cette page en la relisant à l'original et en ajoutant ou en corrigeant le texte. Lorsque vous avez terminé, décochez « Nécessite un examen » et enregistrez la page.
+      transcribed: transcrit

--- a/config/locales/transcription_field/transcription_field-fr.yml
+++ b/config/locales/transcription_field/transcription_field-fr.yml
@@ -1,0 +1,87 @@
+---
+fr:
+  transcription_field:
+    add_columns:
+      must_have_options_list: Les champs sélectionnés doivent avoir une liste d'options. Veuillez ajouter des options à tous les champs sélectionnés et réenregistrer.
+      starting_rows_must_not_be_blank: Les lignes de départ ne doivent pas être vides.
+    add_fields:
+      must_have_options_list: Les champs sélectionnés doivent avoir une liste d'options. Veuillez ajouter des options à tous les champs sélectionnés et réenregistrer.
+    choose_offset:
+      page_layout: Mise en page
+      page_layout_description: Redimensionnez le rectangle sur l'image pour entourer la partie de la page contenant une feuille de calcul, puis cliquez sur le bouton bleu "OK" et enregistrez votre sélection.
+      replace_image: Remplacer l'image
+      replace_image_description: Si l'image d'exemple ne contient pas de feuille de calcul, vous pouvez la remplacer par une page différente de la collection, choisie au hasard.
+      save_selection: Enregistrer la sélection
+    column_form:
+      column_options: Options de colonne (séparées par des points-virgules)
+      column_options_title: Options pour les cellules déroulantes.
+      input_type: Type d'entrée
+      label: Étiquette
+    edit_columns:
+      add_additional_column: Ajouter une colonne supplémentaire
+      cancel: Annuler
+      disable_ruler: Désactiver la règle
+      done: Fait
+      edit_spreadsheet_columns: Configuration de la colonne
+      edit_spreadsheet_header: Configuration de la feuille de calcul
+      enable_ruler: Activer la règle
+      identify_rows: Identifier les lignes
+      identify_rows_description: Les pages peuvent avoir des marges supérieure et inférieure, des champs d'en-tête ou de pied de page ou tout autre texte qui ne doit pas être utilisé lors de l'identification de l'emplacement des lignes sur la page.
+      page_layout: Mise en page
+      preview: Aperçu de la feuille de calcul
+      save: sauvegarder
+      screen_ruler: Règle d'écran
+      screen_ruler_description: Pour améliorer la convivialité et réduire les erreurs du transcripteur, FromThePage peut afficher une règle sur l'image de la page qui met en évidence la partie d'une page que l'utilisateur transcrit. Ceci est utile pour les documents numérisés de manière cohérente écrits sur des formulaires pré-imprimés, mais peut être gênant ou frustrant si les documents sont irréguliers et que la règle de trame ne correspond pas.
+      start_rows_description: Nombre de lignes que la feuille de calcul doit afficher initialement. (Les transcripteurs pourront ajouter des lignes supplémentaires si nécessaire.)
+      start_rows_label: 'Nombre de lignes de départ :'
+      transcription_warning: Ce projet a déjà été partiellement retranscrit. L'ajout de colonnes est acceptable, mais la suppression ou la modification de colonnes peut entraîner la perte de données. Veuillez contacter support@fromthepage.com si vous avez des questions ou si vous avez besoin de renommer des colonnes.
+    edit_field_form:
+      add_additional_field: Ajouter un champ supplémentaire
+      add_additional_line: Ajouter une ligne supplémentaire
+      cancel: Annuler
+      data_entry_type_label: Flux de métadonnées
+      data_entry_type_metadata_only: Les utilisateurs créent uniquement des métadonnées
+      data_entry_type_text_and_metadata: Les utilisateurs transcrivent du texte et créent des métadonnées
+      description_instructions_label: Instructions de description des métadonnées
+      done: Fait
+      line: Ligne
+      preview: Aperçu
+      save: sauvegarder
+    edit_fields:
+      edit_transcription_fields: Modifier les champs de transcription
+      transcription_warning: Ce projet a déjà été partiellement retranscrit. L'ajout de champs est acceptable, mais la suppression ou la modification de champs peut entraîner la perte de données. Veuillez contacter support@fromthepage.com si vous avez des questions ou si vous avez besoin de renommer des champs.
+    edit_metadata_fields:
+      edit_metadata_fields: Modifier les champs de métadonnées
+    field_layout:
+      instructions: Des instructions
+    line_form:
+      field_options: Options de champ (séparées par des points-virgules)
+      field_options_title: Options pour certains champs.
+      input_type: Type d'entrée
+      label: Étiquette
+      page: Page
+      page_title: Pour les formulaires multipages, sur quelle page ce champ doit-il apparaître ? (Laissez vide pour afficher sur chaque page.)
+      percentage_title: Pourcentage de la largeur de ligne à utiliser pour ce champ.
+      percentage_width: Largeur %
+    metadata_field_layout:
+      instructions: Des instructions
+    multiselect_form:
+      options_form_description: Entrez les options pour le champ de métadonnées à sélection multiple, chaque option sur une ligne distincte
+      options_form_title: Options de sélection multiple
+      save: sauvegarder
+    new_column_form:
+      delete_column: Supprimer la colonne
+      field_label: Étiquette de champ
+      field_options: Options de champ
+      input_type: Type d'entrée
+      reorder_column: Réorganiser la colonne
+    new_field_form:
+      configure_options: Configurer les options
+      configure_spreadsheet: Configurer la feuille de calcul
+      delete_field: Supprimer le champ
+      field_label: Étiquette de champ
+      field_options: Options de champ
+      input_type: Type d'entrée
+      page_number: Numéro de page
+      reorder_field: Champ de réorganisation
+      width_percentage: Pourcentage de largeur

--- a/config/locales/user/user-fr.yml
+++ b/config/locales/user/user-fr.yml
@@ -1,0 +1,61 @@
+---
+fr:
+  user:
+    api_key:
+      api_key: clé API
+      api_key_description: Les <a href="https://content.fromthepage.com/api-keys/">clés API</a> permettent l'accès aux collections privées via le <a href="https://github.com/benwbrum/fromthepage /wiki/FromThePage-Support-for-the-IIIF-Presentation-API-and-Web-Annotations">API IIIF</a> ou <a href="http://content.fromthepage.com/bulk-export- api/">API d'exportation en masse</a>.
+      delete_key: Supprimer la clé
+      generate_key: Générer la clé
+      no_api_key_description: Votre compte n'a pas de clé API. Générez-en un pour activer l'accès à l'API.
+      your_api_key_description: 'Votre compte dispose de la clé API suivante, qui peut être utilisée pour accéder à vos collections privées :'
+    owner_profile:
+      api_keys: Clés API
+      edit_profile: Editer le profil
+      login_and_password: Connectez-vous et Mot de passe
+      next_image: Photo suivante
+      previous_image: Image précédente
+      recent_activity: Activité récente
+      website: Site Internet
+    profile:
+      contribution:
+        one: Contribution
+        other: Contributions
+      edit_profile: Editer le profil
+      last_seen: Vu pour la dernière fois %{date}
+      login_and_password: Connectez-vous et Mot de passe
+      newer_activity: Activité plus récente
+      older_activity: Activité plus ancienne
+      recent_activity_by: Activité récente par %{user_display_name}
+      user_deleted: Le profil utilisateur a été supprimé
+      user_since: Utilisateur depuis %{date}
+      users_profile_at_fromthepage: Profil de %{user} sur FromThePage. %{about}
+    update:
+      user_updated: Le profil utilisateur a été mis à jour
+    update_profile:
+      about_you: Au propos de vous
+      add_as_collaborator: Ajouté à la collection privée en tant que collaborateur
+      add_as_owner: Ajouté à la collection en tant que copropriétaire
+      add_as_reviewer: Ajouté à la collection en tant qu'examinateur autorisé
+      default_dictation_language: 'Langue de dictée par défaut :'
+      interface_language: Langue de l'interface
+      location: Emplacement
+      name: Nom
+      name_only_required: Votre nom est le seul champ obligatoire.
+      no_image: Pas d'image
+      ocrid_id: Identifiant OCRID
+      owner_stats: E-mails nocturnes avec activité de collecte détenue
+      page_edited: Note ajoutée en réponse à un commentaire que vous avez fait
+      picture: Image de profil
+      picture_to_be_used_message: Image à utiliser
+      select_notification: 'Sélectionnez les notifications suivantes que vous souhaitez recevoir :'
+      sign_up_url: 'URL d''inscription :'
+      update_profile: Mettre à jour le profil
+      update_user_profile: Mettre à jour le profil utilisateur
+      upload_image: Télécharger une image
+      url: URL
+      user_activity: E-mail de nuit avec l'activité dans les collections sur lesquelles vous avez travaillé
+      user_url: 'URL :'
+      website: Site Internet
+      where_are_you_from: D'où viens-tu?
+      your_blog_or_homepage: Votre blog ou votre page d'accueil
+      your_ocrid_id: Votre identifiant OCRID

--- a/config/locales/user_mailer/user_mailer-fr.yml
+++ b/config/locales/user_mailer/user_mailer-fr.yml
@@ -1,0 +1,67 @@
+---
+fr:
+  user_mailer:
+    added_note:
+      html:
+        view_note: " pour afficher la note en %{collection} : %{work}."
+      message: Nous voulions simplement vous informer que la note suivante a été ajoutée à une page sur laquelle vous avez travaillé dans le travail %{work}, dans la collection %{collection}.
+      text:
+        view_note: 'Vous pouvez afficher la note dans %{collection} : %{work} à l''URL : %{url}.'
+    bulk_export_finished:
+      html:
+        ready_message: a été traité et est prêt à %{this_link}.
+      text:
+        ready_message: 'Votre exportation a été traitée et est prête à cette URL :'
+      this_link: ce lien
+      your_export_is_ready: Votre exportation est prête !
+      your_export_of: Votre exportation de
+    click_here: Cliquez ici
+    collection_collaborator:
+      html:
+        to_view: " pour voir %{collection}"
+      message: Nous voulions simplement vous informer que %{owner} vous a ajouté en tant que collaborateur sur %{collection}.
+      text:
+        to_view: 'Pour afficher %{collection}, visitez l''URL suivante : %{url}'
+    collection_reviewer:
+      html:
+        to_view: " pour voir %{collection}"
+      message: "%{owner} vous a ajouté en tant qu'examinateur autorisé sur %{collection}. Vous devriez pouvoir modifier et approuver toute page nécessitant une révision."
+      text:
+        to_view: 'Pour afficher %{collection}, visitez l''URL suivante : %{url}'
+    greeting: Salut %{user} --
+    html:
+      closing: |
+        Merci, <br><br>
+        DeLaPage
+      turn_off_notification: " pour désactiver cette notification"
+    new_owner:
+      welcome: Accueillir
+    nightly_user_activity:
+      html:
+        to_view_note: " pour afficher la note de la page %{page} dans %{collection} : %{work}, qui a été ajoutée depuis que vous y avez travaillé."
+        to_view_work: " pour afficher %{collection} : %{work}"
+      message: Nous voulions juste vous faire savoir qu'il y a eu une activité dans une collection sur laquelle vous avez travaillé.
+      new_notes: Nouveaux billets
+      new_works: Nouvelles œuvres
+      note_added: Une note a été ajoutée à une page sur laquelle vous avez travaillé dans le travail %{work}, dans la collection %{collection}.
+      text:
+        to_view_note: 'Pour afficher la note sur la page %{work} : %{page}, visitez l''URL suivante : %{url}'
+        to_view_work: 'Pour afficher %{collection} : %{work}, visitez l''URL suivante : %{url}'
+      work_added: "%{owner} a ajouté %{work} à la collection %{collection}."
+    text:
+      closing: |-
+        Merci,
+        DeLaPage
+      turn_off_notification: 'Désactivez cette notification à l''URL : %{url}'
+    upload_finished:
+      html:
+        message: Votre téléchargement a été traité et est prêt à
+      text:
+        message: 'Votre importation a été traitée et est prête à cette URL :'
+      your_upload_is_ready: Votre téléchargement est prêt !
+    work_collaborator:
+      html:
+        to_view: " pour afficher %{collection} - %{work}."
+      message: Nous voulions simplement vous informer que %{owner} vous a ajouté en tant que collaborateur sur %{collection} - %{work}.
+      text:
+        to_view: 'Vous pouvez voir %{collection} : %{work} à l''URL : %{url}'

--- a/config/locales/will_paginate/will_paginate-fr.yml
+++ b/config/locales/will_paginate/will_paginate-fr.yml
@@ -1,0 +1,19 @@
+---
+fr:
+  will_paginate:
+    container_aria_label: Pagination
+    next_label: Suivant →
+    page_aria_label: Page %{page}
+    page_entries_info:
+      multi_page: Affichage de %{model} %{from} - %{to} sur %{count} au total
+      multi_page_html: Affichage de %{model} <b>%{from} - %{to}</b> sur <b>%{count}</b> au total
+      single_page:
+        one: Affichage 1 %{model}
+        other: Affichage de tous les %{count} %{model}
+        zero: Aucun %{model} trouvé
+      single_page_html:
+        one: Affichage <b>1</b> %{model}
+        other: Affichage <b>de tous les %{count}</b> %{model}
+        zero: Aucun %{model} trouvé
+    page_gap: "&hellip;"
+    previous_label: "← Précédent"

--- a/config/locales/work/work-fr.yml
+++ b/config/locales/work/work-fr.yml
@@ -1,0 +1,176 @@
+---
+fr:
+  work:
+    create:
+      work_created: Œuvre créée avec succès
+    describe:
+      always_show_fullscreen: Toujours afficher en plein écran
+      approve: Approuver
+      approve_to_transcribed_tooltip: Enregistrer et approuver ces métadonnées
+      done: Fait
+      finish_to_needs_review_tooltip: Enregistrer les métadonnées terminées
+      finish_to_transcribed_tooltip: Enregistrer les métadonnées terminées
+      fullscreen: Plein écran
+      image_at_the_bottom: Image en bas
+      image_at_the_left: Image à gauche
+      image_at_the_right: Image à droite
+      image_at_the_top: Image en haut
+      layout: Disposition
+      metadata: Métadonnées
+      needs_review: A revoir
+      notes_and_questions: Remarques et questions
+      original_metadata: Métadonnées d'origine
+      page_images: Images de pages
+      save_changes: sauvegarder
+      save_to_incomplete_tooltip: Enregistrer les métadonnées incomplètes
+      save_to_needs_review_tooltip: Enregistrez vos modifications
+      save_to_transcribed_tooltip: Enregistrez vos modifications
+      text: Texte
+      this_page_is_blank: Cette page est vierge
+      view_original: Afficher l'original
+    described: Métadonnées terminées.
+    description_versions:
+      author_contributed_at: "%{author} à %{date}"
+      compared_with: Comparé à
+      help_description: Affichez et comparez les modifications apportées dans chaque révision aux métadonnées de travail. La colonne de gauche montre les métadonnées dans la révision sélectionnée, la colonne de droite montre ce qui a été modifié. Le texte inchangé est <span>surligné en blanc</span>, le texte supprimé est <del>surligné en rouge</del> et le texte inséré est <ins>surligné en vert</ins>.
+      revision: révision
+    download:
+      analyze: Analyser
+      docx_download_description: Téléchargez une version DOCX de ce travail.
+      download: Télécharger
+      expanded_plaintext: Texte en clair étendu
+      expanded_plaintext_export_description: Exportez des transcriptions en texte brut en remplaçant le texte textuel par des titres de sujet canoniques sous forme de fichier zip contenant un fichier par page.
+      experiment: Expérience
+      export: Exporter
+      facing_pdf: Face PDF
+      facing_pdf_export_description: Téléchargez une version PDF de cet ouvrage comprenant des images et du texte sur les pages en vis-à-vis.
+      html: HTML
+      html_export_description: Exportez les transcriptions sous forme de fichier zip contenant un fichier HTML par page.
+      ms_word: MS Word
+      pdf: PDF
+      pdf_download_description: Télécharger une version PDF de ce travail.
+      searchable_plaintext: Texte en clair consultable
+      searchable_plaintext_export_description: Exportez des transcriptions en texte brut optimisées pour la recherche en texte intégral sous forme de fichier zip contenant un fichier par page.
+      table_field_csv: Tableau/Champ CSV
+      table_field_csv_export_description: Exportez toutes les données tabulaires, de feuilles de calcul ou basées sur des champs dans un seul fichier CSV.
+      verbatim_plaintext: Texte brut textuel
+      verbatim_plaintext_export_description: Exportez des transcriptions textuelles en clair sous forme de fichier zip contenant un fichier par page.
+      voyant: Voyant
+      voyant_analysis_description: Envoyez la transcription de ce travail à un Voyant Tools pour analyse.
+      warning_work_not_complete: 'Attention : ce travail peut ne pas être complet.'
+      word_trees: Arbres de mots
+      word_trees_analysis_description: Envoyez la transcription de ce travail au visualiseur Word Trees de Jason Davies pour analyse.
+      zip_export_only_project_owners: Formats d'exportation de fichiers zip accessibles uniquement aux propriétaires de projets.
+    edit:
+      add: Ajouter
+      additional_metadata: Métadonnées supplémentaires
+      additional_metadata_description: Ces champs de métadonnées sont affichés sur l'écran À propos de ce travail et dans les exportations TEI, mais n'affectent pas la fonctionnalité de FromThePage.
+      allowed_collaborators: Collaborateurs autorisés
+      apply: Appliquer
+      author: Auteur
+      collaborators_can_edit_titles: Autoriser les collaborateurs à modifier les titres des pages
+      collection: Le recueil
+      confirm_delete_work: Voulez-vous vraiment supprimer cette œuvre ? Après la suppression, vous ne pourrez plus le récupérer !
+      current_url: L'URL actuelle de ce travail est %{current_url}. Si vous souhaitez modifier la section de travail de l'URL, veuillez utiliser des lettres minuscules et des tirets entre les mots.
+      delete_work: Supprimer le travail
+      description: La description
+      document_date: Date du document
+      document_date_hint: La date du document est au format EDTF (par exemple, 1843, 2001-02, 1643-06-30)
+      document_history: Historique du document
+      editorial_notes: Notes éditoriales
+      enable_ocr_correction: Activer la correction OCR
+      enable_ocr_correction_description: Un travail peut commencer par un texte OCR qui doit être corrigé. Lorsqu'il est coché, l'onglet Transcrire sera remplacé par un onglet Corriger.
+      genre: Genre
+      identifier: Identifiant
+      identifier_description: Identifiant de systèmes extérieurs à FromThePage, à utiliser pour corréler les exportations avec des enregistrements externes. (Ce champ n'est pas visible publiquement.)
+      in_scope: Portée
+      more_work_settings_info: Pour plus d'informations sur les paramètres de travail, consultez l'article wiki <a href="https://github.com/benwbrum/fromthepage/wiki/Preparing-a-Work-for-Transcription" target="_blank">Préparer un travail pour Transcription</a>.
+      no_allowed_collaborators_selected: Aucun collaborateur autorisé sélectionné
+      no_image: Pas d'image
+      pages_are_meaningful: Les pages sont significatives
+      pages_are_meaningful_description: Les pages peuvent être des divisions sémantiques significatives d'un travail (comme dans un journal avec une date pour chaque page), ou elles peuvent ne pas l'être (comme dans les lettres ou les livres, où le texte ne doit pas être divisé en sections basées sur les pages). Lorsque cette case est cochée, le travail aura des titres de page affichés en évidence.
+      permission_description: Description de l'autorisation
+      physical_description: Description physique
+      place_of_creation: Lieu de création
+      recipient: Destinataire
+      remove: Retirer
+      restrict_collaborators: Restreindre les collaborateurs
+      restricted_work_no_collaborators_warning: Seuls les propriétaires de projet peuvent modifier ce travail. Ajoutez des collaborateurs pour rendre le travail modifiable par d'autres.
+      revert: Revenir
+      revert_transcription_conventions_description: Rétablir les conventions de transcription par défaut de la collection
+      save_changes: Sauvegarder les modifications
+      settings_only_work_owners: Les paramètres de cette œuvre ne sont accessibles qu'aux propriétaires de l'œuvre.
+      source_box_folder: Boîte/dossier source
+      source_collection_name: Nom de la collection source
+      source_location: Emplacement de la source
+      support_translation: Soutenir la traduction
+      support_translation_description: Une œuvre peut aussi bien être traduite que transcrite. Lorsque cette case est cochée, le travail aura un onglet Traduction pour chaque page.
+      transcription_conventions: Conventions de transcription
+      translation_instructions: Instructions de traduction
+      upload_image: Télécharger une image
+      uploaded_by: telechargé par
+      url: URL
+      work_image: Image de travail
+      work_image_description: Une image à utiliser pour illustrer le travail. Si aucune image n'est téléchargée, une image de page sera utilisée.
+      work_thumbnail: Vignette de travail
+      work_title: Titre de travail
+    incomplete: Métadonnées incomplètes.
+    metadata_overview:
+      notes_and_questions: Remarques et questions
+      show_image: Afficher l'image
+      this_page_is_blank: Cette page est vierge
+    needsreview: Les métadonnées doivent être révisées.
+    new:
+      collection: Le recueil
+      create_empty_work: Créer un travail vide
+      create_empty_work_description: Cela crée une œuvre vide. Une fois que vous avez créé le travail, vous pouvez ajouter des images de page individuelles. Si vous avez un fichier zip ou pdf avec plusieurs images, vous devez créer le travail et télécharger le fichier sous %{start_project} à la place.
+      create_work: Créer un travail
+      description: La description
+      start_a_project: Démarrer un projet
+      title: Titre
+      work_description: Une œuvre est un document unique comme une lettre, un journal intime, un carnet de terrain, une carte postale ou un cahier.
+    pages_tab:
+      actions: Actions
+      add_new_page: Ajouter une nouvelle page
+      confirm_delete_page: Voulez-vous vraiment supprimer cette page ? Après la suppression, vous ne pourrez pas le récupérer !
+      delete: Effacer
+      featured_page: Page en vedette
+      image_status: État de l'image
+      make_featured_page: Créer une page en vedette
+      move_down: Descendre
+      move_up: Déplacer vers le haut
+      no_pages_found: Aucune page trouvée
+      no_pages_found_description: Ce travail ne contient pas encore de pages
+      page_title: Titre de la page
+      pages_tab_description: Ici vous voyez la liste de toutes les pages du travail. Si vous souhaitez modifier la position d'une page, utilisez les flèches haut et bas à droite. Pour créer une nouvelle page pour ce travail, cliquez sur le bouton Ajouter une nouvelle page. Une fois une nouvelle page vierge créée, recherchez-la dans la liste ci-dessous et passez aux paramètres où vous pouvez télécharger l'image de la page.
+      position: Position
+      ready_to_transcribe: Prêt à %{transcribe}
+      settings: Réglages
+      transcribe: transcrire
+      upload: Télécharger
+      upload_page_image: Image de la page %{upload}
+    save_description:
+      work_described: Votre description a été enregistrée
+    show:
+      author_name: Nom de l'auteur
+      description: La description
+      document_date: Date du document
+      document_history: Historique du document
+      editorial_notes: Notes éditoriales
+      genre: Genre
+      iiif_manifest: Manifeste IIIF
+      location_of_composition: Lieu de composition
+      metadata: Métadonnées
+      number_of_pages: Nombre de pages :&nbsp ;
+      out_of_scope: Hors champ
+      permission_description: Description de l'autorisation
+      physical_description: Description physique
+      recipient_name: Nom du destinataire
+      scope: Portée
+      source_box_folder: Boîte/dossier source
+      source_collection_name: Nom de la collection source
+      source_location: Emplacement de la source
+      uploaded_by: telechargé par
+    undescribed: Aucune métadonnée.
+    update:
+      work_updated: Travail mis à jour avec succès


### PR DESCRIPTION
_Resolves #3165_

This adds French locales for all locale files except `admin` and `admin_mailer`. All/most of the UI should now be translated, except for static pages.

This was done via an edited version of `i18n-tasks translate-missing` and the Google Translate API.