### PR TITLE
Changed deed type hash to be translatable

### DIFF
--- a/app/models/deed_type.rb
+++ b/app/models/deed_type.rb
@@ -31,26 +31,26 @@ class DeedType
   # groups of deed types and also their human-readable names. Any new deed type
   # constant should also be added here.
   TYPES = {
-    PAGE_TRANSCRIPTION => 'Page Transcribed',
-    PAGE_EDIT => 'Page Edited',
-    PAGE_INDEXED => 'Page Indexed',
-    PAGE_MARKED_BLANK => 'Page Marked Blank',
-    ARTICLE_EDIT => 'Article Edited',
-    NOTE_ADDED => 'Note Added',
-    PAGE_TRANSLATED => 'Page Translated',
-    PAGE_TRANSLATION_EDIT => 'Translation Page Edited',
-    OCR_CORRECTED => 'Page OCR Corrected',
-    NEEDS_REVIEW => 'Page Needs Review',
-    TRANSLATION_REVIEW => 'Translation Page Needs Review',
-    TRANSLATION_INDEXED => 'Translation Page Indexed',
-    WORK_ADDED => 'Work Added',
-    COLLECTION_ACTIVE => 'Collection Active',
-    COLLECTION_INACTIVE => 'Collection Inactive',
-    COLLECTION_JOINED => 'Collection Joined',
-    PAGE_REVIEWED => 'Page Reviewed',
-    TRANSLATION_REVIEWED => 'Translation Reviewed',
-    DESCRIBED_METADATA => 'Described Metadata',
-    EDITED_METADATA => 'Edited Metadata Description'
+    PAGE_TRANSCRIPTION => I18n.t('deed.page_transcription'),
+    PAGE_EDIT => I18n.t('deed.page_edit'),
+    PAGE_INDEXED => I18n.t('deed.page_indexed'),
+    PAGE_MARKED_BLANK => I18n.t('deed.page_marked_blank'),
+    ARTICLE_EDIT => I18n.t('deed.article_edit'),
+    NOTE_ADDED => I18n.t('deed.note_added'),
+    PAGE_TRANSLATED => I18n.t('deed.page_translated'),
+    PAGE_TRANSLATION_EDIT => I18n.t('deed.page_translation_edit'),
+    OCR_CORRECTED => I18n.t('deed.ocr_corrected'),
+    NEEDS_REVIEW => I18n.t('deed.needs_review'),
+    TRANSLATION_REVIEW => I18n.t('deed.translation_review'),
+    TRANSLATION_INDEXED => I18n.t('deed.translation_indexed'),
+    WORK_ADDED => I18n.t('deed.work_added'),
+    COLLECTION_ACTIVE => I18n.t('deed.collection_active'),
+    COLLECTION_INACTIVE => I18n.t('deed.collection_inactive'),
+    COLLECTION_JOINED => I18n.t('deed.collection_joined'),
+    PAGE_REVIEWED => I18n.t('deed.page_reviewed'),
+    TRANSLATION_REVIEWED => I18n.t('deed.translation_reviewed'),
+    DESCRIBED_METADATA => I18n.t('deed.described_metadata'),
+    EDITED_METADATA => I18n.t('deed.edited_metadata') 
   }
 
   # This `class << self` inherited group replaces the need to call `self.` on

--- a/app/models/deed_type.rb
+++ b/app/models/deed_type.rb
@@ -31,26 +31,26 @@ class DeedType
   # groups of deed types and also their human-readable names. Any new deed type
   # constant should also be added here.
   TYPES = {
-    PAGE_TRANSCRIPTION => I18n.t('deed.page_transcription'),
-    PAGE_EDIT => I18n.t('deed.page_edit'),
-    PAGE_INDEXED => I18n.t('deed.page_indexed'),
-    PAGE_MARKED_BLANK => I18n.t('deed.page_marked_blank'),
-    ARTICLE_EDIT => I18n.t('deed.article_edit'),
-    NOTE_ADDED => I18n.t('deed.note_added'),
-    PAGE_TRANSLATED => I18n.t('deed.page_translated'),
-    PAGE_TRANSLATION_EDIT => I18n.t('deed.page_translation_edit'),
-    OCR_CORRECTED => I18n.t('deed.ocr_corrected'),
-    NEEDS_REVIEW => I18n.t('deed.needs_review'),
-    TRANSLATION_REVIEW => I18n.t('deed.translation_review'),
-    TRANSLATION_INDEXED => I18n.t('deed.translation_indexed'),
-    WORK_ADDED => I18n.t('deed.work_added'),
-    COLLECTION_ACTIVE => I18n.t('deed.collection_active'),
-    COLLECTION_INACTIVE => I18n.t('deed.collection_inactive'),
-    COLLECTION_JOINED => I18n.t('deed.collection_joined'),
-    PAGE_REVIEWED => I18n.t('deed.page_reviewed'),
-    TRANSLATION_REVIEWED => I18n.t('deed.translation_reviewed'),
-    DESCRIBED_METADATA => I18n.t('deed.described_metadata'),
-    EDITED_METADATA => I18n.t('deed.edited_metadata') 
+    PAGE_TRANSCRIPTION => 'deed.page_transcription',
+    PAGE_EDIT => 'deed.page_edit',
+    PAGE_INDEXED => 'deed.page_indexed',
+    PAGE_MARKED_BLANK => 'deed.page_marked_blank',
+    ARTICLE_EDIT => 'deed.article_edit',
+    NOTE_ADDED => 'deed.note_added',
+    PAGE_TRANSLATED => 'deed.page_translated',
+    PAGE_TRANSLATION_EDIT => 'deed.page_translation_edit',
+    OCR_CORRECTED => 'deed.ocr_corrected',
+    NEEDS_REVIEW => 'deed.needs_review',
+    TRANSLATION_REVIEW => 'deed.translation_review',
+    TRANSLATION_INDEXED => 'deed.translation_indexed',
+    WORK_ADDED => 'deed.work_added',
+    COLLECTION_ACTIVE => 'deed.collection_active',
+    COLLECTION_INACTIVE => 'deed.collection_inactive',
+    COLLECTION_JOINED => 'deed.collection_joined',
+    PAGE_REVIEWED => 'deed.page_reviewed',
+    TRANSLATION_REVIEWED => 'deed.translation_reviewed',
+    DESCRIBED_METADATA => 'deed.described_metadata',
+    EDITED_METADATA => 'deed.edited_metadata' 
   }
 
   # This `class << self` inherited group replaces the need to call `self.` on

--- a/app/views/admin/expunge_confirmation.html.slim
+++ b/app/views/admin/expunge_confirmation.html.slim
@@ -17,7 +17,7 @@
         td.w100.toleft
           =render(:partial => 'deed/deed.html', :locals => { :deed => d, :long_view => true })
         td
-          small.label(class="deed-type-#{d.deed_type}") =d.deed_type_name
+          small.label(class="deed-type-#{d.deed_type}") =t(d.deed_type_name)
         td.nowrap
           =time_tag(d.created_at, class: 'small fglight')
             =time_ago_in_words d.created_at

--- a/app/views/admin/visit_deeds.html.slim
+++ b/app/views/admin/visit_deeds.html.slim
@@ -11,7 +11,7 @@ table.datagrid.striped
       td.w100.toleft
         =render(:partial => 'deed/deed.html', :locals => { :deed => d, :long_view => true })
       td
-        small.label(class="deed-type-#{d.deed_type}") =d.deed_type_name
+        small.label(class="deed-type-#{d.deed_type}") =t(d.deed_type_name)
       td.nowrap
         =time_tag(d.created_at, class: 'small fglight')
           =time_ago_in_words d.created_at

--- a/app/views/deed/list.html.slim
+++ b/app/views/deed/list.html.slim
@@ -27,7 +27,7 @@ table.datagrid.striped
           =render(:partial => 'deed/deed.html', :locals => { :deed => d, :long_view => true, :suppress_collection => true })
           
       td
-        small.label(class="deed-type-#{d.deed_type}") =d.deed_type_name
+        small.label(class="deed-type-#{d.deed_type}") =t(d.deed_type_name)
       td.nowrap
         =time_tag(d.created_at, class: 'small fglight')
           =t('.time_ago_in_words', time: time_ago_in_words(d.created_at))

--- a/app/views/user/profile.html.slim
+++ b/app/views/user/profile.html.slim
@@ -39,7 +39,7 @@
             =raw(strip_tags(render(:partial => 'deed/deed.html', :locals => { :deed => d, :long_view => true })))
             
         td
-          small.label(class="deed-type-#{d.deed_type}") =d.deed_type_name
+          small.label(class="deed-type-#{d.deed_type}") =t(d.deed_type_name)
         td.nowrap
           =time_tag(d.created_at, class: 'small fglight')
             =t('time_ago_in_words', time: time_ago_in_words(d.created_at))

--- a/config/locales/deed/deed-en.yml
+++ b/config/locales/deed/deed-en.yml
@@ -1,6 +1,10 @@
 ---
 en:
   deed:
+    article_edit: Article Edited
+    collection_active: Collection Active
+    collection_inactive: Collection Inactive
+    collection_joined: Collection Joined
     deed:
       html:
         added_a_note_to_page: added a note to page %{page}
@@ -28,6 +32,8 @@ en:
     deeds:
       show_more: Show More
       time_ago_in_words: "%{time} ago"
+    described_metadata: Described Metadata
+    edited_metadata: Edited Metadata Description
     list:
       activity_stream: Activity Stream
       collection_title: 'Collection: %{title}'
@@ -35,3 +41,17 @@ en:
       older_activity: Older Activity
       time_ago_in_words: "%{time} ago"
       user_title: 'User: %{title}'
+    needs_review: Page Needs Review
+    note_added: Note Added
+    ocr_corrected: Page OCR Corrected
+    page_edit: Page Edited
+    page_indexed: Page Indexed
+    page_marked_blank: Page Marked Blank
+    page_reviewed: Page Reviewed
+    page_transcription: Page Transcribed
+    page_translated: Page Translated
+    page_translation_edit: Translation Page Edited
+    translation_indexed: Translation Page Indexed
+    translation_review: Translation Page Needs Review
+    translation_reviewed: Translation Reviewed
+    work_added: Work Added

--- a/config/locales/deed/deed-fr.yml
+++ b/config/locales/deed/deed-fr.yml
@@ -1,6 +1,10 @@
 ---
 fr:
   deed:
+    article_edit: Article modifié
+    collection_active: Collecte active
+    collection_inactive: Collecte inactive
+    collection_joined: Collection rejointe
     deed:
       html:
         added_a_note_to_page: a ajouté une note à la page %{page}
@@ -28,6 +32,8 @@ fr:
     deeds:
       show_more: Voir plus
       time_ago_in_words: Il y a %{time}
+    described_metadata: Métadonnées décrites
+    edited_metadata: Description des métadonnées modifiées
     list:
       activity_stream: Flux d'activité
       collection_title: 'Collection : %{title}'
@@ -35,3 +41,17 @@ fr:
       older_activity: Activité plus ancienne
       time_ago_in_words: Il y a %{time}
       user_title: 'Utilisateur : %{title}'
+    needs_review: La page doit être révisée
+    note_added: Note ajoutée
+    ocr_corrected: OCR de page corrigé
+    page_edit: Page modifiée
+    page_indexed: Page indexée
+    page_marked_blank: Page marquée vierge
+    page_reviewed: Page examinée
+    page_transcription: Page transcrite
+    page_translated: Page traduite
+    page_translation_edit: Page de traduction modifiée
+    translation_indexed: Page de traduction indexée
+    translation_review: La page de traduction doit être révisée
+    translation_reviewed: Traduction révisée
+    work_added: Travail ajouté


### PR DESCRIPTION
_For #3232, deed type buttons not translated_

![deed list](https://user-images.githubusercontent.com/35716893/182483407-8fc151e1-e578-4404-a951-6e45bcfaef83.jpg)

Previously, the deed types shown on the deed list (above) weren't translated to non-English locales because they were explicitly written in to the `DeedType` model:

https://github.com/benwbrum/fromthepage/blob/4fe18a3b14ceace5458e394db8151f3b3ef87b32/app/models/deed_type.rb#L30-L35

In this PR I changed the `TYPES` hash to map to calls to `I18n.t` instead of plaintext.

![french deed list](https://user-images.githubusercontent.com/35716893/182483908-a7663674-d71e-4cf3-99cf-9286fda51c91.jpg)

This works to translate the deed list (above), but I'm not sure if it will break anything else?