### PR TITLE
Updated English wording

### DIFF
--- a/config/locales/deed/deed-en.yml
+++ b/config/locales/deed/deed-en.yml
@@ -16,7 +16,7 @@ en:
         edited_page: edited %{page}
         edited_translation_of_page: edited the translation of %{page}
         in_collection: " in %{collection}"
-        in_the_work: " in the %{work}"
+        in_the_work: " in %{work}"
         indexed_page: indexed %{page}
         indexed_translation_of_page: indexed the translation of %{page}
         joined: 'joined '

--- a/config/locales/deed/deed-en.yml
+++ b/config/locales/deed/deed-en.yml
@@ -7,28 +7,28 @@ en:
     collection_joined: Collection Joined
     deed:
       html:
-        added_a_note_to_page: added a note to page %{page}
+        added_a_note_to_page: added a note to %{page}
         added_work: added %{work}
-        corrected_page: corrected page %{page}
+        corrected_page: corrected %{page}
         described_metadata: described metadata
-        edited_article: edited %{article} article
+        edited_article: edited %{article}
         edited_metadata: edited metadata
-        edited_page: edited page %{page}
-        edited_translation_of_page: edited the translation of page %{page}
-        in_collection: " in %{collection} collection"
-        in_the_work: " in the work %{work}"
-        indexed_page: indexed page %{page}
-        indexed_translation_of_page: indexed the translation of page %{page}
+        edited_page: edited %{page}
+        edited_translation_of_page: edited the translation of %{page}
+        in_collection: " in %{collection}"
+        in_the_work: " in the %{work}"
+        indexed_page: indexed %{page}
+        indexed_translation_of_page: indexed the translation of %{page}
         joined: 'joined '
-        marked_page_as_blank: marked page %{page} as blank
-        marked_page_as_needing_review: marked page %{page} as needing review
-        marked_translation_page_as_needing_review: marked translation page %{page} as needing review
-        reviewed_page: 'reviewed page %{page} '
-        reviewed_translation: reviewed translation of page %{page}
+        marked_page_as_blank: marked %{page} as blank
+        marked_page_as_needing_review: marked %{page} as needing review
+        marked_translation_page_as_needing_review: marked translation %{page} as needing review
+        reviewed_page: 'reviewed %{page} '
+        reviewed_translation: reviewed translation of %{page}
         saying_deed: ", saying &ldquo;%{title}&rdquo;"
         this_collection: this collection
-        transcribed_page: transcribed page %{page}
-        translated_page: translated page %{page}
+        transcribed_page: transcribed %{page}
+        translated_page: translated %{page}
     deeds:
       show_more: Show More
       time_ago_in_words: "%{time} ago"

--- a/config/locales/devise/devise-en.yml
+++ b/config/locales/devise/devise-en.yml
@@ -3,7 +3,7 @@ en:
   devise:
     confirm_password: Confirm Password
     create_account: Create Account
-    display_name: Display Name
+    display_name: Organization Name
     email_address: Email Address
     failure:
       already_authenticated: You are already signed in.

--- a/config/locales/work/work-en.yml
+++ b/config/locales/work/work-en.yml
@@ -103,7 +103,7 @@ en:
       source_box_folder: Source Box/Folder
       source_collection_name: Source Collection Name
       source_location: Source Location
-      support_translation: Support Translation
+      support_translation: Enable Translation
       support_translation_description: A work can be translated as well as transcribed. When checked, the work will have a Translation tab for each page.
       transcription_conventions: Transcription conventions
       translation_instructions: Translation instructions

--- a/spec/features/deed_list_spec.rb
+++ b/spec/features/deed_list_spec.rb
@@ -6,7 +6,7 @@ describe "collection settings js tasks", :order => :defined do
   it "Deed view displays public deeds" do
     visit collections_list_path
     page.click_link("Show More")
-    expect(page).to have_content("eleanor transcribed page 2 in the work MS_641-642 in CS Pierce collection")
+    expect(page).to have_content("eleanor transcribed 2 in MS_641-642 in CS Pierce")
   end
   it "Deed view hides deeds for private collections" do
     visit collections_list_path
@@ -16,7 +16,7 @@ describe "collection settings js tasks", :order => :defined do
     csp.save
 
     page.click_link("Show More")
-    expect(page).to_not have_content("eleanor transcribed page 2 in the work MS_641-642 in CS Pierce collection")
+    expect(page).to_not have_content("eleanor transcribed 2 in MS_641-642 in CS Pierce")
     
     # We need to enable transactional fixtures so we don't have to reset this stuff all the time
     csp.restricted = false
@@ -33,7 +33,7 @@ describe "collection settings js tasks", :order => :defined do
     csp.save
 
     page.click_link("Show More")
-    expect(page).to have_content("eleanor transcribed page 2 in the work MS_641-642 in CS Pierce collection")
+    expect(page).to have_content("eleanor transcribed 2 in MS_641-642 in CS Pierce")
     
     # We need to enable transactional fixtures so we don't have to reset this stuff all the time
     csp.restricted = false

--- a/spec/features/display_marked_as_blank_spec.rb
+++ b/spec/features/display_marked_as_blank_spec.rb
@@ -45,7 +45,7 @@ describe "display marked as blank" do
 
     # Visit page
     visit 'collections'
-    expect(page.find('.sidecol')).to have_content("#{user.display_name} marked page #{page1.title} as blank")
+    expect(page.find('.sidecol')).to have_content("#{user.display_name} marked #{page1.title} as blank")
 
     # Tear down Factories
     Deed.destroy(deed.id)
@@ -72,7 +72,7 @@ describe "display marked as blank" do
     # Visit page
     visit "#{user.login}/#{collection.slug}"
     expect(page).to have_content('Recent Edits')
-    expect(page.find('.sidecol')).to have_content("#{user.display_name} marked page #{page1.title} as blank")
+    expect(page.find('.sidecol')).to have_content("#{user.display_name} marked #{page1.title} as blank")
 
     # Tear down Factories
     Deed.destroy(deed.id)


### PR DESCRIPTION
_Resolves #3242_

-  Changed "Display name" to "Organization name"
-  Changed "Support translation" to "Enable translation"
-  Removed "page", "work", "collection" in deeds (i.e. "Sylvie transcribed page Image 1 in the work Diary of Matilda Brown in Test Collection collection)