### PR TITLE
Added missing Spanish messages

### DIFF
--- a/config/locales/activerecord/activerecord-es.yml
+++ b/config/locales/activerecord/activerecord-es.yml
@@ -11,6 +11,44 @@ es:
       work:
         slug: URL
         title: Título
+    errors:
+      models:
+        collection:
+          attributes:
+            slug:
+              blank: es requerido
+              invalid: debe tener al menos una letra
+        document_set:
+          attributes:
+            slug:
+              blank: es requerido
+              invalid: debe tener al menos una letra
+        work:
+          attributes:
+            slug:
+              blank: es requerido
+              invalid: debe tener al menos una letra
+        xml_source_processor:
+          blank_subject_in: Sujeto en blanco en %{tag}
+          blank_tag_in: Etiqueta en blanco en %{tag}
+          blank_text_in: Texto en blanco en %{tag}
+          subject_linking_error: 'Error de vinculación de asunto:'
+          tags_should_not_use_3_brackets: Las etiquetas deben crearse usando 2 corchetes, no 3
+          unclosed_bracket_within: Corchete no cerrado dentro de %{tag}
+          wrong_number_of_closing_braces: Número incorrecto de llaves de cierre después de %{tag}
+    models:
+      bulk_export:
+        one: exportación a granel
+        other: exportaciones a granel
+      ia_leaf:
+        one: página
+        other: paginas
+      page:
+        one: página
+        other: paginas
+      work:
+        one: trabajar
+        other: obras
   errors:
     messages:
       not_saved:

--- a/config/locales/article/article-es.yml
+++ b/config/locales/article/article-es.yml
@@ -1,12 +1,104 @@
 ---
 es:
   article:
+    article_links:
+      n_pages_refer_to:
+        one: 1 página se refiere a %{article}
+        other: "%{count} páginas se refieren a %{article}"
+      n_subjects_refer_to:
+        one: 1 sujeto se refiere a %{article}
+        other: "%{count} sujetos se refieren a %{article}"
+      show_pages_that_mention: Mostrar páginas que mencionen %{article} en todos los trabajos
     combine_duplicate:
       selected_subjects_combined: Asignaturas seleccionadas combinadas con %{title}
     delete:
       must_remove_referring_links: Debes eliminar todos los enlaces de referencia antes de eliminar este tema.
+    edit:
+      autolink: Enlace automático
+      categories: Categorías
+      combine_selected: Combinar seleccionado
+      confirm_delete_subject: "¿Está seguro de que desea eliminar este asunto? ¡Después de borrar no podrás recuperarlo!"
+      delete_subject: Eliminar asunto
+      description: Descripción
+      latitude: Latitud
+      longitude: Longitud
+      microphone: Micrófono
+      n_pages:
+        one: 1 pagina
+        other: "%{count} páginas"
+      no_duplicates_found: No se encontraron duplicados
+      no_duplicates_found_description: El tema es único dentro de la colección, no se han encontrado posibles duplicados del tema "%{article}".
+      possible_duplicates:
+        one: Posible duplicado
+        other: Posibles duplicados
+      possible_duplicates_description: Revise la lista a continuación y seleccione los temas para combinar. Los duplicados se reasignarán para que todos los enlaces existentes apunten al asunto "%{article}".
+      save_changes: Guardar cambios
+      select_categories: Seleccionar categorías
+      title: Título
+      uri: URI
+    graph:
+      dot:
+        title: Temas mencionados frecuentemente con %{subject}
+    list:
+      actions: Comportamiento
+      add_child_category: Agregar categoría secundaria
+      add_root_category: Agregar categoría raíz
+      categories: Categorías
+      category_back_message: Una vez que termine de editar las categorías, %{page_link} para volver a la página "%{page}".
+      click_here: haga clic aquí
+      confirm_delete_category: "¿Está seguro de que desea eliminar esta categoría y todas sus subcategorías? ¡Después de borrar no podrás recuperarlo!"
+      create_category_message: "%{link} que usarás para agrupar materias."
+      create_the_first_category: Crear la primera categoría
+      delete_category: Eliminar categoría
+      disable_gis_for_category: Deshabilitar GIS para la categoría
+      edit_category: Editar categoria
+      enable_gis_for_category: Habilitar SIG para la categoría
+      no_categories: Sin categorías
+      no_categories_message: No hay categorías de temas en la colección.<br>
+      there_are_no_subjects: No hay asignaturas para la categoría seleccionada
+      uncategorized: Sin categorizar
+      uncategorized_subjects: Temas sin categorizar
+      upload_subjects: Subir materias
+    show:
+      all_uncategorized_subjects: Todos los temas sin categorizar en la colección.
+      categories: Categorías
+      description: Descripción
+      download: Descargar
+      download_description: Descargue una hoja de cálculo de temas coincidentes y obras en las que aparecen.
+      edit_description_description: Edite la descripción en la pestaña de configuración.
+      export: Exportar
+      n_possible_duplicates:
+        one: 1 posible duplicado
+        other: "%{count} posibles duplicados"
+      no_category_message: Este tema no pertenece a ninguna categoría.
+      references: Referencias
+      related_subjects: Temas relacionados
+      related_subjects_1: Temas relacionados
+      related_subjects_description: El gráfico muestra los otros temas mencionados en las mismas páginas que el tema "%{article}". Si el mismo tema aparece en una página con "%{article}" más de una vez, aparece más cerca de "%{article}" en el gráfico y se colorea en un tono más oscuro. Cuanto más cerca está un sujeto del centro, más "relacionados" están los sujetos.
+      search_all_pages: Buscar en todas las páginas
+      search_all_pages_description: Busque en el texto de %{collection} páginas que contengan palabras utilizadas para vincular a <em>%{article}</em>
+      search_unlinked_pages: Buscar páginas no vinculadas
+      search_unlinked_pages_description: Solo busque texto de páginas que no se vinculen a <em>%{article}</em>
+      see_also: 'Ver también:'
+      text_search: Búsqueda de texto
     subject_upload:
       csv_file_must_contain_headers: El archivo CSV debe contener encabezados para HEADING, ARTICLE, URI y CATEGORY. Estos términos quieren decir encabezado, artículo, Identificador Universal de Recursos, y categoría, respectivamente.
+    tooltip:
+      category:
+        one: 'Categoría:'
+        other: 'Categorías:'
+      explore_this_subject: Explora este tema
     update:
+      gis_coordinates_truncated:
+        one: " (Coordenadas GIS truncadas a %{precision} lugar decimal)"
+        other: " (Coordenadas GIS truncadas a %{precision} lugares decimales)"
       subject_successfully_updated: El tema se ha actualizado exitosamente
       subjects_auto_linking: Proceso de auto-vinculación de temas completado
+    upload_form:
+      browse: Navegar
+      click_to_browse: Haga clic para buscar un archivo...
+      csv_file_with: Archivo CSV con una fila por asunto
+      example_csv: CSV de ejemplo
+      upload: Subir
+      upload_subjects: Subir materias
+      upload_subjects_description: Para crear sujetos a partir de un archivo de autoridad externo, cargue un archivo %{link}.

--- a/config/locales/article_version/article_version-es.yml
+++ b/config/locales/article_version/article_version-es.yml
@@ -1,0 +1,14 @@
+---
+es:
+  article_version:
+    show:
+      description: Aquí puede ver todas las revisiones de temas y comparar los cambios que se han realizado en cada revisión. La columna de la izquierda muestra el título y la descripción del tema en la revisión seleccionada, la columna de la derecha muestra lo que se ha cambiado. El texto que no ha cambiado está <span>resaltado en blanco</span>, el texto eliminado está <del>resaltado en rojo</del> y el texto insertado está <ins>resaltado en color verde</ins>.
+      n_revisions:
+        one: 1 revisión
+        other: "%{count} revisiones"
+      no_description_provided: No se proporcionó descripción
+      no_versions_to_compare: No hay versiones para comparar
+      no_versions_to_compare_description: Este tema no ha sido descrito, por eso no tenemos versiones de artículos para comparar.
+      revision_changes: Cambios de revisión
+      untitled: Intitulado
+      user_at_time: "%{user} a %{time}"

--- a/config/locales/bulk_export/bulk_export-es.yml
+++ b/config/locales/bulk_export/bulk_export-es.yml
@@ -1,0 +1,55 @@
+---
+es:
+  bulk_export:
+    create:
+      export_running_message: Exportación en ejecución. El correo electrónico se enviará a %{email} al finalizar.
+    create_for_work:
+      export_running_message: Exportación en ejecución. El correo electrónico se enviará a %{email} al finalizar.
+    download:
+      download_cleaned_message: Esta descarga de exportación se ha limpiado. Por favor, comience uno nuevo.
+    index:
+      actions: Comportamiento
+      collection: 'Recopilación:'
+      date: Fecha
+      file_name: 'Nombre del archivo:'
+      show_details: Mostrar detalles
+      status: Estado
+      upload_details: Subir detalles
+      user: Usuario
+    new:
+      download: Descargar
+      expanded_plaintext: Texto sin formato expandido
+      expanded_plaintext_description: Al igual que el texto sin formato textual, este archivo de texto sin formato representará saltos de línea con una sola línea nueva, saltos de párrafo con una doble línea nueva y saltos de página con una triple línea nueva. Se diferencia del texto textual en que la normalización se aplicará a todos los temas mencionados, de modo que mientras el texto textual puede decir "Saludé al Sr. Jones y su esposa esta mañana", el texto sin formato modificado dirá "Saludé a James Jones". y Elizabeth Smith Jones esta mañana”. Este texto artificial es útil para el análisis programático, pero no está destinado a ser leído por humanos.
+      export_all_works: Exportar todas las obras
+      facing_edition_pdf: Edición enfrentada PDF
+      facing_edition_pdf_description: Un archivo PDF que contiene imágenes y transcripciones en páginas opuestas.
+      html: HTML
+      html_description: Esto puede ser útil para la conservación en otros sistemas o como punto de partida para su visualización en otro sitio web.
+      one_file_per_collection: Un archivo por colección
+      one_file_per_page: Un archivo por página
+      one_file_per_work: Un archivo por obra
+      one_site_per_collection: Un sitio por colección
+      previous_exports: Exportaciones anteriores
+      search_optimized_plaintext: Texto sin formato optimizado para búsqueda
+      search_optimized_plaintext_description: Una versión de texto sin formato de la obra optimizada para la búsqueda de texto completo. Esta versión contiene una transcripción literal de texto sin formato de cada página (como se describe anteriormente), excepto que las palabras separadas por saltos de línea con guión se unen, y se adjunta una lista de los nombres canónicos mencionados dentro de cada página al final de la página.
+      start_export: Iniciar exportación
+      static_site: Sitio estático
+      static_site_description: Un sitio web estático de Jekyll que contiene la edición completa
+      status: Estado
+      subject_details_csv: Detalles del asunto CSV
+      subject_details_csv_description: Una hoja de cálculo que enumera cada tema de la colección.
+      subject_index_csv: Índice de materias CSV
+      subject_index_csv_description: Una hoja de cálculo que enumera cada lugar donde se menciona un tema dentro de una página dentro de la colección.
+      table_field_csv: CSV de tabla/campo
+      table_field_csv_description: Exporta una hoja de cálculo con datos tabulares o basados en campos.
+      tei_xml: TEI XML
+      tei_xml_description: Esto puede ser útil para los editores que planean hacer más marcado dentro de los editores TEI-XML como oXygen.
+      text_docx: Texto DOCX
+      text_docx_description: Un archivo de MS-Word (.docx) que contiene transcripciones de texto.
+      text_pdf: PDF de texto
+      text_pdf_description: Un archivo PDF que contiene transcripciones de texto.
+      time: Tiempo
+      verbatim_plaintext: Texto sin formato textual
+      verbatim_plaintext_description: Este archivo de texto sin formato representará saltos de línea con una sola línea nueva, saltos de párrafo con una doble línea nueva y saltos de página con una triple línea nueva. Contendrá el texto textual, con todo el formato, enmienda y enlace de tema eliminado.
+      work_metadata_csv: CSV de metadatos de trabajo
+      work_metadata_csv_description: Una hoja de cálculo que enumera cada trabajo con recuentos de páginas y metadatos.

--- a/config/locales/category/category-es.yml
+++ b/config/locales/category/category-es.yml
@@ -1,12 +1,21 @@
 ---
 es:
   category:
+    add_new:
+      create_category: Crear categoría
+      enable_gis: Habilitar SIG
+      title: Título
     create:
       category_created: La categoría ha sido creada
     delete:
       category_deleted: La categoría ha sido eliminada
     disable_gis:
       gis_disabled_for: GIS deshabilitado para %{title}
+    edit:
+      edit_category: Editar categoria
+      enable_gis: Habilitar SIG
+      save_changes: Guardar cambio
+      title: Título
     enable_gis:
       gis_enabled_for: GIS habilitado para %{title}
     update:

--- a/config/locales/collection/collection-es.yml
+++ b/config/locales/collection/collection-es.yml
@@ -1,7 +1,12 @@
 ---
 es:
   collection:
+    approve_all:
+      approved_n_pages: "%{page_count} páginas aprobadas."
     collection_works:
+      n_pages:
+        one: '1 pagina:'
+        other: "%{count} páginas:"
       progress: Progreso
       work_title: Título de la obra
     contributor_activity:
@@ -30,6 +35,7 @@ es:
       detailed_spreadsheet_export: Una hoja de cálculo exportable y detallada de todos los colaboradores está disponible en el panel del dueño.
       export_activity_as_csv: Exportar Actividad Como CSV
       export_as_csv: Exportar como CSV
+      find_project_newsletters_recommendations: Encuentre recomendaciones para boletines de proyectos.
       new_collaborators: Nuevos Colaboradores
       no_activity_this_time_frame: No hubo actividad en este lapso de tiempo
       no_collaborators: No hay colaboradores
@@ -44,8 +50,10 @@ es:
       add_a_new_work: Añadir una obra nueva
       add_another_work_under: Puedes añadir otro trabajo en %{start_project}
       add_button: Añadir
+      alert: Configure los campos o elija la transcripción basada en documentos en Tipo de transcripción.
       api_access: Acceso API
       api_access_description: Permitir acceso a transcripciones a través del API IIIF
+      authorized_reviewers: revisores autorizados
       blank_collection: Colección en Blanco
       blank_collection_description: Al presionar este botón se restablecerá la colección a un estado en blanco. Se eliminarán todas las transcripciones y otras obras en la colección, como si la misma apenas hubiera sido importada.
       close_api: Cerrar API
@@ -60,19 +68,33 @@ es:
       collection_privacy: Privacidad de la Colección
       collection_public_message: La colección puede ser vista por cualquier persona en Internet. Puedes hacer que la colección sea privada para restringir su visibilidad a los dueños.
       collection_restricted_message: La colección solo puede ser vista por los dueños enumerados a continuación. Es posible cambiar esto para que la colección sea legible públicamente.
+      collection_reviewers: Revisores autorizados
+      collection_reviewers_description: Estos usuarios podrán revisar y aprobar las transcripciones, así como editarlas.
       collection_status: Estado de la Colección
+      confirm_blank_collection: "¿Está seguro?"
       confirm_delete_collection: "¿Estás seguro de que deseas eliminar esta colección? ¡Después de eliminarla no podrá ser recuperada!"
       current_url: La dirección URL actual de esta colección es %{current_url}. Si deseas editar la sección de la obra en el URL, por favor utiliza letras minúsculas y guiones entre cualquiera de las palabras.
       default_orientation: Selecciona la orientación predeterminada para la página de transcripción
       delete_collection: Eliminar Colección
       description: Descripción
       disable_document_sets: Deshabilitar Conjuntos de Documentos
+      disable_facets: Deshabilitar facetas
       disable_ocr: Deshabilitar OCR
       document_sets: Conjuntos de Documentos
       document_sets_description: Los conjuntos de documentos son subconjuntos de las obras en esta colección que se pueden utilizar para darle foco a un proyecto de edición o para crear una exposición pública sobre un enfoque particular de los documentos.
+      done: Hecho
+      edit_authorized_reviewers: Editar revisores autorizados
+      edit_buttons: Configurar botones
+      edit_collaborators: Editar colaboradores
       edit_fields: Campos
+      edit_metadata_fields: Editar campos
+      edit_owners: Editar propietarios
+      editor_buttons: Botones del editor
+      editor_buttons_description: Elija los botones de marcado para que aparezcan en el editor de transcripción.
       enable_document_sets: Habilitar Conjuntos de Documentos
+      enable_facets: Habilitar facetas
       enable_field_based_transcription: Habilitar transcripción basada en campos
+      enable_metadata_description: Habilitar descripción de metadatos
       enable_ocr: Habilitar OCR
       field_based_transcription: Transcripción basada en campos
       footer: Pie de página
@@ -84,6 +106,14 @@ es:
       make_collection_inactive: Hacer Inactiva la Colección
       make_collection_private: Hacer Privada la Colección
       make_collection_public: Hacer Pública la Colección
+      metadata: metadatos
+      metadata_description: Cargue los metadatos de los elementos de esta colección de forma masiva.
+      metadata_entry: Metadatos Descripción
+      metadata_facets: Facetas de metadatos
+      metadata_facets_description: Permita a los usuarios buscar obras dentro de esta colección a través de metadatos.
+      n_contributions:
+        one: 1 contribución
+        other: "%{count} contribuciones"
       no_document_sets_in_collection: Esta colección no tiene ningún conjunto de documentos.
       no_image: No Hay Imagen
       ocr_correction: Corrección OCR
@@ -97,9 +127,19 @@ es:
       picture_to_be_used_message: La imagen se utilizará para ilustrar la descripción de la colección.
       remove_collaborator: Eliminar colaborador
       remove_owner: Eliminar dueño
+      remove_reviewer: Eliminar revisor
+      restrict_completed_works: Restringir trabajos terminados
+      restricted_completed_works: Trabajos Terminados Restringidos
+      restricted_completed_works_description: Este botón restringirá los trabajos %{work_count} que se completaron pero que actualmente no están restringidos a los propietarios del proyecto o colaboradores designados. Puede cambiar esta configuración y agregar colaboradores en la página de configuración de cada trabajo.
       revert_document_based_transcription: Revertir a Transcripción Basada en el Documento
+      revert_metadata_description: Deshabilitar Descripción
+      review_type: Tipo de revisión
+      review_type_optional: " Opcional: Los colaboradores pueden solicitar la revisión de sus transcripciones."
+      review_type_required: " Obligatorio: todas las transcripciones iniciales se marcarán como que necesitan revisión. (La revisión puede ser realizada por cualquier persona)."
+      review_type_restricted: " Restringido: todas las transcripciones necesitan revisión y solo los revisores autorizados pueden aprobar las transcripciones."
       save_changes: Guardar Cambios
       start_a_project: Iniciar Un Proyecto
+      subjects_enabled: Habilitar indexación de materias
       suggestions_help_tab: Sugerencias para la pestaña de ayuda.
       suggestions_transcription_conventions: Sugerencias para las convenciones de transcripción.
       text_language: Selecciona el idioma para texto de transcripción
@@ -108,20 +148,44 @@ es:
       transcription_type: Tipo de Transcripción
       transcription_type_description: Cada página puede tener un área para entrada de texto de formato libre (este es el valor predeterminado) o varios campos de entrada cortos diseñados para formularios. Todas las páginas de la colección tienen el mismo tipo de entradas de transcripción. El dictado de voz no es compatible y se deshabilitará.
       upload_image: Subir Imagen
+      upload_metadata: Subir metadatos
+      url: URL
+      user_download: Permitir a los usuarios descargar obras.
       voice_recognition: Voz a texto disponible para transcribir
+    edit_buttons:
+      description: FromThePage puede admitir el marcado dentro de las transcripciones en formularios TEI-XML o HTML. Recomendamos configurar no más de seis botones para que aparezcan en el editor de transcripción. Considere si otros sistemas podrán usar este tipo de margen; si solo se admite texto sin formato, los proyectos deben usar convenciones tipográficas en lugar de marcado.
+      heading: Configuración del editor de transcripciones
+      html: "(HTML)"
+      markup_preference_description: Algunas etiquetas tienen formas equivalentes en HTML y TEI-XML. Elija una preferencia para determinar qué forma de etiqueta se inserta cuando un usuario presiona el botón.
+      markup_preference_label: Estilo de marcado
+      prefer_html: Preferir HTML
+      prefer_tei: Prefiero TEI
+      save: Ahorrar
+      tei: " (TEI-XML)"
     enable_ocr:
       notice: La corrección OCR ha sido habilitada para todas las obras.
     facet_form:
+      current_filters: Filtros actuales
       filter: Filtro
+      reset_all_filters: Restablecer todos los filtros
+      search: Búsqueda
     facets:
+      collection_facets_updated_successfully: Las facetas de la colección se actualizaron correctamente
       field_label: Etiqueta del campo
       label: Etiqueta
       metadata_facets: Faceta de metadatos
       metadata_facets_description: Configura la faceta de metadatos revisando los metadatos en tu colección y etiquetando los campos que serán mostrados a los transcriptores.
       occurrences: Eventos
       order: Orden
+      translate: Traducir
       type: Tipo
     indexed: indexado
+    localize:
+      label: Faceta
+      metadata_facets_localize_description: Proporcione etiquetas específicas del idioma para cada faceta.
+      save: Ahorrar
+      translate_facets: Traducir etiquetas de facetas
+      translation: Traducción
     needs_review: requiere revisión
     needs_review_pages:
       pages_that_need_review: Páginas que Necesitan Revisión
@@ -137,20 +201,60 @@ es:
       enter_collection_title: Para crear una colección nueva, comienza por ingresar el título de la colección. En el siguiente paso, podrás añadir obras a la colección.
       individual_researcher_limited_account: Las Cuentas de Investigador Individual están limitadas a una sola colección. Para actualizar su cuenta, póngase en contacto con support@fromthepage.com.
       title: Título
+    one_off_list:
+      date: Fecha
+      filter_contributions: Filtrar
+      no_contributions_need_review: Ninguna contribución necesita revisión
+      one_off_description: Estas contribuciones fueron realizadas por usuarios que solo editaron una sola página. Es posible que necesiten atención especial.
+      one_off_title: Aportaciones puntuales
+      review: Revisar
+      title: Página (Trabajo)
+      user: Usuario
+    quality_sampling: Muestreo de calidad
+    recent_contributor_list:
+      date: Fecha de la primera contribución
+      filter_users: Filtrar
+      no_contributions_need_review: Ninguna contribución necesita revisión
+      number_of_contributions: Contribuciones Totales
+      recent_contributor_description: Estos colaboradores han comenzado a trabajar en el proyecto recientemente, pero su trabajo nunca ha sido revisado.
+      recent_contributor_title: Colaboradores recientes
+      review: Revisar
+      user: Usuario
+    reviewer_dashboard:
+      one_off_contributions: Aportaciones puntuales
+      pages_needing_review: Páginas para revisar
+      quality_sampling: Muestreo de calidad
+      quality_sampling_desc: Los muestreos de calidad le permiten verificar las contribuciones al azar y luego evaluar las páginas para revisar en función de la cantidad de texto corregido para un usuario u obra en particular.
+      total_page: Página total
+      transcribed_page: Página transcrita
+      unreviewed_contributors: Nuevos colaboradores
+      works_to_review: Obras para revisar
     show:
       about: Acerca de
       add_a_new_work: Añadir una obra nueva
       all_complete: Todas las obras están completamente transcritas.
+      help_create_metadata: "¡Ayudar!"
+      help_transcribe_or_correct: "¡Ayudar!"
+      n_pages:
+        one: '1 pagina:'
+        other: "%{count} páginas:"
+      pages_need_correction: Páginas que necesitan corrección
+      pages_need_correction_or_transcription: Páginas que necesitan corrección o transcripción
       pages_need_review: Páginas que Necesitan Revisión
+      pages_need_transcription: Páginas que necesitan transcripción
       project_by: Proyecto de
       recent_edits: Ediciones Recientes
       recent_notes: Notas Recientes
       search: Búsqueda
       search_by_title: Buscar por título...
+      search_by_title_1: Buscar por título
       search_the_text: Buscar el texto...
+      search_the_text_1: buscar el texto
       show_more: Mostrar Más
       start_transcribing: Comenzar a Transcribir
       subject_categories: Categorías de Temas
+      this_work_has_not_been_described: Este trabajo necesita mejores metadatos.
+      this_work_has_pages_that_need_work: Algunas páginas todavía necesitan trabajo.
       time_ago_in_words: Hace %{time}
       works: Obras
     start_transcribing:
@@ -159,9 +263,45 @@ es:
     translated: traducido
     update:
       notice: La colección ha sido actualizada
+    update_buttons:
+      editor_buttons_updated: Botones del editor actualizados
+    upload:
+      acceptable_image_files: Se aceptan archivos PNG, GIF y JPG.
+      image_naming_guidelines: 'Las imágenes se deben nombrar de modo que una ordenación alfabética resulte en el orden de página correcto.<br> (Esto puede requerir "relleno con ceros" para cualquier número de página: <code>page_09.jpg, page_10.jpg</code> ordenará correctamente, pero <code>page_9.jpg, page_10.jpg</code> no).'
+      image_orientation_guidelines: Las imágenes deben estar orientadas de manera que queden boca arriba.
+      page_image_guidelines: Directrices de imagen de página
+    user_contribution_list:
+      approve_all: Aprobar todo
+      date: Fecha
+      email: 'Correo electrónico: %{email}'
+      filter_contributions: Filtrar
+      no_contributions: Sin contribuciones
+      notes: notas
+      quality_score: 'Puntuación de calidad:'
+      real_name: 'Nombre real: %{user}'
+      review: Revisar
+      title: Página (Trabajo)
+      user_contribution_description: Páginas que necesitan revisión por parte del usuario %{user_name}
+      user_profile: Perfil del usuario
     works_list:
       alphabetical: Orden Alfabético
       percent_complete: Porcentaje completado
       recent_activity: Actividad Reciente
       sort_works_by: Ordenar Obras Por...
       works: Obras
+    works_to_review:
+      and_n_more: y %{n} más
+      contributors: Colaboradores
+      description: Funciona con páginas que necesitan revisión
+      filter_works: Filtrar
+      incomplete: Incompleto
+      last_activity: Última actividad
+      no_works_need_review: Ningún trabajo necesita revisión
+      notes: notas
+      review: Revisar
+      title: Título
+      total: Total
+  collection_helper:
+    link:
+      incomplete_works: Obras incompletas
+      show_all: Mostrar todo

--- a/config/locales/contact/contact-es.yml
+++ b/config/locales/contact/contact-es.yml
@@ -1,0 +1,24 @@
+---
+es:
+  contact:
+    form:
+      contact_reason: Motivo de contacto
+      contact_us: Contáctenos
+      contact_us_description: "¿Quieres más información sobre FromThePage? Háganos saber cómo podemos ayudar."
+      email_address: Dirección de correo electrónico
+      event: Evento
+      first_name: Nombre de pila
+      free_trial: Prueba gratis
+      large_institution_quote: Cotización de gran institución
+      last_name: Apellido
+      other: Otro
+      press: Prensa
+      product_question: Pregunta sobre el producto
+      submit: Enviar
+      tell_us_more: Cuéntanos más sobre tu proyecto
+    send_email:
+      get_started_right_away: Comience de inmediato con una prueba gratuita de FromThePage.
+      start_free_trial: Empiza la prueba gratuita
+      thank_you: Gracias
+      thank_you!: "¡Gracias!"
+      will_follow_up: Un miembro del equipo se pondrá en contacto contigo.

--- a/config/locales/dashboard/dashboard-es.yml
+++ b/config/locales/dashboard/dashboard-es.yml
@@ -10,11 +10,59 @@ es:
       recent_activity: Actividad reciente
     create_work:
       work_created: La obra ha sido creada exitosamente
+    editor:
+      activity_stream: Últimas acciones
+      article_in_the_work: Artículo %{article} en la colección %{collection}
+      page_in_the_work: Página %{page} en el trabajo %{work}
+      revision_version: Revisión %{version}
+      view_page: Ver pagina
+      your_recent_article_edits: Sus ediciones recientes de artículos
+      your_recent_notes: Tus notas recientes
+      your_recent_page_edits: Tus ediciones recientes de la página
+    editor_header:
+      your_projects: Tus Proyectos
+    empty:
+      add_new_collection: Agregar nueva colección
+      create_empty_work: Crear trabajo vacío
+      create_empty_work_description: Utilice esta opción para crear una obra vacía. A continuación, puede cargar imágenes de páginas individuales en el trabajo.
+      create_work: Crear trabajo
+      description: Descripción
+      select_a_collection: "- Seleccione una colección -"
+      title: Título
+    exports:
+      bulk_exports_description: Aquí se enumeran todas las exportaciones masivas que ha realizado. Las exportaciones se limpian después de unos días y ya no están disponibles para descargar
+      configuration: Configuración (nivel)
+      create_bulk_export_description: Cree una exportación masiva desde la pestaña Exportar de una colección o la pestaña Descargar de una obra.
+      date: Fecha de exportación
+      download: Descargar
+      exported_item: Colección/Obra exportada
+      facing_edition_work: Edición enfrentada PDF (obra)
+      html_page: HTML (página)
+      html_work: HTML (trabajo)
+      plaintext_emended_page: Texto sin formato analítico (página)
+      plaintext_emended_work: Texto sin formato analítico (trabajo)
+      plaintext_searchable_page: Texto sin formato que se puede buscar (página)
+      plaintext_searchable_work: Texto sin formato que se puede buscar (trabajo)
+      plaintext_verbatim_page: Texto sin formato textual (página)
+      plaintext_verbatim_work: Texto sin formato textual (trabajo)
+      refresh: Actualizar
+      reload_this_page_to: Vuelva a cargar esta página para actualizar la lista.
+      status: Estado
+      subject_csv_collection: Índice de materias CSV (colección)
+      table_csv_collection: CSV de campo/tabla (colección)
+      table_csv_work: CSV de campo/tabla (trabajo)
+      tei_work: TEX-XML (trabajo)
+      text_docx_work: MS Word .docx (trabajo)
+      text_pdf_work: Texto PDF (trabajo)
+      work_metadata_csv: Metadatos de trabajo (colección)
+    guest_header:
+      recent_activity: Actividad reciente
     hierarchical_collections_and_document_sets:
       project_by: Proyecto por %{author}
       start_transcribing: Comenzar a Transcribir
     landing_page:
       all_collections: Todas las Colecciones
+      more: Más...
       next_image: Siguiente imagen
       previous_image: Imagen anterior
       recent_activity: Actividad Reciente
@@ -29,10 +77,13 @@ es:
       acceptable_formats: Los archivos PNG, GIF y JPG son aceptables.
       images_should_be_named: 'Las imágenes deben nombrarse de modo que un ordenamiento alfabético dará como resultado el orden de página correcto.<br> (Esto puede requerir "cero-relleno" para cualquier número de página: <code>pagina_09.jpg, pagina_10jpg</code> se ordenará correctamente, pero <code>page_9.jpg, pagina_10.jpg</code> no.)'
       images_should_be_oriented: Las imágenes deben estar orientadas para que el lado correcto quede hacia arriba.
+      import: Importar
       import_a_iiif_manifest_or_collection: Importar Manifiesto IIIF o Colección
       import_from_archive_dot_org: Importar desde Archive.org
       import_from_contentdm: Importar desde CONTENTdm
       import_from_the_internet_archive: Importar desde Internet Archive
+      import_many_link: importar varios objetos compuestos individuales.
+      or_import_many: O
       page_image_guidelines: Guías para Imagen de Página
       paste_in_the_url: Pega el URL del objeto compuesto de tu sitio CONTENTdm.
     owner:
@@ -48,19 +99,40 @@ es:
       you_dont_have_any_collections: No hay colecciones todavía
       your_activity: Tu Actividad
     owner_header:
+      account_type: "%{type} cuenta"
+      actions: Comportamiento
+      collection:
+        one: Recopilación
+        other: Colecciones
       create_a_collection: Crear una colección
+      current_subscription_expires: La suscripción actual caduca %{date}
+      document_set:
+        one: Conjunto de documentos
+        other: Conjuntos de documentos
+      exports: Exportaciones
       owner_dashboard: Panel de Control del Dueño
+      since: desde %{date}
       start_a_project: Iniciar Un Proyecto
       summary: Resumen
+      to_upgrade_contact: Para actualizar, póngase en contacto con support@fromthepage.com
+      total_pages: 'Páginas totales: %{pages}'
+      work:
+        one: Trabajar
+        other: Obras
       your_collections: Tus Colecciones
     upload:
+      acceptable_image_files: Se aceptan archivos PNG, GIF y JPG.
       browse: Navegar
       click_to_browse_a_file: Haz clic para consultar un archivo...
       click_to_browse_files: Haz clic para consultar los archivos...
       each_folder_will_be_treated: Cada carpeta se tratará como un documento diferente, por lo tanto, no mezcle páginas de documentos diferentes en la misma carpeta.
       each_pdf_will_be_treated: Cada PDF se tratará como su propio documento, por lo tanto, no divida las páginas del mismo documento entre más de un PDF.
       for_example_a_zip_file: 'Por ejemplo, un archivo ZIP con 3 imágenes, 2 PDFs, y 1 carpeta que contenga 5 imágenes más crearía 4 obras: las imágenes de nivel superior en una, cada PDF en su propia obra, y un último trabajo con las 5 imágenes de la carpeta.'
+      image_naming_guidelines: 'Las imágenes se deben nombrar de modo que una ordenación alfabética resulte en el orden de página correcto.<br> (Esto puede requerir "relleno con ceros" para cualquier número de página: <code>page_09.jpg, page_10.jpg</code> ordenará correctamente, pero <code>page_9.jpg, page_10.jpg</code> no).'
+      image_orientation_guidelines: Las imágenes deben estar orientadas de manera que queden boca arriba.
       import_form_message: Utilizando este formulario puedes importar imágenes de página a FromThePage. Debes seleccionar una colección como destino de importación y adjuntar un archivo ZIP o PDF que contenga las imágenes de página que se usarán en tu proyecto.
+      page_image_guidelines: Directrices de imagen de página
+      select_a_collection: "- Seleccione una colección -"
       to_specify_metadata: Para especificar metadatos junto con imágenes, incluya un archivo %{link} en cada carpeta que especifique campos para la obra.
       trial_accounts_are_limited: Las cuentas de prueba están limitadas a 200 páginas. Por favor contacta a support@fromthepage.com para actualizar tu cuenta.
       upload_file: Subir archivo

--- a/config/locales/deed/deed-es.yml
+++ b/config/locales/deed/deed-es.yml
@@ -1,6 +1,10 @@
 ---
 es:
   deed:
+    article_edit: Artículo editado
+    collection_active: Colección Activa
+    collection_inactive: Colección inactiva
+    collection_joined: Colección Unida
     deed:
       html:
         added_a_note_to_page: añadió una nota a la página %{page}
@@ -26,6 +30,8 @@ es:
     deeds:
       show_more: Mostrar Más
       time_ago_in_words: Hace %{time}
+    described_metadata: Metadatos descritos
+    edited_metadata: Descripción de los metadatos editados
     list:
       activity_stream: Flujo de Actividad
       collection_title: 'Colección: %{title}'
@@ -33,3 +39,17 @@ es:
       older_activity: Actividad Anterior
       time_ago_in_words: Hace %{time}
       user_title: 'Usuario: %{title}'
+    needs_review: Página necesita revisión
+    note_added: Nota añadida
+    ocr_corrected: Página OCR corregido
+    page_edit: Página editada
+    page_indexed: Página indexada
+    page_marked_blank: Página marcada en blanco
+    page_reviewed: Página revisada
+    page_transcription: Página transcrita
+    page_translated: Página traducida
+    page_translation_edit: Página de traducción editada
+    translation_indexed: Página de traducción indexada
+    translation_review: Página de traducción necesita revisión
+    translation_reviewed: Traducción revisada
+    work_added: Trabajo agregado

--- a/config/locales/devise/devise-es.yml
+++ b/config/locales/devise/devise-es.yml
@@ -1,6 +1,10 @@
 ---
 es:
   devise:
+    confirm_password: Confirmar contraseña
+    create_account: Crear una cuenta
+    display_name: Nombre para mostrar
+    email_address: Dirección de correo electrónico
     failure:
       already_authenticated: Ya has iniciado sesión.
       inactive: Tu cuenta aún no ha sido activada.
@@ -8,27 +12,94 @@ es:
       not_found_in_database: La contraseña o %{authentication_keys} son inválidos.
       timeout: La sesión expiró. Por favor vuelve a iniciar sesión para continuar.
       unauthenticated: Para continuar debes iniciar sesión o crear una cuenta.
+    login: Acceso
     mailer:
       reset_password_instructions:
+        change_my_password: cambiar mi contraseña
+        greeting: "¡Hola %{email}!"
+        message_1: 'Alguien ha solicitado un enlace para cambiar su contraseña. Puedes hacerlo a través del siguiente enlace:'
+        message_2: Si no lo solicitó, ignore este correo electrónico.
+        message_3: Su contraseña no cambiará hasta que acceda al enlace anterior y cree una nueva.
         subject: Instrucciones para reestablecer la contraseña
     omniauth_callbacks:
       failure: No se pudo corroborar tu información de %{kind} ya que %{reason}.
       success: Corroborado exitosamente por la cuenta %{kind}.
+    password: Clave
     passwords:
+      edit:
+        change_password: Cambia la contraseña
+        change_password_message: Cree una nueva contraseña para su cuenta. La contraseña debe tener al menos 8 caracteres y contener tanto letras como números. ¡No use la misma contraseña que usa para su banco en línea o cuenta de correo electrónico!
+        new_password: Nueva contraseña
+      new:
+        message: Ingrese la dirección de correo electrónico asociada con su cuenta de FromThePage. Si su dirección de correo electrónico existe en nuestra base de datos, recibirá un enlace de recuperación de contraseña en su dirección de correo electrónico en unos minutos.
+        password_recovery: Recuperación de contraseña
+        recover_password: Recuperar contraseña
       no_token: Esta página solo puede ser accesada desde un  correo para reestablecer la contraseña. Si este es el caso, por favor asegúrate de haber usado el URL entero que se proveyó en el correo para reestablecer la contraseña.
       send_instructions: Recibirás un correo con las instrucciones para reestablecer la contraseña en unos minutos.
       send_paranoid_instructions: Si tu dirección de correo electrónico ya existe en nuestra base de datos, dentro de unos minutos recibirás un enlace para recuperar su contraseña en el buzón de entrada de tu correo.
       updated: La contraseña ha sido cambiada exitosamente. Has iniciado sesión.
       updated_not_active: La contraseña ha sido cambiada exitosamente.
+    real_name: Nombre real
+    real_name_message: Los proyectos pueden usar esto cuando le den crédito. Deje esto en blanco si no desea que se le acredite.
+    receive_activity_emails: Recibir correos electrónicos de actividad
     registrations:
+      choose_saml:
+        harvard_university: Universidad Harvard
+        institution: Institución
+        lds_full_name: Iglesia de Jesucristo de los Santos de los Últimos Días
+        sign_in_with_institution: Ingresa con tu Institución
       destroyed: "¡Adiós! La cuenta ha sido cancelada exitosamente. Esperamos verte de nuevo pronto."
+      edit:
+        confirm_delete_account: "¿Está seguro de que desea eliminar su cuenta? ¡Después de eliminar la cuenta, no podrás recuperarla!"
+        current_password: Contraseña actual
+        delete_account: Borrar cuenta
+        edit_account: Editar cuenta
+        message: Aquí puede cambiar la información de su cuenta. Si no desea cambiar su contraseña, deje los campos de contraseña en blanco. Debe ingresar su contraseña actual para confirmar los cambios.
+        new_password: Nueva contraseña
+        save_changes: Guardar cambios
+        waiting_confirmation_message: Actualmente esperando confirmación para %{resource}
+      new_trial:
+        fill_in_the_following: Complete la siguiente información para crear una prueba de doscientas páginas
+        just_want_to_transcribe: "¿Solo quieres transcribir? %{sign_up_here}"
+        login: Acceso
+        message: Complete la siguiente información para crear una cuenta de propietario de proyecto FromThePage de prueba de doscientas páginas. ¿Tiene preguntas? %{schedule_a_kickoff_call}
+        project_owner_account_have: Cuenta del propietario del proyecto FromThePage. ¿Tiene preguntas?
+        schedule_a_kickoff_call: Programe una llamada de inicio.
+        sign_up_for_trial: Regístrese para una prueba
+        sign_up_here: Registrate aquí
+        want_to_transcribe: quieres transcribir?
+      owner_new:
+        projects_may_use_this: Los proyectos pueden usar esto cuando le den crédito. Deje esto en blanco si no desea que se le acredite.
+        you_ll_use_this: Usarás este nombre para iniciar sesión. Se mostrará públicamente.
       signed_up: "¡Te damos la bienvenida! Has iniciado sesión exitosamente."
       updated: La cuenta se ha actualizado correctamente.
       updated_but_not_signed_in: La cuenta se ha actualizado exitosamente, pero dado que se cambió la contraseña, debes volver a iniciar sesión
     sessions:
       already_signed_out: Has cerrado sesión exitosamente.
+      new:
+        forgot_your_password: "¿Olvidaste tu contraseña?"
+        or: o
+        remember_me: " Acuérdate de mí"
+        sign_in_with_institution: Regístrese con su Institución (SSO)
+        sign_up_as_transcriber_message: "¿Quieres unirte a un proyecto existente como transcriptor? Regístrese como transcriptor."
+        sign_up_now: Regístrate ahora
+        start_free_trial: Empiza la prueba gratuita
+        start_free_trial_message: "¿Quiere comenzar un nuevo proyecto de transcripción? Inicie una prueba gratuita."
       signed_in: Has iniciado sesión exitosamente.
       signed_out: Has cerrado sesión exitosamente.
+    shared:
+      links:
+        forgot_your_password: "¿Olvidaste tu contraseña?"
+        no_confirmation_instructions: "¿No recibió las instrucciones de confirmación?"
+        no_unlock_instructions: "¿No recibiste instrucciones de desbloqueo?"
+        sign_in_existing_account: Iniciar sesión cuenta existente
+        sign_in_with_google: Inicia sesión con Google
+        sign_in_with_institution: Regístrese con su Institución (SSO)
+        sign_up_new_account: Regístrate para una nueva cuenta
+    sign_in: Registrarse
+    sign_up: Inscribirse
+    user_name: Nombre de usuario
+    user_name_message: Usarás este nombre para iniciar sesión. Se mostrará públicamente.
   errors:
     messages:
       expired: ha expirado, por favor solicite uno nuevo

--- a/config/locales/display/display-es.yml
+++ b/config/locales/display/display-es.yml
@@ -4,7 +4,11 @@ es:
     display_page:
       collaboration_is_restricted: La colaboración está restringida para esta colección. Por favor, contacta al dueño del proyecto para colaborar con la transcripción.
       collection_is_not_active: Este proyecto no está activo. Por favor, contacta al dueño del proyecto para caulquier pregunta.
+      corrected: corregido
       facsimile: Facsímil
+      help_correct: ayudar a corregir
+      help_transcribe: ayudar a transcribir
+      help_translate: ayuda a traducir
       mark_the_page_blank: marcar la página en blanco
       or_mark_blank: "<br>o %{mark_blank}"
       page_notes: Notas de Página
@@ -13,10 +17,18 @@ es:
       show_translation: Mostrar Traducción
       this_page_is_blank: Esta página está en blanco
       this_page_is_not: Esta página no es %{text_type}
+      transcribed: transcrito
       transcription: Transcripción
+      translated: traducido
       translation: Traducción
     list_pages:
       actions: Acciones
+      blank_page: Página en blanco
+      completed: Terminado
+      correct: Correcto
+      describe: Describir
+      index: Índice
+      metadata: Metadatos
       n_notes:
         one: 1 nota
         other: "%{count} notas"
@@ -24,9 +36,14 @@ es:
       no_pages_found: No se encontró ninguna página
       no_pages_in_work: Esta obra aún no contiene ninguna página, ve a %{link} para crear una nueva página
       page_title: Título de la Página
+      pages_tab: Pestaña Páginas
+      review: Revisar
+      transcribe: Transcribir
+      translate: Traducir
       user_notes: Notas del Usuario
     multi_page:
       categories: Categorías
+      describe: Crear metadatos
       pages_need_indexing: Páginas que Necesitan Indexación
       pages_need_review: Páginas que Necesitan Revisión
       pages_need_transcription: Páginas que Necesitan Transcripción
@@ -34,18 +51,36 @@ es:
       search: Búsqueda
       search_for: Búsqueda de obras %{search_string}
       search_in_collection: Buscar en la colección...
+      search_in_collection_1: Buscar en la colección
       translations_need_indexing: Traducciones que Necesitan Indexación
       translations_need_review: Traducciones que Necesitan Revisión
       view_all_pages: Ver Todas las Páginas
     pages_view:
       collaboration_is_restricted: La colaboración está restringida para esta colección. Por favor, contacta al dueño del proyecto para colaborar con la transcripción.
       corrected: corregida
+      help_complete: Edita esta página
+      help_correct: ayudar a corregir
       help_transcribe: Por favor, ayuda a transcribir
       help_translate: ayuda a traducir
       last_edit: Última edición hace %{edit_time} por %{user_link}
       no_pages_found: No se encontró ninguna página
+      no_pages_needing_transcription_found_these_pages_are_incomplete: Ninguna página necesita transcripción desde cero. Estas páginas han sido parcialmente transcritas pero necesitan ser completadas.
       page_not_translated: Esta página no está traducida, por favor  %{help_translate} esta página
+      pages_needing_completion: Páginas que necesitan completarse
+      pages_that_need_transcription: Páginas que necesitan transcripción
+      review_metadata: Revisar metadatos
       this_page_is_blank: Esta página está en blanco
+      this_page_is_incomplete: esta pagina esta incompleta
       this_page_is_not: Esta página no es %{status}, por favor %{help} esta página
       transcribed: transcrita
+      translation: Traducción
       unable_to_find_pages: No pudimos encontrar ninguna página que coincida con la solicitud
+  display_helper:
+    page_action:
+      blank_page: Página en blanco
+      completed: Terminado
+      correct: Correcto
+      index: Índice
+      review: Revisar
+      transcribe: Transcribir
+      translate: Traducir

--- a/config/locales/document_sets/document_sets-es.yml
+++ b/config/locales/document_sets/document_sets-es.yml
@@ -8,6 +8,8 @@ es:
       description: Descripción
       document_is_marked_public: Si el conjunto de documentos está marcado como público, las obras colocadas en él serán legibles incluso si la colección está marcada como privada.
       save_document_set: Guardar Conjunto de Documentos
+      title: Título
+      url: URL
     index:
       actions: Acciones
       aggregating_works_thematic_exhibits: Agregando obras a exposiciones temáticas
@@ -19,6 +21,9 @@ es:
       document_sets_for: Conjuntos de Documentos para %{title}
       edit: Editar
       focusing_transcriber_effort: Concentrando el esfuerzo del transcriptor en un grupo particular de obras.
+      n_pages:
+        one: '1 pagina:'
+        other: "%{count} páginas:"
       no_document_sets: Esta colección no tiene conjuntos de documentos
       privacy: Privacidad
       private: Privado
@@ -27,15 +32,23 @@ es:
       save: Guardar
       search: Búsqueda
       search_for_works: Búsqueda de obras...
+      status: Estado
       title: Título
+      toggle_work_in_document_set: Alternar %{work} en el conjunto de documentos %{document_set}
+      transfer_works: Transferencia de obras
       work: Obras
     new:
       create_document_set: Crear Conjunto de Documentos
       create_new_document_set: Crear Nuevo Conjunto de Documentos
       description: Descripción
       document_set_is_marked_public: Si el conjunto de documentos está marcado como público, las obras colocadas en él serán legibles incluso si la colección está marcada como privada.
+      public: Público
+      title: Título
     set_works:
       collaboration: Colaboración
+      n_pages:
+        one: '1 pagina:'
+        other: "%{count} páginas:"
       progress: Progreso
       remove_from_set: Eliminar del conjunto
       remove_title_from_document_set: Eliminar %{title} del Conjunto de Documentos
@@ -58,13 +71,35 @@ es:
       make_document_set_private: Hacer Privado el Conjunto de Documentos
       make_document_set_public: Hacer Público el Conjunto de Documentos
       manage_works: Administrar Obras
+      n_contributions:
+        one: 1 contribución
+        other: "%{count} contribuciones"
+      n_pages:
+        one: '1 pagina:'
+        other: "%{count} páginas: pl"
       no_image: No Hay Imagen
       picture_document_set_description: " Una imagen a ser utilizada para ilustrar la descripción del conjunto de documentos."
       remove: Eliminar
       save: Guardar
       search: Búsqueda
       search_for_works: Búsqueda de obras...
+      status: Estado
       upload_image: Subir Imagen
       work: Obras
+    transfer:
+      source_and_target_can_not_be_the_same: El origen y el destino no pueden ser el mismo.
+    transfer_form:
+      all: todos los trabajos
+      cancel: Cancelar
+      completed: Solo obras terminadas
+      copy: Copiar (no crea obras duplicadas)
+      move: Muevete
+      source_set: Conjunto de documentos de origen
+      status_filter: que funciona
+      target_set: Conjunto de documentos de destino
+      transfer: Transferir
+      transfer_type_label: Tipo de transferencia
+      transfer_works: Transferencia de obras
+      transfer_works_description: Transferir trabajos entre conjuntos de documentos. (La copia colocará el mismo trabajo dentro de dos conjuntos de documentos al mismo tiempo).
     update:
       document_updated: El documento ha sido actualizado

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,5 +1,6 @@
 ---
 es:
+  authentication_failed: Autenticación fallida
   dashboard:
     collaborator: Panel de Control del Colaborador
     plain: Panel de Control
@@ -15,3 +16,4 @@ es:
       default: "%d de %b de %Y %I:%M %p"
       short: "%d/%m/%Y a las %I:%M %p"
   time_ago_in_words: Hace %{time}
+  unauthorized_collection: No tienes acceso a %{project}. Inicie sesión o comuníquese con el propietario del proyecto para ser agregado.

--- a/config/locales/export/export-es.yml
+++ b/config/locales/export/export-es.yml
@@ -5,7 +5,14 @@ es:
       connect: Conectar
       contentdm_credentials: Credenciales CONTENTdm
       contentdm_credentials_description: Ingresa tu código de licencia CONTENTdm y tus credenciales de inicio de sesión para exportar a CONTENTdm
+      contentdm_password: contraseña de CONTENTdm
+      contentdm_user_name: Nombre de usuario de CONTENTdm
+      license_key: Clave de licencia
+    facing_edition:
+      contributions_message: 'Este documento no sería posible sin las contribuciones editoriales de las siguientes personas:'
+      export_metadata: Exportación FromThePage de %{work} desde %{collection} realizada en %{time}.
     index:
+      api: API
       export_all_table_data_as_csv: Exportar todos los datos de la tabla en formato CSV
       export_all_tables: Exportar todas las tablas
       export_all_tables_description: Haz clic en el botón para exportar datos de la tabla de toda la colección en un solo archivo CSV. Tenga en cuenta que el proceso de exportación puede tardar algún tiempo en completarse, así que espera hasta que aparezca el cuadro de diálogo Guardar archivo.
@@ -26,14 +33,23 @@ es:
       export_work_metadata: Exportar metadatos de trabajo
       export_work_metadata_as_csv: Exportar metadatos de trabajo en formato CSV
       export_work_metadata_description: Exportar una hoja de cálculo que contiene una fila para cada trabajo de la colección, con columnas para estadísticas sobre las páginas transcritas y los metadatos del trabajo.
+      here: aquí
+      html: HTML
+      iiif: IIIF
       iiif_api_description: También tenemos una API basada en IIIF para exportar transcripciones tus colecciones de manera programática. Más información %{link}
       iiif_collection_api_endpoint: 'Endpoint de la API de recolección IIIF: %{link}'
       indexed: Indexado
+      more: Más
+      more_export_formats: Formatos de exportación adicionales
+      n_pages:
+        one: 1 pagina
+        other: "%{count} páginas"
       pages: Páginas
       plain_text: Texto sin formato
       progress: Progreso
       review: Revisar
       table_csv: Tabla en formato CSV
+      tei: IET
       work_title: Título del trabajo
     show:
       categories: 'Categorías:'

--- a/config/locales/ia/ia-es.yml
+++ b/config/locales/ia/ia-es.yml
@@ -2,11 +2,44 @@
 es:
   ia:
     confirm_import:
+      book_already_imported_description: 'Las obras enumeradas a continuación pueden haber sido importadas de la misma fuente:'
+      book_already_imported_warning: 'Advertencia: ¡Es posible que este libro ya se haya importado!'
+      book_was_imported: Libro de archivo de Internet "%{book}"; fue importado por %{user} en %{date}
+      cancel_import: Cancelar importación
+      import_anyway: Importar de todos modos
+      import_from_archive_org: Importar desde Archive.org
+      not_converted_into_work: pero no se ha convertido en un trabajo de FromThePage.
       please_enter_valid_url: Por favor, ingrese un URL de libro de Archive.org válido para importar
+      was_converted_into_work: y se convirtió en trabajo de FromThePage
     convert:
       converted_to_work: "%{title} ha sido convertido en una obra de FromThePage"
+    ia_book_form:
+      book_url: URL del libro
+      import_book_description: Para importar un libro, abra este libro en www.archive.org, luego copie la URL del libro de la barra de direcciones del navegador y péguela a continuación.
+      import_from_archive_org: Importar desde Archive.org
+      import_work: Importar trabajo
     import_work:
       imported_into_staging: "%{title} se ha importado al área de preparación"
+    manage:
+      actions: Comportamiento
+      book_imported_description: Este libro se ha importado de Internet Archive pero aún no se ha convertido en una obra. A continuación, verá la lista de páginas importadas y su texto OCR. Utilice el menú de acciones para definir la primera página (ocultar todas las páginas anteriores) y la última página (ocultar todas las páginas siguientes). También puede administrar los títulos de página del texto OCR y finalmente convertir esta importación en un trabajo al publicarlo en una colección. Para obtener más información sobre esta pantalla, consulte el artículo Wiki <a href="https://github.com/benwbrum/fromthepage/wiki/Importing-Works-from-the-Internet-Archive" target="_blank">Importación de obras del Archivo de Internet</a>.
+      conceal_following_pages: Ocultar páginas siguientes
+      conceal_preceding_pages: Ocultar páginas anteriores
+      first_line_of_ocr: Primera línea de OCR
+      first_line_of_ocr_description: "<b>Primera línea de OCR</b> reemplaza los títulos de página con la línea superior del texto OCR en cada página. Esto es útil para agendas y diarios, ya que la primera línea generalmente es una fecha."
+      last_line_of_ocr: Última línea de OCR
+      last_line_of_ocr_description: "<b>Última línea de OCR</b> reemplaza los títulos de página con la última línea de texto OCR en cada página. Esto es útil para trabajos impresos en los que los números de página aparecen en la parte inferior."
+      manage_archive_org_import: Administrar la importación de Archive.org
+      ocr_for_page_contents: "¿Usar texto OCR para el contenido de la página?"
+      ocr_for_page_contents_description: Seleccione esta casilla de verificación para completar la transcripción inicial de cada página con el contenido del OCR correspondiente. (No haga esto si sus páginas contienen escritura a mano que desea transcribir).
+      ocr_page_titles_description: Este proceso tardará varios segundos en ejecutarse, ya que requiere analizar todo el texto OCR del libro y actualizar el título de cada página. Una vez que el libro se haya convertido en una obra de FromThePage, podrá corregir los títulos de las páginas manualmente.
+      page_n_of_n: Página %{n} de %{total} (%{n2})
+      page_titles: Títulos de página
+      publish_to_collaborators: Publicar para colaboradores
+      publish_work: Publicar trabajo
+      publish_work_description: Una vez que tenga los títulos y las hojas listos, haga clic en Publicar para convertir el libro en un trabajo de FromThePage listo para transcribir. Este proceso tardará varios minutos en ejecutarse.
+      select_a_collection: "- Seleccione una colección -"
+      select_a_collection_1: Seleccione una colección
     mark_beginning:
       preceding_the_beginning: Las páginas previas al principio del texto han sido ocultadas
     mark_end:

--- a/config/locales/layouts/application-es.yml
+++ b/config/locales/layouts/application-es.yml
@@ -11,11 +11,21 @@ es:
       create_an_account: Crear Una Cuenta
       documentation: Documentación
       find_a_project: Encontrar Un Proyecto
+      home: Hogar
+      internet_archive_difficulties: Internet Archive está experimentando dificultades. Por favor, inténtelo de nuevo más tarde.
       owner_dashboard: Panel de Control del Dueño
+      pricing: Precios
       privacy_policy: Política de Privacidad
       projects: Proyectos
+      recaptcha_validation_failed: La validación de ReCAPTCHA falló
       sign_in: Iniciar Sesión
       sign_out: Cerrar Sesión
+      sign_up_to_transcribe: Regístrese para transcribir
+      signed_in_as: Registrado como
       terms_and_conditions: Términos y Condiciones
+      transcription_for_archives_special_collections: Transcripción para Archivos y Colecciones Especiales
+      transcription_for_digital_scholarship: Transcripción para Beca Digital
+      transcription_for_linguists: Transcripción para lingüistas
+      transcription_for_state_provincial_archives: Transcripción para archivos estatales y provinciales
       undo_login_as: Deshacer Inicio de Sesión Como
       your_profile: Tu Perfil

--- a/config/locales/metadata/metadata-es.yml
+++ b/config/locales/metadata/metadata-es.yml
@@ -1,0 +1,10 @@
+---
+es:
+  metadata:
+    upload:
+      browse: Navegar
+      click_to_browse_a_file: Haga clic para buscar un archivo...
+      template_file_anchor: este archivo de plantilla
+      upload: Subir
+      upload_metadata: Subir metadatos
+      upload_metadata_description: Para actualizar los metadatos de varias obras dentro de esta colección, cargue una hoja de cálculo con una fila por obra. Descargue %{link} para comenzar.

--- a/config/locales/notes/notes-es.yml
+++ b/config/locales/notes/notes-es.yml
@@ -27,6 +27,7 @@ es:
       note_body: Cuerpo de la Nota
       please_sign_in_to_write: Por favor, %{link} para escribir una nota para esta página
       save_note: Guardar Nota
+      sign_in: registrarse
       write_a_new_note: Escribir una nueva nota...
     update:
       error_updating_note: Hubo un error al actualizar la nota

--- a/config/locales/page/page-es.yml
+++ b/config/locales/page/page-es.yml
@@ -15,10 +15,20 @@ es:
       here_you_can_edit: Aquí puedes editar el título de la página y subir una nueva imagen. Para editar la transcripción de la página o el texto de traducción, cambia a la pestaña correspondiente arriba.
       page_image: Imagen de la Página
       page_position: 'Posición de Página: %{position}'
+      page_status: Estado de la página
+      page_status_: No empezado
+      page_status_blank: Página en blanco
+      page_status_incomplete: Incompleto
+      page_status_indexed: Indexado
+      page_status_review: Revisión de necesidades
+      page_status_transcribed: Completo
+      page_status_translated: Traducido
       page_title: Título de la Página
+      page_translation_status: Estado de traducción de la página
       rotate_clockwise: Girar en Sentido Horario
       rotate_counterclockwise: Girar Hacia la Izquierda
       save_changes: Guardar Cambios
+      status: 'Estado:'
     new:
       add_new_page: Añadir Nueva Página
       browse: Navegar
@@ -28,5 +38,6 @@ es:
       page_image: Imagen de la Página
       save_and_add_next_page: Guardar y Añadir Página Siguiente
       save_and_new_work: Guardar y Trabajo Nuevo
+      title: Título
     update:
       page_updated: Página actualizada

--- a/config/locales/page_version/page_version-es.yml
+++ b/config/locales/page_version/page_version-es.yml
@@ -8,3 +8,7 @@ es:
       n_revisions:
         one: 1 revisión
         other: "%{count} revisiones"
+      no_transcription_provided: No se proporcionó transcripción
+      no_translation_provided: No se proporcionó traducción
+      translation: Traducción
+      untitled: Intitulado

--- a/config/locales/quality_samplings/quality_samplings-es.yml
+++ b/config/locales/quality_samplings/quality_samplings-es.yml
@@ -1,0 +1,42 @@
+---
+es:
+  quality_samplings:
+    destroy:
+      quality_sampling_destroyed: El muestreo de calidad se destruyó con éxito.
+    index:
+      description: El muestreo de calidad le permite verificar las contribuciones al azar, recopilando datos sobre la calidad a medida que revisa cada contribución.
+      new_sampling: Iniciar muestreo
+    show:
+      actions: Comportamiento
+      approval_delta_display_0: Muy bajo
+      approval_delta_display_1: Bajo
+      approval_delta_display_2: Promedio
+      approval_delta_display_3: Alto
+      approval_delta_display_4: Muy alto
+      description: El muestreo de calidad le permite verificar las contribuciones al azar y luego evaluar las páginas para revisar en función de la cantidad de texto corregido para un usuario u obra en particular. Este número puede crecer a medida que se transcriban más páginas.
+      not_applicable: N / A
+      not_fully_sampled_yet: Esta muestra aún no se ha revisado por completo.
+      pages_corrected: Páginas corregidas
+      pages_corrected_desc: Páginas que requirieron corrección durante la aprobación (bajo es mejor).
+      pages_in_sample: Páginas en muestra
+      pages_in_sample_desc: Número de páginas de la muestra para el usuario u obra.
+      pages_sampled: Páginas muestreadas
+      pages_sampled_desc: Número de páginas muestreadas hasta ahora del campo total del muestreo.
+      pages_to_be_reviewed: Páginas para revisar
+      pages_to_be_reviewed_desc: Número de páginas que aún necesitan revisión en toda la colección.
+      quality_score: Nivel de calidad
+      quality_score_desc: Porcentaje promedio de cambios necesarios durante la aprobación.
+      relative_corrections: Correcciones relativas
+      relative_corrections_desc: "¿Cuántas correcciones se requirieron antes de la aprobación, en relación con otros usuarios en esta muestra?"
+      review: Revisar
+      review_url: Revisar URL
+      review_url_desc: URL que permitirá a los revisores aprobar las contribuciones directamente, sin mostrar esta pantalla.
+      sample: Revisar muestra
+      sample_field_size: 'Páginas a revisar:'
+      sample_set_has_increased: El conjunto de muestras ha aumentado en %{increase} páginas
+      sample_set_size: 'Tamaño del conjunto de muestra:'
+      total_pages_desc: Número de páginas dentro de esta colección.
+      user: Contribuyente
+      work: Trabajar
+    update:
+      quality_sampling_updated: El muestreo de calidad se actualizó con éxito.

--- a/config/locales/sc_collections/sc_collections-es.yml
+++ b/config/locales/sc_collections/sc_collections-es.yml
@@ -1,8 +1,45 @@
 ---
 es:
   sc_collections:
+    cdm_bulk_import_create:
+      import_started: Su importación ha comenzado. Cuando esté completo, debería recibir un correo electrónico en %{email}.
+    cdm_bulk_import_new:
+      bulk_contentdm_import: Importación masiva de CONTENTdm
+      compound_object_urls: URL de objetos compuestos
+      import: Importar
+      import_ocr_text: Importar texto OCR de CONTENTdm
+      select_a_collection_to_import_into: "- Seleccione una colección para importar a -"
+      separate_urls_with: Separe las URL con espacios o saltos de línea.
     convert_manifest:
       metadata_is_being_imported: Los metadatos %{ocr_text} se están importando desde CONTENTdm y aparecerán en breve.
+    explore_collection:
+      already_imported_into: Ya importado en
+      collection: 'Colección: %{sc_collection}'
+      collections: 'Colecciones:'
+      first_page: Primera página
+      id: 'Identificación: %{id}'
+      import_checked_manifests: Importar manifiestos marcados
+      import_ocr_text: Importar texto OCR de CONTENTdm
+      manifests: 'Manifiestos:'
+      next_page: Siguiente página
+      no_label: sin etiqueta
+      previous_page: Pagina anterior
+      select_a_collection: Seleccione una colección
+      select_a_collection_to_import_into: "- Seleccione una colección para importar a -"
+      select_all_manifests: Seleccionar todos los manifiestos
+      this_collection_is_divided: Esta colección está dividida en varias páginas.
+    explore_manifest:
+      canvases: 'Lienzos:'
+      collection: 'Colección: %{sc_collection}'
+      description: 'Descripción: %{description}}'
+      id: 'Identificación:'
+      import_manifest: Manifiesto de importación
+      import_ocr_text: Importar texto OCR de CONTENTdm
+      license: 'Licencia: %{license}'
+      manifest: 'Manifiesto: %{sc_manifest}}'
+      metadata: 'Metadatos: %{metadata}}'
+      select_a_collection_to_import_into: "- Seleccione una colección para importar a -"
+      select_a_collection_to_import_into_label: Seleccione una colección para importar a
     import:
       no_manifest_exist: No existe manifiesto IIIF para el elemento CONTENTdm %{url}
       please_enter_valid_url: Ingrese un URL válido para el manifiesto IIIF.

--- a/config/locales/shared/shared-es.yml
+++ b/config/locales/shared/shared-es.yml
@@ -4,6 +4,7 @@ es:
     article_tabs:
       overview: Resumen General
       settings: Configuración
+      subject: tema
       versions: Versiones
     codemirror:
       abbr_description: Marca las abreviaturas abreviaturas en un texto con expansiones en el atributo expan.
@@ -25,25 +26,63 @@ es:
     collection_tabs:
       add_work: Añadir Obra
       collaborators: Colaboradores
+      collection: recopilación
       edit_fields: Campos
+      edit_metadata_fields: Campos de metadatos
       export: Exportar
+      facets: facetas
       overview: Resumen General
+      review: Revisar
       sets: Conjuntos
       settings: Configuración
       statistics: Estadísticas
       subjects: Temas
       works_list: Lista de Obras
+    description_tabs:
+      describe: Metadatos
+      help: Ayuda
+      metadata: metadatos
+      nav_info: Trabajo %{position} de %{size}
+      next_page: Siguiente página
+      next_work: Siguiente trabajo
+      overview: Visión general
+      previous_page: Pagina anterior
+      previous_work: Trabajo previo
+      versions: Versiones
     handsontable:
       date_tooltip: Las fechas deben ser conforme el formato YYYY-MM-DD (cuatro dígitos del año, dos dígitos del mes, dos dígitos del dá, con guiones que separen los números).
+    markup_help:
+      markup_help_description: '"Autolink" sugerirá temas a los que se podrían vincular ciertas palabras o puede usar llaves dobles para vincular temas. <code>[[Jane Doe]]</code> vinculará el texto "Jane Doe" al asunto Jane Doe, mientras que <code>[[Jane Doe|Jane]]</code> vinculará el texto "Jane" al tema Jane Doe. Recomendamos que la vinculación se deje a un editor después de realizar la transcripción inicial.'
+    osd_div:
+      brightness: Brillo
+      contrast: Contraste
+      full_page: Alternar página completa
+      home: Vete a casa
+      image_filters: filtros de imagen
+      open_seadragon_needs_js: OpenSeadragon no está disponible a menos que JavaScript esté habilitado.
+      rotate_left: Girar a la izquierda
+      rotate_right: Gira a la derecha
+      threshold: Límite
+      zoom_in: Acercarse
+      zoom_out: Disminuir el zoom
     page_tabs:
       correct: Corregir
+      describe_work: Describir el trabajo
       help: Ayuda
       nav_info: Página %{position} de %{size}
+      next_page: Siguiente página
       overview: Resumen General
+      page: página
+      previous_page: Pagina anterior
       settings: Configuración
       transcribe: Transcribir
       translate: Traducción
       versions: Versiones
+    review_breadcrumbs:
+      dashboard: Panel de revisión
+      page: Página
+    validation_summary:
+      form: forma
     work_tabs:
       about: Acerca de
       contents: Contenido
@@ -52,3 +91,4 @@ es:
       pages: Paginas
       read: Leer
       settings: Configuración
+      work: Trabajar

--- a/config/locales/statistics/statistics-es.yml
+++ b/config/locales/statistics/statistics-es.yml
@@ -3,8 +3,12 @@ es:
   statistics:
     collaborator_time:
       collaborator_time: Tiempo del colaborador
+      collaborator_time_for_dates: Hora del colaborador para fechas
+      end_date: Fecha final
       export_activity_as_csv: Exportar actividad detallada como CSV
       no_activity_for_date_range: TNo hay actividad para este intervalo de fechas.
+      start_date: Fecha de inicio
+      update: Actualizar
       user_totals_for_dates: Totales de usuarios para fechas
     collaborators:
       collaborators: Colaboradores
@@ -21,6 +25,12 @@ es:
       collaborator:
         one: Colaborador
         other: Colaboradores
+      incomplete_page:
+        one: página incompleta
+        other: páginas incompletas
+      lines_transcribed:
+        one: línea de texto
+        other: lineas de texto
       note:
         one: Nota
         other: Notas
@@ -30,6 +40,27 @@ es:
       page:
         one: Página
         other: Páginas
+      page_edit:
+        one: Editar página
+        other: Ediciones de página
+      page_indexed:
+        one: Página indexada
+        other: Páginas indexadas
+      page_needing_review:
+        one: Página que necesita revisión
+        other: Páginas que necesitan revisión
+      page_reviewed:
+        one: Página revisada
+        other: Páginas revisadas
+      page_transcribed:
+        one: Página transcrita
+        other: Páginas transcritas
+      page_translated:
+        one: Página traducida
+        other: Páginas traducidas
+      records_indexed:
+        one: registro indexado
+        other: Registros indexados
       reference:
         one: Referencia
         other: Referencias
@@ -39,6 +70,9 @@ es:
       work:
         one: Trabajo
         other: Trabajos
+      works_described:
+        one: trabajo descrito
+        other: obras descritas
     recent_statistics:
       collaborator:
         one: Colaborador
@@ -52,6 +86,24 @@ es:
       ocr_correction:
         one: Corrección OCR
         other: Correcciones OCR
+      page_edit:
+        one: Editar página
+        other: Ediciones de página
+      page_indexed:
+        one: Página indexada
+        other: Páginas indexadas
+      page_marked_needing_review:
+        one: Página marcada que necesita revisión
+        other: Páginas marcadas que necesitan revisión
+      page_reviewed:
+        one: Página revisada
+        other: Páginas revisadas
+      page_transcribed:
+        one: Página transcrita
+        other: Páginas transcritas
+      page_translated:
+        one: Página traducida
+        other: Páginas traducidas
       reference:
         one: Referencia
         other: Referencias
@@ -62,6 +114,9 @@ es:
       collaborator:
         one: Colaborador
         other: Colaboradores
+      incomplete_page:
+        one: página incompleta
+        other: páginas incompletas
       last_days_statistics: Estadísticas de los últimos 7 días
       new_subject:
         one: Nuevo tema
@@ -72,6 +127,27 @@ es:
       ocr_correction:
         one: Corrección OCR
         other: Correcciones OCR
+      page_edit:
+        one: Editar página
+        other: Ediciones de página
+      page_indexed:
+        one: Página indexada
+        other: Páginas indexadas
+      page_marked_needing_review:
+        one: Página marcada que necesita revisión
+        other: Páginas marcadas que necesitan revisión
+      page_needing_review:
+        one: Página que necesita revisión
+        other: Páginas que necesitan revisión
+      page_reviewed:
+        one: Página revisada
+        other: Páginas revisadas
+      page_transcribed:
+        one: Página transcrita
+        other: Páginas transcritas
+      page_translated:
+        one: Página traducida
+        other: Páginas traducidas
       reference:
         one: Referencia
         other: Referencias

--- a/config/locales/transcribe/transcribe-es.yml
+++ b/config/locales/transcribe/transcribe-es.yml
@@ -18,10 +18,12 @@ es:
       image_at_the_left: Imagen hacia la izquierda
       image_at_the_right: Imagen hacia la derecha
       image_at_the_top: Imagen hacia arriba
+      layout: Diseño
       mark_as_blank: Marcar como en blanco
       microphone: Micrófono
       more_help: Más ayuda....
       needs_review: Necesita Revisión
+      notes_and_questions: Notas y Preguntas
       this_page_marked_blank: Esta página está en blanco
       this_page_marked_needs_review: Esta página ha sido marcada como "necesita revisión". Puedes mejorar esta página corrigiéndola con el original y agregando o corrigiendo texto. Cuando hayas terminado, desmarca "necesita revisión" y guarda la página.
       this_page_marked_needs_review_workflow_version: Esta página necesita revisión. Puedes mejorar esta página revisándola con el original y añadiendo o corrigiendo el texto y. Después, aprueba el texto.
@@ -41,9 +43,15 @@ es:
     save_buttons:
       approve: Aprobar
       approve_to_transcribed_tooltip: Guardar y aprobar esta página
+      autolink: Enlace automático
+      autolink_tooltip: Sugerir etiquetas de asunto automáticamente
       done: Terminado
+      edit: Editar
+      edit_tooltip: Edita esta página
       finish_to_needs_review_tooltip: Guardar una página completada
       finish_to_transcribed_tooltip: Guardar una página completada
+      preview: Avance
+      preview_tooltip: Vista previa de esta página
       save_changes: Guardar Cambios
       save_to_incomplete_tooltip: Guardar una página incompleta
       save_to_needs_review_tooltip: SGuardar tus cambios
@@ -57,8 +65,11 @@ es:
       notice: Puedes guardar hasta %{guest_deed_count} transcripciones como visitante.
     translate:
       autolink: Enlace automático
+      corrected: corregido
       edit: Editar
       edit_translation: Editar traducción
+      help_correct: ayudar a corregir
+      help_transcribe: ayudar a transcribir
       mark_as_blank: Marcar como en blanco
       mark_the_page_blank: marcar la página en blanco
       microphone: Micrófono
@@ -69,6 +80,8 @@ es:
       preview: Vista Preliminar
       save_changes: Guardar Cambios
       show_image: Mostrar Imagen
+      show_transcription: Mostrar transcripción
       this_page_is_blank: Esta página está en blanco
       this_page_is_not: Esta página no es %{text_type}
       this_page_marked_needs_review: Esta página ha sido marcada como "necesita revisión". Puedes mejorar esta página corrigiéndola con el original y agregando o corrigiendo texto. Cuando hayas terminado, desmarca "necesita revisión" y guarda la página.
+      transcribed: transcrito

--- a/config/locales/transcription_field/transcription_field-es.yml
+++ b/config/locales/transcription_field/transcription_field-es.yml
@@ -1,16 +1,87 @@
 ---
 es:
   transcription_field:
+    add_columns:
+      must_have_options_list: Los campos seleccionados deben tener una lista de opciones. Agregue opciones a cualquier campo seleccionado y vuelva a guardar.
+      starting_rows_must_not_be_blank: Las filas iniciales no deben estar en blanco.
     add_fields:
       must_have_options_list: Los campos seleccionados deben tener una lista de opciones. Agregue opciones a cualquier campo seleccionado y vuelva a guardar.
+    choose_offset:
+      page_layout: Diseño de página
+      page_layout_description: Cambie el tamaño del rectángulo en la imagen para rodear la parte de la página que contiene una hoja de cálculo, luego guarde su selección.
+      replace_image: Reemplazar imagen
+      replace_image_description: Si la imagen de ejemplo no contiene una hoja de cálculo, puede reemplazarla con una página diferente de la colección, elegida al azar.
+      save_selection: Guardar selección
+    column_form:
+      column_options: Opciones de columna (separadas con punto y coma)
+      column_options_title: Opciones para celdas desplegables.
+      input_type: Tipo de entrada
+      label: Etiqueta
+    edit_columns:
+      add_additional_column: Agregar columna adicional
+      cancel: Cancelar
+      disable_ruler: Deshabilitar regla
+      done: Hecho
+      edit_spreadsheet_columns: Configuración de columna
+      edit_spreadsheet_header: Configuración de la hoja de cálculo
+      enable_ruler: Habilitar regla
+      identify_rows: Identificar filas
+      identify_rows_description: Las páginas pueden tener márgenes superior e inferior, campos de encabezado o pie de página u otro texto que no debe usarse al identificar dónde están las filas en la página.
+      page_layout: Diseño de página
+      preview: Vista previa de la hoja de cálculo
+      save: Ahorrar
+      screen_ruler: Regla de pantalla
+      screen_ruler_description: Para mejorar la usabilidad y reducir los errores del transcriptor, FromThePage puede mostrar una regla en la imagen de la página que resalta la parte de la página que el usuario está transcribiendo. Esto es útil para documentos escaneados consistentemente escritos en formularios preimpresos, pero puede distraer o frustrar si los documentos son irregulares y la regla de la pantalla no coincide.
+      start_rows_description: Número de filas que la hoja de cálculo debe mostrar inicialmente. (Los transcriptores podrán agregar filas adicionales si es necesario).
+      start_rows_label: 'Recuento de filas inicial:'
+      transcription_warning: Este proyecto ya ha sido transcrito parcialmente. Agregar columnas está bien, pero eliminar o cambiar columnas puede provocar la pérdida de datos. Póngase en contacto con support@fromthepage.com si tiene preguntas o necesita cambiar el nombre de las columnas.
+    edit_field_form:
+      add_additional_field: Agregar campo adicional
+      add_additional_line: Agregar línea adicional
+      cancel: Cancelar
+      data_entry_type_label: Flujo de metadatos
+      data_entry_type_metadata_only: Los usuarios solo crean metadatos
+      data_entry_type_text_and_metadata: Los usuarios transcriben texto y crean metadatos
+      description_instructions_label: Metadatos Descripción Instrucciones
+      done: Hecho
+      line: Línea
+      preview: Avance
+      save: Ahorrar
     edit_fields:
       edit_transcription_fields: Editar Campos de Transcripción
+      transcription_warning: Este proyecto ya ha sido transcrito parcialmente. Agregar campos está bien, pero eliminar o cambiar campos puede provocar la pérdida de datos. Póngase en contacto con support@fromthepage.com si tiene preguntas o necesita cambiar el nombre de los campos.
+    edit_metadata_fields:
+      edit_metadata_fields: Editar campos de metadatos
     field_layout:
       instructions: Instrucciones
     line_form:
       field_options: Opciones de campo (separa con punto y coma)
       field_options_title: Opciones para los campos seleccionados.
+      input_type: Tipo de entrada
+      label: Etiqueta
       page: Página
       page_title: Para formularios de varias páginas, ¿en qué página debería aparecer este campo? (Déjalo en blanco para mostrar en cada página.)
       percentage_title: Porcentaje del ancho de línea que se utilizará para este campo.
       percentage_width: Ancho %
+    metadata_field_layout:
+      instructions: Instrucciones
+    multiselect_form:
+      options_form_description: Ingrese opciones para el campo de metadatos de selección múltiple, con cada opción en una línea separada
+      options_form_title: Opciones de selección múltiple
+      save: Ahorrar
+    new_column_form:
+      delete_column: Eliminar columna
+      field_label: Etiqueta de campo
+      field_options: Opciones de campo
+      input_type: Tipo de entrada
+      reorder_column: Reordenar columna
+    new_field_form:
+      configure_options: Configurar opciones
+      configure_spreadsheet: Configurar hoja de cálculo
+      delete_field: Eliminar campo
+      field_label: Etiqueta de campo
+      field_options: Opciones de campo
+      input_type: Tipo de entrada
+      page_number: Número de página
+      reorder_field: Reordenar campo
+      width_percentage: Porcentaje de ancho

--- a/config/locales/user/user-es.yml
+++ b/config/locales/user/user-es.yml
@@ -1,12 +1,20 @@
 ---
 es:
   user:
+    api_key:
+      api_key: Clave API
+      api_key_description: Las <a href="https://content.fromthepage.com/api-keys/">claves API</a> permiten el acceso a colecciones privadas a través de <a href="https://github.com/benwbrum/fromthepage /wiki/FromThePage-Support-for-the-IIIF-Presentation-API-and-Web-Annotations">IIIF API</a> o <a href="http://content.fromthepage.com/bulk-export- api/">API de exportación masiva</a>.
+      delete_key: Eliminar clave
+      generate_key: Generar clave
+      no_api_key_description: Su cuenta no tiene una clave API. Genere uno para habilitar el acceso a la API.
+      your_api_key_description: 'Su cuenta tiene la siguiente clave API, que puede usarse para acceder a sus colecciones privadas:'
     owner_profile:
       api_keys: Claves API
       edit_profile: Editar Perfil
       login_and_password: Inicio de sesión y Contraseña
       next_image: Siguiente imagen
       previous_image: Imagen anterior
+      recent_activity: Actividad reciente
       website: Página Web
     profile:
       contribution:
@@ -15,9 +23,12 @@ es:
       edit_profile: Editar Perfil
       last_seen: Visto por última vez %{date}
       login_and_password: Inicio de sesión y Contraseña
+      newer_activity: Actividad más reciente
+      older_activity: Actividad anterior
       recent_activity_by: Actividad Reciente de %{user_display_name}
       user_deleted: El perfil del usuario ha sido borrado
       user_since: Usuario desde %{date}
+      users_profile_at_fromthepage: Perfil de %{user} en FromThePage. %{about}
     update:
       user_updated: El perfil del usuario ha sido actualizado
     update_profile:
@@ -26,14 +37,25 @@ es:
       add_as_owner: Añadido a obra privada como dueño
       add_as_reviewer: Añadido a la colección como revisor autorizado
       default_dictation_language: 'Idioma de dictado predeterminado: '
+      interface_language: Lenguaje de interfaz
+      location: Ubicación
       name: Nombre
       name_only_required: Tu nombre es el único campo obligatorio.
+      no_image: Sin imágen
+      ocrid_id: ID OCRID
       owner_stats: Correos electrónicos nocturnos con la actividad de la colección propia
       page_edited: Nota añadida en respuesta a un comentario que hiciste
       picture: Imagen de perfil
+      picture_to_be_used_message: Imagen a utilizar
       select_notification: "'Selecciona cuál de las siguientes notificaciones deseas recibir:"
+      sign_up_url: 'URL de registro:'
       update_profile: Actualizar Perfil
       update_user_profile: Actualizar Perfil de Usuario
+      upload_image: Cargar imagen
+      url: URL
       user_activity: Correo electrónico nocturno con la actividad de colecciones en las que has trabajado
+      user_url: 'URL:'
+      website: Sitio web
       where_are_you_from: "¿De dónde eres?"
       your_blog_or_homepage: Tu blog o página de inicio
+      your_ocrid_id: Su identificación OCRID

--- a/config/locales/user_mailer/user_mailer-es.yml
+++ b/config/locales/user_mailer/user_mailer-es.yml
@@ -1,11 +1,39 @@
 ---
 es:
   user_mailer:
+    added_note:
+      html:
+        view_note: " para ver la nota en %{collection}: %{work}."
+      message: Solo queríamos informarle que la siguiente nota se ha agregado a una página en la que trabajó en el trabajo %{work}, en la colección %{collection}.
+      text:
+        view_note: 'Puede ver la nota en %{collection}: %{work} en la URL: %{url}.'
+    bulk_export_finished:
+      html:
+        ready_message: ha sido procesado y está listo en %{this_link}.
+      text:
+        ready_message: 'Su exportación ha sido procesada y está lista en esta URL:'
+      this_link: este enlace
+      your_export_is_ready: "¡Tu exportación está lista!"
+      your_export_of: Su exportación de
     click_here: Haz clic aquí
+    collection_collaborator:
+      html:
+        to_view: " para ver %{collection}"
+      message: Solo queríamos informarte que %{owner} te agregó como colaborador en %{collection}.
+      text:
+        to_view: 'Para ver %{collection}, visite la siguiente URL: %{url}'
+    collection_reviewer:
+      html:
+        to_view: " para ver %{collection}"
+      message: "%{owner} lo agregó como revisor autorizado en %{collection}. Debería poder editar y aprobar cualquier página que necesite revisión."
+      text:
+        to_view: 'Para ver %{collection}, visite la siguiente URL: %{url}'
     greeting: Hola %{user} --
     html:
       closing: "Gracias, <br><br> \nFromThePage\n"
       turn_off_notification: " para desactivar esta notificación."
+    new_owner:
+      welcome: Bienvenidos
     nightly_user_activity:
       html:
         to_view_note: " para ver la nota de la página %{page} en %{collection}: %{work}, que se ha añadido desde que trabajaste en ella."
@@ -13,4 +41,25 @@ es:
       message: Solo queríamos dejarte saber que hubo actividad en una colección en la que trabajaste.
       new_notes: Notas Nuevas
       new_works: Obras nuevas
+      note_added: Se ha agregado una nota a una página en la que trabajó en el trabajo %{work}, en la colección %{collection}.
+      text:
+        to_view_note: 'Para ver la nota en la página %{work}: %{page}, visite la siguiente URL: %{url}'
+        to_view_work: 'Para ver %{collection}: %{work}, visite la siguiente URL: %{url}'
       work_added: "%{owner} añadió %{work} a la colección %{collection}. "
+    text:
+      closing: |-
+        Gracias,
+        DeLaPágina
+      turn_off_notification: 'Desactive esta notificación en la URL: %{url}'
+    upload_finished:
+      html:
+        message: Su carga ha sido procesada y está lista en
+      text:
+        message: 'Su carga ha sido procesada y está lista en esta URL:'
+      your_upload_is_ready: "¡Tu carga está lista!"
+    work_collaborator:
+      html:
+        to_view: " para ver %{collection} - %{work}."
+      message: Solo queríamos informarte que %{owner} te agregó como colaborador en %{collection} - %{work}.
+      text:
+        to_view: 'Puede ver %{collection}: %{work} en la URL: %{url}'

--- a/config/locales/will_paginate/will_paginate-es.yml
+++ b/config/locales/will_paginate/will_paginate-es.yml
@@ -1,19 +1,19 @@
 ---
 es:
   will_paginate:
-    container_aria_label: 
-    next_label: 
-    page_aria_label: 
+    container_aria_label: Paginación
+    next_label: Siguiente →
+    page_aria_label: Página %{page}
     page_entries_info:
-      multi_page: 
-      multi_page_html: 
+      multi_page: Mostrando %{model} %{from} - %{to} de %{count} en total
+      multi_page_html: Mostrando %{model} <b>%{from} - %{to}</b> de <b>%{count}</b> en total
       single_page:
-        one: 
-        other: 
-        zero: 
+        one: Mostrando 1 %{model}
+        other: Mostrando todo %{count} %{model}
+        zero: No se encontró %{model}
       single_page_html:
-        one: 
-        other: 
-        zero: 
-    page_gap: 
-    previous_label: 
+        one: Mostrando <b>1</b> %{model}
+        other: Mostrando <b>todo %{count}</b> %{model}
+        zero: No se encontró %{model}
+    page_gap: "&hellip;"
+    previous_label: "← Anterior"

--- a/config/locales/work/work-es.yml
+++ b/config/locales/work/work-es.yml
@@ -1,6 +1,156 @@
 ---
 es:
   work:
+    create:
+      work_created: Trabajo creado con éxito
+    describe:
+      always_show_fullscreen: Mostrar siempre pantalla completa
+      approve: Aprobar
+      approve_to_transcribed_tooltip: Guardar y aprobar estos metadatos
+      done: Hecho
+      finish_to_needs_review_tooltip: Guardar metadatos completados
+      finish_to_transcribed_tooltip: Guardar metadatos completados
+      fullscreen: Pantalla completa
+      image_at_the_bottom: Imagen en la parte inferior
+      image_at_the_left: Imagen a la izquierda
+      image_at_the_right: Imagen a la derecha
+      image_at_the_top: Imagen en la parte superior
+      layout: Diseño
+      metadata: metadatos
+      needs_review: Necesita revisión
+      notes_and_questions: notas y preguntas
+      original_metadata: Metadatos originales
+      page_images: Imágenes de la página
+      save_changes: Ahorrar
+      save_to_incomplete_tooltip: Guardar metadatos incompletos
+      save_to_needs_review_tooltip: Guarda tus cambios
+      save_to_transcribed_tooltip: Guarda tus cambios
+      text: Texto
+      this_page_is_blank: esta pagina esta en blanco
+      view_original: Ver originales
+    described: Metadatos completados.
+    description_versions:
+      author_contributed_at: "%{author} a %{date}"
+      compared_with: Comparado con
+      help_description: Vea y compare los cambios que se han realizado en cada revisión a los metadatos de trabajo. La columna de la izquierda muestra los metadatos en la revisión seleccionada, la columna de la derecha muestra lo que se ha cambiado. El texto que no ha cambiado está <span>resaltado en blanco</span>, el texto eliminado está <del>resaltado en rojo</del> y el texto insertado está <ins>resaltado en color verde</ins>.
+      revision: revisión
+    download:
+      analyze: Analizar
+      docx_download_description: Descargue una versión DOCX de este trabajo.
+      download: Descargar
+      expanded_plaintext: Texto sin formato expandido
+      expanded_plaintext_export_description: Exporte transcripciones de texto sin formato reemplazando texto textual con títulos de temas canónicos como un archivo zip que contiene un archivo por página.
+      experiment: Experimento
+      export: Exportar
+      facing_pdf: Frente a PDF
+      facing_pdf_export_description: Descargue una versión en PDF de este trabajo que incluye imágenes y texto en las páginas opuestas.
+      html: HTML
+      html_export_description: Exporte las transcripciones como un archivo zip que contiene un archivo HTML por página.
+      ms_word: MS Word
+      pdf: PDF
+      pdf_download_description: Descargue una versión en PDF de este trabajo.
+      searchable_plaintext: Texto sin formato que se puede buscar
+      searchable_plaintext_export_description: Exporte transcripciones de texto sin formato optimizadas para la búsqueda de texto completo como un archivo zip que contiene un archivo por página.
+      table_field_csv: CSV de tabla/campo
+      table_field_csv_export_description: Exporte todos los datos tabulares, de hojas de cálculo o basados en campos como un solo archivo CSV.
+      verbatim_plaintext: Texto sin formato textual
+      verbatim_plaintext_export_description: Exporte transcripciones textuales de texto sin formato como un archivo zip que contiene un archivo por página.
+      voyant: Voyante
+      voyant_analysis_description: Envíe la transcripción de este trabajo a Voyant Tools para su análisis.
+      warning_work_not_complete: 'Advertencia: este trabajo puede no estar completo.'
+      word_trees: Árboles de palabras
+      word_trees_analysis_description: Envíe la transcripción de este trabajo al visualizador Word Trees de Jason Davies para su análisis.
+      zip_export_only_project_owners: Formatos de exportación de archivos zip solo accesibles para los propietarios de proyectos.
+    edit:
+      add: Agregar
+      additional_metadata: Metadatos adicionales
+      additional_metadata_description: Estos campos de metadatos se muestran en la pantalla Acerca de de este trabajo y en las exportaciones de TEI, pero no afectan la funcionalidad de FromThePage.
+      allowed_collaborators: Colaboradores permitidos
+      apply: Aplicar
+      author: Autor
+      collaborators_can_edit_titles: Permitir que los colaboradores editen los títulos de las páginas
+      collection: Recopilación
+      confirm_delete_work: "¿Está seguro de que desea eliminar este trabajo? ¡Después de borrar no podrás recuperarlo!"
+      current_url: La URL actual para este trabajo es %{current_url}. Si desea editar la sección de trabajo de la URL, utilice letras minúsculas y guiones entre las palabras.
+      delete_work: Eliminar trabajo
+      description: Descripción
+      document_date: Fecha del documento
+      document_date_hint: La fecha del documento está en el formato EDTF (por ejemplo, 1843, 2001-02, 1643-06-30)
+      document_history: Historia del documento
+      editorial_notes: Notas editoriales
+      enable_ocr_correction: Habilitar la corrección OCR
+      enable_ocr_correction_description: Un trabajo puede comenzar con texto OCR que necesita ser corregido. Cuando está marcada, la pestaña Transcribir será reemplazada por una pestaña Corregir.
+      genre: Género
+      identifier: identificador
+      identifier_description: Identificador de sistemas fuera de FromThePage, que se utilizará para correlacionar exportaciones con registros externos. (Este campo no es visible para el público).
+      in_scope: En alcance
+      more_work_settings_info: Para obtener más información sobre la configuración de trabajo, consulte el artículo wiki <a href="https://github.com/benwbrum/fromthepage/wiki/Preparing-a-Work-for-Transcription" target="_blank">Preparación de un trabajo para Transcripción</a>.
+      no_allowed_collaborators_selected: No se han seleccionado colaboradores permitidos
+      no_image: Sin imágen
+      pages_are_meaningful: Las páginas son significativas
+      pages_are_meaningful_description: Las páginas pueden ser divisiones semánticas significativas de un trabajo (como en un diario con una fecha para cada página), o pueden no serlo (como en cartas o libros, donde el texto no debe dividirse en secciones según las páginas). Cuando está marcado, el trabajo tendrá títulos de página destacados.
+      permission_description: Descripción del permiso
+      physical_description: Descripción física
+      place_of_creation: Lugar de creación
+      recipient: Recipiente
+      remove: Remover
+      restrict_collaborators: Restringir colaboradores
+      restricted_work_no_collaborators_warning: Solo los propietarios de proyectos pueden editar este trabajo. Agregue colaboradores para que el trabajo sea editable por otros.
+      revert: Revertir
+      revert_transcription_conventions_description: Revertir las convenciones de transcripción al valor predeterminado de la colección
+      save_changes: Guardar cambios
+      settings_only_work_owners: Los ajustes para este trabajo solo son accesibles para los propietarios del trabajo.
+      source_box_folder: Caja/carpeta de origen
+      source_collection_name: Nombre de la colección de origen
+      source_location: Ubicación de origen
+      support_translation: Traducción de soporte
+      support_translation_description: Una obra puede traducirse y transcribirse. Cuando esté marcado, el trabajo tendrá una pestaña de Traducción para cada página.
+      transcription_conventions: Convenciones de transcripción
+      translation_instructions: Instrucciones de traducción
+      upload_image: Cargar imagen
+      uploaded_by: subido por
+      url: URL
+      work_image: Imagen de trabajo
+      work_image_description: Una imagen que se utilizará para ilustrar el trabajo. Si no se carga ninguna imagen, se utilizará una imagen de página.
+      work_thumbnail: Miniatura de trabajo
+      work_title: Título de trabajo
+    incomplete: Metadatos incompletos.
+    metadata_overview:
+      notes_and_questions: notas y preguntas
+      show_image: Mostrar imagen
+      this_page_is_blank: esta pagina esta en blanco
+    needsreview: Los metadatos necesitan revisión.
+    new:
+      collection: Recopilación
+      create_empty_work: Crear trabajo vacío
+      create_empty_work_description: Esto crea un trabajo vacío. Una vez que cree el trabajo, puede agregar imágenes de página individuales. Si tiene un archivo zip o pdf con varias imágenes, debe crear el trabajo y cargar el archivo en %{start_project} en su lugar.
+      create_work: Crear trabajo
+      description: Descripción
+      start_a_project: Iniciar un proyecto
+      title: Título
+      work_description: Un trabajo es un documento único como una carta, un diario, un libro de campo, una tarjeta postal o un cuaderno.
+    pages_tab:
+      actions: Comportamiento
+      add_new_page: Agregar nueva página
+      confirm_delete_page: "¿Estás seguro de que quieres eliminar esta página? ¡Después de borrar no podrás recuperarlo!"
+      delete: Borrar
+      featured_page: Página destacada
+      image_status: Estado de la imagen
+      make_featured_page: Hacer página destacada
+      move_down: Mover hacia abajo
+      move_up: Ascender
+      no_pages_found: No se encontraron páginas
+      no_pages_found_description: Este trabajo aún no contiene ninguna página.
+      page_title: Título de la página
+      pages_tab_description: Aquí se ve la lista de todas las páginas de la obra. Si desea cambiar la posición de una página, use las flechas hacia arriba y hacia abajo a la derecha. Para crear una nueva página para este trabajo, haga clic en el botón Agregar nueva página. Una vez creada una nueva página en blanco, búsquela en la lista a continuación y vaya a la configuración donde puede cargar la imagen de la página.
+      position: Posición
+      ready_to_transcribe: Listo para %{transcribe}
+      settings: Ajustes
+      transcribe: transcribir
+      upload: Subir
+      upload_page_image: Imagen de la página %{upload}
+    save_description:
+      work_described: Tu descripción ha sido guardada
     show:
       author_name: Nombre del Autor
       description: Descripción
@@ -8,13 +158,19 @@ es:
       document_history: Historial del Documento
       editorial_notes: Notas editoriales
       genre: Género
+      iiif_manifest: Manifiesto IIIF
       location_of_composition: Ubicación de la Composición
+      metadata: metadatos
       number_of_pages: Número de Páginas:nbsp;
       out_of_scope: Fuera del alcance
       permission_description: Descripción del Permiso
       physical_description: Descripción Física
+      recipient_name: Nombre del Recipiente
       scope: Alcance
       source_box_folder: Caja/Carpeta de la fuente
       source_collection_name: Nombre de la colección de la fuente
       source_location: Ubicación de la fuente
       uploaded_by: Subido por
+    undescribed: Sin metadatos.
+    update:
+      work_updated: Trabajo actualizado con éxito


### PR DESCRIPTION
_Resolves #3179_

This translates all of the remaining untranslated Spanish messages so that you shouldn't see any leftover English when you have your locale set to Spanish. It was done via `i18n-tasks translate missing` and the Google Translate API.

This PR we can merge now because robot Spanish is better than English (and so our `i18n-tasks` tests can run), and we'll have a separate PR (#3253) for reviewing these messages.