### PR TITLE
Added missing Portuguese messages

### DIFF
--- a/config/locales/activerecord/activerecord-pt.yml
+++ b/config/locales/activerecord/activerecord-pt.yml
@@ -11,6 +11,44 @@ pt:
       work:
         slug: URL
         title: Titulo
+    errors:
+      models:
+        collection:
+          attributes:
+            slug:
+              blank: É necessário
+              invalid: deve ter pelo menos uma letra
+        document_set:
+          attributes:
+            slug:
+              blank: É necessário
+              invalid: deve ter pelo menos uma letra
+        work:
+          attributes:
+            slug:
+              blank: É necessário
+              invalid: deve ter pelo menos uma letra
+        xml_source_processor:
+          blank_subject_in: Assunto em branco em %{tag}
+          blank_tag_in: Tag em branco em %{tag}
+          blank_text_in: Texto em branco em %{tag}
+          subject_linking_error: 'Erro de vinculação de assunto:'
+          tags_should_not_use_3_brackets: As tags devem ser criadas usando 2 colchetes, não 3
+          unclosed_bracket_within: Colchete não fechado dentro de %{tag}
+          wrong_number_of_closing_braces: Número incorreto de chaves de fechamento após %{tag}
+    models:
+      bulk_export:
+        one: exportação a granel
+        other: exportações a granel
+      ia_leaf:
+        one: página
+        other: Páginas
+      page:
+        one: página
+        other: Páginas
+      work:
+        one: trabalhar
+        other: funciona
   errors:
     messages:
       not_saved:

--- a/config/locales/article/article-pt.yml
+++ b/config/locales/article/article-pt.yml
@@ -1,12 +1,104 @@
 ---
 pt:
   article:
+    article_links:
+      n_pages_refer_to:
+        one: 1 página refere-se a %{article}
+        other: As páginas %{count} referem-se a %{article}
+      n_subjects_refer_to:
+        one: 1 assunto refere-se a %{article}
+        other: "%{count} assuntos referem-se a %{article}"
+      show_pages_that_mention: Mostrar páginas que mencionam %{article} em todos os trabalhos
     combine_duplicate:
       selected_subjects_combined: Temas selecionados combinados com %{title}
     delete:
       must_remove_referring_links: Você deve remover todos os links que fazem referência antes de deletar este tema.
+    edit:
+      autolink: Autolink
+      categories: Categorias
+      combine_selected: Combinar selecionado
+      confirm_delete_subject: Tem certeza de que deseja excluir este assunto? Após a exclusão, você não poderá recuperá-lo!
+      delete_subject: Excluir assunto
+      description: Descrição
+      latitude: Latitude
+      longitude: Longitude
+      microphone: Microfone
+      n_pages:
+        one: 1 página
+        other: "%{count} páginas"
+      no_duplicates_found: Nenhuma duplicata encontrada
+      no_duplicates_found_description: O assunto é único dentro da coleção, não foram encontradas possíveis duplicatas do assunto "%{article}".
+      possible_duplicates:
+        one: Possível duplicata
+        other: Possíveis duplicatas
+      possible_duplicates_description: Por favor, revise a lista abaixo e selecione os assuntos para combinar. As duplicatas serão remapeadas para que todos os links existentes apontem para o assunto "%{article}".
+      save_changes: Salvar alterações
+      select_categories: Selecionar categorias
+      title: Título
+      uri: URI
+    graph:
+      dot:
+        title: Assuntos mencionados frequentemente com %{subject}
+    list:
+      actions: Ações
+      add_child_category: Adicionar categoria secundária
+      add_root_category: Adicionar categoria raiz
+      categories: Categorias
+      category_back_message: Assim que terminar de editar as categorias, %{page_link} para retornar à página "%{page}".
+      click_here: Clique aqui
+      confirm_delete_category: Tem certeza de que deseja excluir esta categoria e todas as suas subcategorias? Após a exclusão, você não poderá recuperá-lo!
+      create_category_message: "%{link} que você usará para agrupar assuntos."
+      create_the_first_category: Crie a primeira categoria
+      delete_category: Excluir categoria
+      disable_gis_for_category: Desativar GIS para categoria
+      edit_category: Editar categoria
+      enable_gis_for_category: Ativar GIS para categoria
+      no_categories: Sem categorias
+      no_categories_message: Não há categorias de assunto na coleção.<br>
+      there_are_no_subjects: Não há assuntos para a categoria selecionada
+      uncategorized: Sem categoria
+      uncategorized_subjects: Assuntos não categorizados
+      upload_subjects: Carregar assuntos
+    show:
+      all_uncategorized_subjects: Todos os assuntos não categorizados na coleção
+      categories: Categorias
+      description: Descrição
+      download: Download
+      download_description: Faça o download de uma planilha de assuntos e trabalhos simultâneos em que eles aparecem.
+      edit_description_description: Edite a descrição na guia de configurações.
+      export: Exportar
+      n_possible_duplicates:
+        one: 1 Possível Duplicata
+        other: "%{count} Possíveis Duplicatas"
+      no_category_message: Este assunto não pertence a nenhuma categoria
+      references: Referências
+      related_subjects: Assuntos Relacionados
+      related_subjects_1: Assuntos relacionados
+      related_subjects_description: O gráfico mostra os outros assuntos mencionados nas mesmas páginas que o assunto "%{article}". Se o mesmo assunto ocorrer em uma página com "%{article}" mais de uma vez, ele aparecerá mais próximo de "%{article}" no gráfico e será colorido em um tom mais escuro. Quanto mais próximo um assunto estiver do centro, mais "relacionados" serão os assuntos.
+      search_all_pages: Pesquisar todas as páginas
+      search_all_pages_description: Pesquise no texto de %{collection} por páginas que contenham palavras usadas para vincular a <em>%{article}</em>
+      search_unlinked_pages: Pesquisar páginas não vinculadas
+      search_unlinked_pages_description: Pesquise apenas texto de páginas que não estejam vinculadas a <em>%{article}</em>
+      see_also: 'Veja também:'
+      text_search: Pesquisa de texto
     subject_upload:
       csv_file_must_contain_headers: O arquivo CSV deve conter cabeçalhos para HEADING, ARTICLE, URI, and CATEGORY, os quais significam "cabeçalho," "artigo," "Indentificador Universal de Recursos," e "categoria" respectivamente.
+    tooltip:
+      category:
+        one: 'Categoria:'
+        other: 'Categorias:'
+      explore_this_subject: Explorar este assunto
     update:
+      gis_coordinates_truncated:
+        one: " (Coordenadas GIS truncadas para a casa decimal %{precision})"
+        other: " (coordenadas GIS truncadas para %{precision} casas decimais)"
       subject_successfully_updated: O tema foi atualizado com sucesso
       subjects_auto_linking: Processo de auto-ligação dos temas concluído
+    upload_form:
+      browse: Navegar
+      click_to_browse: Clique para procurar um arquivo...
+      csv_file_with: Arquivo CSV com uma linha por assunto
+      example_csv: Exemplo CSV
+      upload: Envio
+      upload_subjects: Carregar assuntos
+      upload_subjects_description: Para criar assuntos de um arquivo de autoridade externa, faça upload de um arquivo %{link}.

--- a/config/locales/article_version/article_version-pt.yml
+++ b/config/locales/article_version/article_version-pt.yml
@@ -1,0 +1,14 @@
+---
+pt:
+  article_version:
+    show:
+      description: Aqui você pode ver todas as revisões de assunto e comparar as mudanças que foram feitas em cada revisão. A coluna da esquerda mostra o título e a descrição do assunto na revisão selecionada, a coluna da direita mostra o que foi alterado. O texto inalterado é <span>destacado em branco</span>, o texto excluído é <del>destacado em vermelho</del> e o texto inserido é <ins>destacado em verde</ins>.
+      n_revisions:
+        one: 1 revisão
+        other: "%{count} revisões"
+      no_description_provided: Nenhuma descrição fornecida
+      no_versions_to_compare: Não há versões para comparar
+      no_versions_to_compare_description: Este assunto não foi descrito, por isso não temos versões de artigos para comparar.
+      revision_changes: Alterações de revisão
+      untitled: Sem título
+      user_at_time: "%{user} em %{time}"

--- a/config/locales/bulk_export/bulk_export-pt.yml
+++ b/config/locales/bulk_export/bulk_export-pt.yml
@@ -1,0 +1,55 @@
+---
+pt:
+  bulk_export:
+    create:
+      export_running_message: Exportação em execução. O e-mail será enviado para %{email} após a conclusão.
+    create_for_work:
+      export_running_message: Exportação em execução. O e-mail será enviado para %{email} após a conclusão.
+    download:
+      download_cleaned_message: Este download de exportação foi limpo. Por favor, inicie um novo.
+    index:
+      actions: Ações
+      collection: 'Coleção:'
+      date: Encontro
+      file_name: 'Nome do arquivo:'
+      show_details: Mostrar detalhes
+      status: Status
+      upload_details: Detalhes do upload
+      user: Do utilizador
+    new:
+      download: Download
+      expanded_plaintext: Texto simples expandido
+      expanded_plaintext_description: Como o texto simples literal, este arquivo de texto simples representará quebras de linha com uma nova linha única, quebras de parágrafo com uma nova linha dupla e quebras de página com uma nova linha tripla. Ele difere do texto literal, pois a normalização será aplicada a todos os assuntos mencionados, de modo que, enquanto o texto literal pode ser "Cumprimentei o Sr. Jones e sua esposa esta manhã.", o texto simples corrigido será "Cumprimentei James Jones e Elizabeth Smith Jones esta manhã”. Este texto artificial é útil para análise programática, mas não deve ser lido por humanos.
+      export_all_works: Exportar todos os trabalhos
+      facing_edition_pdf: Edição de frente para PDF
+      facing_edition_pdf_description: Um arquivo PDF contendo imagens e transcrições em páginas opostas.
+      html: HTML
+      html_description: Isso pode ser útil para preservação em outros sistemas ou como ponto de partida para exibição em outro site.
+      one_file_per_collection: Um arquivo por coleção
+      one_file_per_page: Um arquivo por página
+      one_file_per_work: Um arquivo por obra
+      one_site_per_collection: Um site por coleção
+      previous_exports: Exportações anteriores
+      search_optimized_plaintext: Texto simples otimizado para pesquisa
+      search_optimized_plaintext_description: Uma versão em texto simples do trabalho otimizada para pesquisa de texto completo. Esta versão contém uma transcrição literal de cada página (como descrito acima), exceto que as palavras quebradas por novas linhas hifenizadas são unidas e uma lista dos nomes canônicos mencionados em cada página é anexada ao final da página.
+      start_export: Iniciar exportação
+      static_site: Site estático
+      static_site_description: Um site estático Jekyll contendo a edição inteira
+      status: Status
+      subject_details_csv: Detalhes do assunto CSV
+      subject_details_csv_description: Uma planilha listando cada assunto da coleção
+      subject_index_csv: Índice de assunto CSV
+      subject_index_csv_description: Uma planilha listando cada lugar em que um assunto é mencionado em uma página da coleção
+      table_field_csv: CSV de tabela/campo
+      table_field_csv_description: Exporta uma planilha com dados baseados em campo ou tabulares.
+      tei_xml: XML TEI
+      tei_xml_description: Isso pode ser útil para editores que planejam fazer mais marcação em editores TEI-XML como oXygen.
+      text_docx: Texto DOCX
+      text_docx_description: Um arquivo MS-Word (.docx) contendo transcrições de texto.
+      text_pdf: Texto PDF
+      text_pdf_description: Um arquivo PDF contendo transcrições de texto.
+      time: Tempo
+      verbatim_plaintext: Texto simples literal
+      verbatim_plaintext_description: Este arquivo de texto simples representará quebras de linha com uma nova linha única, quebras de parágrafo com uma nova linha dupla e quebras de página com uma nova linha tripla. Ele conterá o texto literal, com todas as formatações, emendas e links de assuntos removidos.
+      work_metadata_csv: CSV de metadados de trabalho
+      work_metadata_csv_description: Uma planilha listando cada trabalho com contagens de páginas e metadados.

--- a/config/locales/category/category-pt.yml
+++ b/config/locales/category/category-pt.yml
@@ -1,12 +1,21 @@
 ---
 pt:
   category:
+    add_new:
+      create_category: Criar categoria
+      enable_gis: Ativar SIG
+      title: Título
     create:
       category_created: A categoria foi criada
     delete:
       category_deleted: A categoria foi deletada
     disable_gis:
       gis_disabled_for: GIS desativado para %{title}
+    edit:
+      edit_category: Editar categoria
+      enable_gis: Ativar SIG
+      save_changes: Salvar alterações
+      title: Título
     enable_gis:
       gis_enabled_for: GIS ativado para %{title}
     update:

--- a/config/locales/collection/collection-pt.yml
+++ b/config/locales/collection/collection-pt.yml
@@ -1,7 +1,12 @@
 ---
 pt:
   collection:
+    approve_all:
+      approved_n_pages: Páginas %{page_count} aprovadas.
     collection_works:
+      n_pages:
+        one: '1 página:'
+        other: "%{count} páginas:"
       progress: Progresso
       work_title: Título da obra
     contributor_activity:
@@ -30,6 +35,7 @@ pt:
       detailed_spreadsheet_export: Uma planilha detalhada de todos os colaboradores está disponível para exportar no painel de controle do dono.
       export_activity_as_csv: Exportar Atividade em formato .CSV
       export_as_csv: Exportar em formato .CSV
+      find_project_newsletters_recommendations: Encontre recomendações para boletins de projetos.
       new_collaborators: Novos Colaboradores
       no_activity_this_time_frame: Nenhuma atividade neste período de tempo
       no_collaborators: Sem Colaboradores
@@ -44,8 +50,10 @@ pt:
       add_a_new_work: Adicionar uma nova obra
       add_another_work_under: Você pode adicionar uma nova obra em %{start_project}
       add_button: Adicionar
+      alert: Configure os campos ou escolha a transcrição baseada em documento em Tipo de transcrição.
       api_access: Acesso API
       api_access_description: Permitir o acesso a transcrições através de IIIF API
+      authorized_reviewers: Revisores autorizados
       blank_collection: Repor Coleção em Branco
       blank_collection_description: Este botão repõe a coleção num estado em branco. Ele exclui todas as transcrições e outros trabalhos sobre a coleção, como se fosse recentemente importado.
       close_api: Fechar API
@@ -60,19 +68,33 @@ pt:
       collection_privacy: Privacidade da Coleção
       collection_public_message: A coleção pode ser visualizada por qualquer pessoa na Internet. Você pode tornar a coleção privada para restringir a visualização apenas aos donos.
       collection_restricted_message: A coleção só pode ser visualizada pelos donos listados abaixo. Você pode tornar a coleção publicamente acessível.
+      collection_reviewers: Revisores autorizados
+      collection_reviewers_description: Esses usuários poderão revisar e aprovar transcrições, bem como editá-las.
       collection_status: Status da Coleção
+      confirm_blank_collection: Tem certeza?
       confirm_delete_collection: Tem certeza que deseja apagar esta coleção? Depois de apagar não pode ser recuperada!
       current_url: O URL atual desta coleção é %{current_url}. Se quiser editar a parte da obra no URL, por favor use letras minúsculas e traços entre as palavras.
       default_orientation: Selecione a orientação da página predeterminada da transcrição
       delete_collection: Apagar Coleção
       description: Descrição
       disable_document_sets: Desativar Conjuntos de Documentos
+      disable_facets: Desativar facetas
       disable_ocr: Desativar OCR
       document_sets: Conjuntos de Documentos
       document_sets_description: Conjuntos de documentos são subconjuntos das obras desta coleção, que podem ser usados para focar um projeto de edição ou para criar uma exposição pública com um foco particular dos documentos.
+      done: Feito
+      edit_authorized_reviewers: Editar revisores autorizados
+      edit_buttons: Configurar botões
+      edit_collaborators: Editar colaboradores
       edit_fields: Campos
+      edit_metadata_fields: Editar campos
+      edit_owners: Editar proprietários
+      editor_buttons: Botões do Editor
+      editor_buttons_description: Escolha os botões de marcação para aparecer no editor de transcrição.
       enable_document_sets: Ativar Conjuntos de Documentos
+      enable_facets: Ativar facetas
       enable_field_based_transcription: Ativar a Transcrição Baseada em Campos de Formulário
+      enable_metadata_description: Ativar descrição de metadados
       enable_ocr: Ativar OCR
       field_based_transcription: Transcrição baseada em campos de formulário
       footer: Rodapé
@@ -84,6 +106,14 @@ pt:
       make_collection_inactive: Tornar a Coleção Inativa
       make_collection_private: Tornar a Coleção Privada
       make_collection_public: Tornar a Coleção Pública
+      metadata: Metadados
+      metadata_description: Carregue metadados para itens desta coleção em massa.
+      metadata_entry: Descrição de metadados
+      metadata_facets: Facetas de metadados
+      metadata_facets_description: Permitir que os usuários naveguem por obras nesta coleção por meio de metadados.
+      n_contributions:
+        one: 1 contribuição
+        other: "%{count} contribuições"
       no_document_sets_in_collection: Esta coleção não tem nenhum conjunto de documentos.
       no_image: Sem Imagem
       ocr_correction: Correcção de OCR
@@ -97,9 +127,19 @@ pt:
       picture_to_be_used_message: Uma imagem para ilustrar a descrição da coleção.
       remove_collaborator: Remover Colaborador
       remove_owner: Remover Dono
+      remove_reviewer: Remover revisor
+      restrict_completed_works: Restringir trabalhos concluídos
+      restricted_completed_works: Trabalhos Concluídos Restritos
+      restricted_completed_works_description: Este botão restringirá os trabalhos %{work_count} concluídos, mas não restritos atualmente aos proprietários do projeto ou colaboradores designados. Você pode alterar essa configuração e adicionar colaboradores na página de configurações de cada trabalho.
       revert_document_based_transcription: Reverter para a Transcrição Baseada em Documento
+      revert_metadata_description: Desativar descrição
+      review_type: Tipo de revisão
+      review_type_optional: " Opcional: Os colaboradores podem solicitar a revisão de suas transcrições."
+      review_type_required: " Obrigatório: Todas as transcrições iniciais serão marcadas como precisando de revisão. (A revisão pode ser realizada por qualquer pessoa.)"
+      review_type_restricted: " Restrito: Todas as transcrições precisam de revisão e apenas revisores autorizados podem aprovar transcrições."
       save_changes: Guardar Alterações
       start_a_project: Iniciar um Projeto
+      subjects_enabled: Ativar indexação de assunto
       suggestions_help_tab: Sugestões para a sua aba de ajuda.
       suggestions_transcription_conventions: Sugestões para as suas convenções de transcrição.
       text_language: Selecione o idioma da transcrição
@@ -108,20 +148,44 @@ pt:
       transcription_type: Tipo de Transcrição
       transcription_type_description: Cada página pode ter uma área livre de entrada de texto (o padrão) ou vários campos de entrada curtos criados para formulários.  Todas as páginas da coleção têm o mesmo tipo de entrada de texto da transcrição. O ditado de voz não é suportado e será desativado.
       upload_image: Subir Imagem
+      upload_metadata: Carregar metadados
+      url: URL
+      user_download: Permitir que os usuários baixem obras.
       voice_recognition: Voz para texto disponível para a transcrição
+    edit_buttons:
+      description: FromThePage pode suportar marcação em transcrições em formulários TEI-XML ou HTML. Recomendamos configurar no máximo seis botões para aparecer no editor de transcrição. Considere se outros sistemas poderão usar esse tipo de marcação; se apenas texto simples for suportado, os projetos devem usar convenções de tipografia em vez de marcação.
+      heading: Configuração do Editor de Transcrição
+      html: "(HTML)"
+      markup_preference_description: Algumas tags possuem formas equivalentes em HTML e TEI-XML. Escolha uma preferência para determinar qual forma de tag é inserida quando um usuário pressiona o botão.
+      markup_preference_label: Estilo de marcação
+      prefer_html: Prefira HTML
+      prefer_tei: Prefira TEI
+      save: Salvar
+      tei: " (TEI-XML)"
     enable_ocr:
       notice: A correção de OCR foi ativada para todas as obras.
     facet_form:
+      current_filters: Filtros atuais
       filter: Filtro
+      reset_all_filters: Redefinir todos os filtros
+      search: Procurar
     facets:
+      collection_facets_updated_successfully: As facetas da coleção foram atualizadas com sucesso
       field_label: Field Label
       label: Rótulo
       metadata_facets: Facetas de metadados
       metadata_facets_description: Configure as facetas de metadados revisando os metadados em sua coleção e marcando os campos a serem exibidos aos transcritores.
       occurrences: Ocorrências
       order: Ordem
+      translate: Traduzir
       type: Tipo
     indexed: indexado
+    localize:
+      label: Faceta
+      metadata_facets_localize_description: Forneça rótulos específicos de idioma para cada faceta.
+      save: Salvar
+      translate_facets: Traduzir rótulos de atributo
+      translation: Tradução
     needs_review: Precisa ser revisado
     needs_review_pages:
       pages_that_need_review: Páginas para Revisar
@@ -137,20 +201,60 @@ pt:
       enter_collection_title: Para criar uma nova coleção, introduza o título da coleção. No próximo passo você poderá adicionar obras na coleção.
       individual_researcher_limited_account: Uma Conta de Investigador Individual se limita a uma única coleção. Para elevar a sua conta entre em contato com support@fromthepage.com.
       title: Titulo
+    one_off_list:
+      date: Encontro
+      filter_contributions: Filtro
+      no_contributions_need_review: Nenhuma contribuição precisa de revisão
+      one_off_description: Essas contribuições foram feitas por usuários que editaram apenas uma única página. Eles podem precisar de atenção especial.
+      one_off_title: Contribuições únicas
+      review: Análise
+      title: Página (Trabalho)
+      user: Do utilizador
+    quality_sampling: Amostragem de Qualidade
+    recent_contributor_list:
+      date: Data da Primeira Contribuição
+      filter_users: Filtro
+      no_contributions_need_review: Nenhuma contribuição precisa de revisão
+      number_of_contributions: Total de Contribuições
+      recent_contributor_description: Esses colaboradores começaram a trabalhar no projeto recentemente, mas seu trabalho nunca foi revisado.
+      recent_contributor_title: Contribuintes recentes
+      review: Análise
+      user: Do utilizador
+    reviewer_dashboard:
+      one_off_contributions: Contribuições únicas
+      pages_needing_review: Páginas para revisão
+      quality_sampling: Amostragem de Qualidade
+      quality_sampling_desc: As amostras de qualidade permitem que você verifique as contribuições aleatoriamente e avalie as páginas a serem revisadas com base na quantidade de texto corrigido para um determinado usuário ou trabalho.
+      total_page: Página total
+      transcribed_page: Página transcrita
+      unreviewed_contributors: Novos colaboradores
+      works_to_review: Trabalhos para Revisão
     show:
       about: Sobre
       add_a_new_work: Adicionar uma nova obra
       all_complete: Todas as obras estão totalmente transcritas.
+      help_create_metadata: Ajudar!
+      help_transcribe_or_correct: Ajudar!
+      n_pages:
+        one: '1 página:'
+        other: "%{count} páginas:"
+      pages_need_correction: Páginas que precisam de correção
+      pages_need_correction_or_transcription: Páginas que precisam de correção ou transcrição
       pages_need_review: Páginas para Revisar
+      pages_need_transcription: Páginas que precisam de transcrição
       project_by: Projeto por
       recent_edits: Edições Recentes
       recent_notes: Notas Recentes
       search: Buscar
       search_by_title: Buscar por título...
+      search_by_title_1: Pesquisar por título
       search_the_text: Buscar o texto...
+      search_the_text_1: Pesquise o texto
       show_more: Mostrar Mais
       start_transcribing: Iniciar Transcrição
       subject_categories: Categorias de Temas
+      this_work_has_not_been_described: Este trabalho precisa de melhores metadados.
+      this_work_has_pages_that_need_work: Algumas páginas ainda precisam de trabalho.
       time_ago_in_words: Há %{time}
       works: Obras
     start_transcribing:
@@ -159,9 +263,45 @@ pt:
     translated: traduzido
     update:
       notice: A coleção foi atualizada
+    update_buttons:
+      editor_buttons_updated: Botões do editor atualizados
+    upload:
+      acceptable_image_files: Arquivos PNG, GIF e JPG são todos aceitáveis.
+      image_naming_guidelines: 'As imagens devem ser nomeadas para que uma classificação alfabética resulte na ordem correta das páginas.<br> (Isso pode exigir "preenchimento zero" para qualquer número de página: <code>page_09.jpg, page_10.jpg</code> classificará corretamente, mas <code>page_9.jpg, page_10.jpg</code> não.)'
+      image_orientation_guidelines: As imagens devem ser orientadas para que fiquem com o lado certo para cima.
+      page_image_guidelines: Diretrizes de imagem da página
+    user_contribution_list:
+      approve_all: Aprovar tudo
+      date: Encontro
+      email: 'E-mail: %{email}'
+      filter_contributions: Filtro
+      no_contributions: Sem contribuições
+      notes: Notas
+      quality_score: 'Índice de qualidade:'
+      real_name: 'Nome verdadeiro: %{user}'
+      review: Análise
+      title: Página (Trabalho)
+      user_contribution_description: Páginas que precisam de revisão pelo usuário %{user_name}
+      user_profile: Perfil de usuário
     works_list:
       alphabetical: Alfabético
       percent_complete: Percentagem Completa
       recent_activity: Atividade Recente
       sort_works_by: Ordenar Obras por...
       works: Obras
+    works_to_review:
+      and_n_more: e %{n} mais
+      contributors: Contribuintes
+      description: Funciona com páginas que precisam de revisão
+      filter_works: Filtro
+      incomplete: Incompleto
+      last_activity: ultima atividade
+      no_works_need_review: Nenhuma obra precisa de revisão
+      notes: Notas
+      review: Análise
+      title: Título
+      total: Total
+  collection_helper:
+    link:
+      incomplete_works: Trabalhos incompletos
+      show_all: Mostre tudo

--- a/config/locales/contact/contact-pt.yml
+++ b/config/locales/contact/contact-pt.yml
@@ -1,0 +1,24 @@
+---
+pt:
+  contact:
+    form:
+      contact_reason: Motivo do contato
+      contact_us: Contate-nos
+      contact_us_description: Quer mais informações sobre FromThePage? Nos diga como podemos ajudar.
+      email_address: Endereço de email
+      event: Evento
+      first_name: Primeiro nome
+      free_trial: Teste grátis
+      large_institution_quote: Cotação de grande instituição
+      last_name: Sobrenome
+      other: Outro
+      press: Imprensa
+      product_question: Pergunta sobre o produto
+      submit: Enviar
+      tell_us_more: Conte-nos mais sobre seu projeto
+    send_email:
+      get_started_right_away: Comece imediatamente com uma avaliação gratuita do FromThePage.
+      start_free_trial: Iniciar avaliação gratuita
+      thank_you: obrigada
+      thank_you!: Obrigada!
+      will_follow_up: Um membro da equipe irá acompanhá-lo.

--- a/config/locales/dashboard/dashboard-pt.yml
+++ b/config/locales/dashboard/dashboard-pt.yml
@@ -10,11 +10,59 @@ pt:
       recent_activity: Atividade Recente
     create_work:
       work_created: Obra criada com sucesso
+    editor:
+      activity_stream: Fluxo de atividades
+      article_in_the_work: Artigo %{article} na coleção %{collection}
+      page_in_the_work: Página %{page} no trabalho %{work}
+      revision_version: Revisão %{version}
+      view_page: Ver pagina
+      your_recent_article_edits: Suas edições recentes de artigos
+      your_recent_notes: Suas notas recentes
+      your_recent_page_edits: Suas edições recentes de página
+    editor_header:
+      your_projects: Seus projetos
+    empty:
+      add_new_collection: Adicionar nova coleção
+      create_empty_work: Criar trabalho vazio
+      create_empty_work_description: Use esta opção para criar um trabalho vazio. Você pode então carregar imagens de páginas individuais no trabalho.
+      create_work: Criar trabalho
+      description: Descrição
+      select_a_collection: "- Selecione uma coleção -"
+      title: Título
+    exports:
+      bulk_exports_description: Isso lista todas as exportações em massa que você executou. As exportações são limpas após alguns dias e não estão mais disponíveis para download
+      configuration: Configuração (nível)
+      create_bulk_export_description: Crie uma exportação em massa na guia Exportar de uma coleção ou na guia Download de uma obra.
+      date: Data de exportação
+      download: Download
+      exported_item: Coleção/Obra Exportada
+      facing_edition_work: Edição de rosto PDF (trabalho)
+      html_page: HTML (página)
+      html_work: HTML (trabalho)
+      plaintext_emended_page: Texto simples analítico (página)
+      plaintext_emended_work: Texto simples analítico (trabalho)
+      plaintext_searchable_page: Texto simples pesquisável (página)
+      plaintext_searchable_work: Texto simples pesquisável (trabalho)
+      plaintext_verbatim_page: Texto simples literal (página)
+      plaintext_verbatim_work: Texto simples literal (trabalho)
+      refresh: Atualizar
+      reload_this_page_to: Recarregue esta página para atualizar a lista.
+      status: Status
+      subject_csv_collection: Índice de assuntos CSV (coleção)
+      table_csv_collection: Campo/Tabela CSV (coleção)
+      table_csv_work: Campo/Tabela CSV (trabalho)
+      tei_work: TEX-XML (trabalho)
+      text_docx_work: MS Word .docx (trabalho)
+      text_pdf_work: Texto PDF (trabalho)
+      work_metadata_csv: Metadados de trabalho (coleção)
+    guest_header:
+      recent_activity: Atividade recente
     hierarchical_collections_and_document_sets:
       project_by: Projeto de %{author}
       start_transcribing: Iniciar Transcrição
     landing_page:
       all_collections: Todas as Coleções
+      more: Mais...
       next_image: Imagem seguinte
       previous_image: Imagem anterior
       recent_activity: Atividade Recente
@@ -29,10 +77,13 @@ pt:
       acceptable_formats: Os arquivos em formatos PNG, GIF e JPG são todos aceitados.
       images_should_be_named: 'As imagens devem ser nomeadas para que uma ordenação alfabética resulte na ordem de página correta. <br> (Isso pode necessitar o uso de zeros adicionais nos números das páginas: <code>pagina_09.jpg, pagina_10.jpg</code> ficaria na ordem correta, mas <code>pagina_9.jpg, pagina_10.jpg</code> não ficaria.)'
       images_should_be_oriented: As imagens devem ser orientadas de cabeça para cima.
+      import: Importar
       import_a_iiif_manifest_or_collection: Importar um Manifesto ou Coleção IIIF
       import_from_archive_dot_org: Importar de Archive.org
       import_from_contentdm: Importar de CONTENTdm
       import_from_the_internet_archive: Importar de Internet Archive
+      import_many_link: importar vários objetos compostos individuais.
+      or_import_many: Ou
       page_image_guidelines: Regras Gerais das Imagens da Página
       paste_in_the_url: Cole o URL de um objeto composto na sua página web de CONTENTdm.
     owner:
@@ -48,19 +99,40 @@ pt:
       you_dont_have_any_collections: Você ainda não tem nenhuma coleção.
       your_activity: Sua Atividade
     owner_header:
+      account_type: conta %{type}
+      actions: Ações
+      collection:
+        one: Coleção
+        other: Coleções
       create_a_collection: Criar uma Coleção
+      current_subscription_expires: A assinatura atual expira %{date}
+      document_set:
+        one: Conjunto de documentos
+        other: Conjuntos de documentos
+      exports: Exportações
       owner_dashboard: Painel de Controle do Dono
+      since: desde %{date}
       start_a_project: Iniciar um Projeto
       summary: Resumo
+      to_upgrade_contact: Para atualizar, entre em contato com support@fromthepage.com
+      total_pages: 'Total de páginas: %{pages}'
+      work:
+        one: Trabalhar
+        other: Funciona
       your_collections: Suas Coleções
     upload:
+      acceptable_image_files: Arquivos PNG, GIF e JPG são todos aceitáveis.
       browse: Navegar
       click_to_browse_a_file: Clique para navegar num arquivo...
       click_to_browse_files: Clique para navegar nos arquivos
       each_folder_will_be_treated: Cada pasta será tratada como um documento diferente, por isso não misture páginas de documentos diferentes na mesma pasta.
       each_pdf_will_be_treated: Cada PDF será tratado como seu próprio documento, por isso não divida páginas do mesmo documento entre mais de um PDF.
       for_example_a_zip_file: 'Por exemplo, um arquivo ZIP com 3 imagens, 2 PDFs, e uma pasta contendo 5 imagens adicionais criaria 4 obras: as imagens de nível superior em um, cada PDF em sua própria obra, e uma última obra contendo as 5 imagens adicionais da pasta.'
+      image_naming_guidelines: 'As imagens devem ser nomeadas para que uma classificação alfabética resulte na ordem correta das páginas.<br> (Isso pode exigir "preenchimento zero" para qualquer número de página: <code>page_09.jpg, page_10.jpg</code> classificará corretamente, mas <code>page_9.jpg, page_10.jpg</code> não.)'
+      image_orientation_guidelines: As imagens devem ser orientadas para que fiquem com o lado certo para cima.
       import_form_message: Usando este formulário, você pode importar as suas imagens de página para FromThePage. Você deve selecionar uma coleção de destino para importar e anexar um arquivo ZIP ou PDF contendo imagens de página para o seu projeto.
+      page_image_guidelines: Diretrizes de imagem da página
+      select_a_collection: "- Selecione uma coleção -"
       to_specify_metadata: Para indicar os meta-dados juntamente com as imagens, inclua um %{link} arquivo em cada pasta que indique os campos para a obra.
       trial_accounts_are_limited: As contas de teste estão limitadas a 200 páginas. Por favor entre em contato com support@fromthepage.com para elevar a sua conta.
       upload_file: Subir arquivo

--- a/config/locales/deed/deed-pt.yml
+++ b/config/locales/deed/deed-pt.yml
@@ -1,6 +1,10 @@
 ---
 pt:
   deed:
+    article_edit: Artigo editado
+    collection_active: Coleção ativa
+    collection_inactive: Coleção inativa
+    collection_joined: Coleção associada
     deed:
       html:
         added_a_note_to_page: adicionou uma nota à página %{page}
@@ -26,6 +30,8 @@ pt:
     deeds:
       show_more: Mostrar Mais
       time_ago_in_words: Há %{time}
+    described_metadata: Metadados Descritos
+    edited_metadata: Descrição de metadados editada
     list:
       activity_stream: Fluxo de Atividade
       collection_title: 'Coleção: %{title}'
@@ -33,3 +39,17 @@ pt:
       older_activity: Atividade Mais Antiga
       time_ago_in_words: Há %{time}
       user_title: 'Usuário: %{title}'
+    needs_review: A página precisa de revisão
+    note_added: Nota adicionada
+    ocr_corrected: OCR de página corrigido
+    page_edit: Página editada
+    page_indexed: Página indexada
+    page_marked_blank: Página marcada em branco
+    page_reviewed: Página revisada
+    page_transcription: Página transcrita
+    page_translated: Página traduzida
+    page_translation_edit: Página de tradução editada
+    translation_indexed: Página de tradução indexada
+    translation_review: A página de tradução precisa de revisão
+    translation_reviewed: Tradução revisada
+    work_added: Trabalho adicionado

--- a/config/locales/devise/devise-pt.yml
+++ b/config/locales/devise/devise-pt.yml
@@ -1,6 +1,10 @@
 ---
 pt:
   devise:
+    confirm_password: Confirme a Senha
+    create_account: Criar uma conta
+    display_name: Nome em Exibição
+    email_address: Endereço de email
     failure:
       already_authenticated: Você já entrou na sua conta.
       inactive: A sua conta ainda não foi ativada.
@@ -8,27 +12,94 @@ pt:
       not_found_in_database: "%{authentication_keys} ou senha inválidos."
       timeout: A sua sessão expirou. Por favor, entre na sua conta novamente para continuar.
       unauthenticated: Você tem que entrar na sua conta ou se inscrever numa conta antes de continuar.
+    login: Conecte-se
     mailer:
       reset_password_instructions:
+        change_my_password: Mudar minha senha
+        greeting: Olá %{email}!
+        message_1: 'Alguém solicitou um link para alterar sua senha. Você pode fazer isso através do link abaixo:'
+        message_2: Se você não solicitou isso, ignore este e-mail.
+        message_3: Sua senha não será alterada até que você acesse o link acima e crie uma nova.
         subject: Instruções para redefinir a senha
     omniauth_callbacks:
       failure: Não foi possível autenticar você com %{kind} porque "%{reason}".
       success: Foi autenticado com sucesso a partir da conta de %{kind}.
+    password: Senha
     passwords:
+      edit:
+        change_password: Mudar senha
+        change_password_message: Crie uma nova senha para sua conta. A senha deve ter pelo menos 8 caracteres e conter letras e números. Por favor, não use a mesma senha que você usa para seu banco online ou conta de e-mail!
+        new_password: Nova Senha
+      new:
+        message: Insira o endereço de e-mail associado à sua conta FromThePage. Se o seu endereço de e-mail existir em nosso banco de dados, você receberá um link de recuperação de senha em seu endereço de e-mail em alguns minutos.
+        password_recovery: Recuperação de senha
+        recover_password: Recuperar senha
       no_token: Você não pode acessar esta página sem utilizar o link enviado através de um email de redefinição de senha. Se você utilizou um link enviado através de um email de redefinição de senha, por favor, certifique-se que você usou o URL completo fornecido.
       send_instructions: Você receberá um e-mail com instruções para redefinir a sua senha em poucos minutos.
       send_paranoid_instructions: Se o seu endereço de e-mail existe em nossa base de dados, você receberá um link de recuperação de senha no seu e-mail em poucos minutos.
       updated: A sua senha foi alterada com sucesso. Você já entrou na sua conta.
       updated_not_active: A sua senha foi alterada com sucesso.
+    real_name: Nome real
+    real_name_message: Os projetos podem usar isso ao dar crédito a você. Deixe em branco se não quiser ser creditado.
+    receive_activity_emails: Receba e-mails de atividades
     registrations:
+      choose_saml:
+        harvard_university: Universidade de Harvard
+        institution: Instituição
+        lds_full_name: Igreja de Jesus Cristo dos Santos dos Últimos Dias
+        sign_in_with_institution: Faça login com sua instituição
       destroyed: Tchau! A sua conta foi cancelada com sucesso. Esperamos voltar a ver você em breve.
+      edit:
+        confirm_delete_account: Tem certeza de que deseja excluir sua conta? Depois de excluir a conta, você não poderá recuperá-la!
+        current_password: Senha atual
+        delete_account: Deletar conta
+        edit_account: Editar conta
+        message: Aqui você pode alterar as informações da sua conta. Se você não quiser alterar sua senha, deixe os campos de senha em branco. Você é obrigado a digitar sua senha atual para confirmar as alterações.
+        new_password: Nova Senha
+        save_changes: Salvar alterações
+        waiting_confirmation_message: Atualmente aguardando confirmação para %{resource}
+      new_trial:
+        fill_in_the_following: Por favor, preencha as seguintes informações para criar uma avaliação de duzentas páginas
+        just_want_to_transcribe: Quer apenas transcrever? %{sign_up_here}
+        login: Conecte-se
+        message: Preencha as informações a seguir para criar uma conta de proprietário do projeto FromThePage de avaliação de duzentas páginas. Tem perguntas? %{schedule_a_kickoff_call}
+        project_owner_account_have: Conta do proprietário do projeto FromThePage. Tem perguntas?
+        schedule_a_kickoff_call: Agende uma chamada inicial.
+        sign_up_for_trial: Inscreva-se para um teste
+        sign_up_here: Assine aqui
+        want_to_transcribe: quer transcrever?
+      owner_new:
+        projects_may_use_this: Os projetos podem usar isso ao dar crédito a você. Deixe em branco se não quiser ser creditado.
+        you_ll_use_this: Você usará esse nome para fazer login. Ele será exibido publicamente.
       signed_up: Bem-vindo! A sua conta foi criada com sucesso.
       updated: A sua conta foi atualizada com sucesso.
       updated_but_not_signed_in: Sua conta foi atualizada com sucesso, mas como sua senha foi alterada, você precisa entrar novamente
     sessions:
       already_signed_out: Saiu com sucesso.
+      new:
+        forgot_your_password: Esqueceu sua senha?
+        or: ou
+        remember_me: " Lembre de mim"
+        sign_in_with_institution: Faça login com sua instituição (SSO)
+        sign_up_as_transcriber_message: Quer participar de um projeto existente como transcritor? Inscreva-se como um transcritor.
+        sign_up_now: Inscreva-se agora
+        start_free_trial: Iniciar avaliação gratuita
+        start_free_trial_message: Quer começar um novo projeto de transcrição? Inicie um teste gratuito.
       signed_in: Entrou com sucesso.
       signed_out: Saiu com sucesso.
+    shared:
+      links:
+        forgot_your_password: Esqueceu sua senha?
+        no_confirmation_instructions: Não recebeu as instruções de confirmação?
+        no_unlock_instructions: Não recebeu instruções de desbloqueio?
+        sign_in_existing_account: Faça login na conta existente
+        sign_in_with_google: Faça login no Google
+        sign_in_with_institution: Faça login com sua instituição (SSO)
+        sign_up_new_account: Registe-se para uma nova conta
+    sign_in: Entrar
+    sign_up: Inscrever-se
+    user_name: Nome de usuário
+    user_name_message: Você usará esse nome para fazer login. Ele será exibido publicamente.
   errors:
     messages:
       expired: expirou, por favor solicite um novo

--- a/config/locales/display/display-pt.yml
+++ b/config/locales/display/display-pt.yml
@@ -4,7 +4,11 @@ pt:
     display_page:
       collaboration_is_restricted: A colaboração é restrita para esta coleção. Por favor, entre em contato com o dono do projeto se você deseja ajudar a transcrever.
       collection_is_not_active: Este projeto não está ativo. Entre em contato com o proprietário do projeto em caso de dúvidas.
+      corrected: corrigido
       facsimile: Fac-símile
+      help_correct: ajudar a corrigir
+      help_transcribe: ajude a transcrever
+      help_translate: ajude a traduzir
       mark_the_page_blank: marcar a página como em branco
       or_mark_blank: "<br>ou %{mark_ blank}"
       page_notes: Notas da Página
@@ -13,10 +17,18 @@ pt:
       show_translation: Mostrar Tradução
       this_page_is_blank: Esta página está em branco
       this_page_is_not: Esta página não é %{text_type}
+      transcribed: transcrito
       transcription: Transcrição
+      translated: traduzido
       translation: Tradução
     list_pages:
       actions: Ações
+      blank_page: Página em branco
+      completed: Concluído
+      correct: Correto
+      describe: Descrever
+      index: Índice
+      metadata: Metadados
       n_notes:
         one: 1 nota
         other: "%{count} notas"
@@ -24,9 +36,14 @@ pt:
       no_pages_found: Nenhuma página encontrada
       no_pages_in_work: Esta obra ainda não contém nenhuma página; vá para %{link} para criar uma nova página
       page_title: Título da Página
+      pages_tab: Guia de páginas
+      review: Análise
+      transcribe: Transcrever
+      translate: Traduzir
       user_notes: Notas do Usuário
     multi_page:
       categories: Categorias
+      describe: Criar metadados
       pages_need_indexing: Páginas para Indexar
       pages_need_review: Páginas para Revisar
       pages_need_transcription: Páginas para Transcrever
@@ -34,18 +51,36 @@ pt:
       search: Buscar
       search_for: Buscar por %{search_string}
       search_in_collection: Buscar na coleção...
+      search_in_collection_1: Pesquisar na coleção
       translations_need_indexing: Traduções para Indexar
       translations_need_review: Traduções para Revisar
       view_all_pages: Ver Todas as Páginas
     pages_view:
       collaboration_is_restricted: A colaboração é restrita para esta coleção. Por favor, entre em contato com o dono do projeto se você deseja ajudar a transcrever.
       corrected: corrigiu
+      help_complete: Edite essa página
+      help_correct: ajudar a corrigir
       help_transcribe: Por favor, ajude a transcrever
       help_translate: ajudar a traduzir
       last_edit: Última edição há %{edit_time} por %{user_link}
       no_pages_found: Nenhuma página encontrada
+      no_pages_needing_transcription_found_these_pages_are_incomplete: Nenhuma página precisa de transcrição do zero. Estas páginas foram parcialmente transcritas, mas precisam ser completadas.
       page_not_translated: Esta página não está traduzida, por favor %{help_translate} esta página
+      pages_needing_completion: Páginas que precisam de conclusão
+      pages_that_need_transcription: Páginas que precisam de transcrição
+      review_metadata: Revisar metadados
       this_page_is_blank: Esta página está em branco
+      this_page_is_incomplete: Esta página está incompleta
       this_page_is_not: Esta página não está %{status}, por favor %{help} esta página
       transcribed: transcreveu
+      translation: Tradução
       unable_to_find_pages: Não conseguimos encontrar nenhuma página correspondente ao seu pedido
+  display_helper:
+    page_action:
+      blank_page: Página em branco
+      completed: Concluído
+      correct: Correto
+      index: Índice
+      review: Análise
+      transcribe: Transcrever
+      translate: Traduzir

--- a/config/locales/document_sets/document_sets-pt.yml
+++ b/config/locales/document_sets/document_sets-pt.yml
@@ -8,6 +8,8 @@ pt:
       description: Descrição
       document_is_marked_public: Se o conjunto de documentos está marcado como público, as obras colocadas dentro dele serão acessíveis mesmo que a coleção seja marcada como privada.
       save_document_set: Guardar o Conjunto de Documentos
+      title: Título
+      url: URL
     index:
       actions: Ações
       aggregating_works_thematic_exhibits: Agregar obras em exposições temáticas
@@ -19,6 +21,9 @@ pt:
       document_sets_for: Conjuntos de Documentos para %{título}
       edit: Editar
       focusing_transcriber_effort: Focar os esforços dos transcritores em um grupo específico de obras.
+      n_pages:
+        one: '1 página:'
+        other: "%{count} páginas:"
       no_document_sets: Esta coleção não contem conjuntos de documentos
       privacy: Privacidade
       private: Privado
@@ -27,15 +32,23 @@ pt:
       save: Guardar
       search: Buscar
       search_for_works: Buscar obras...
+      status: Status
       title: Titulo
+      toggle_work_in_document_set: Alternar %{work} no conjunto de documentos %{document_set}
+      transfer_works: Trabalhos de Transferência
       work: Obra
     new:
       create_document_set: Criar Conjunto de Documentos
       create_new_document_set: Criar Novo Conjunto de Documentos
       description: Descrição
       document_set_is_marked_public: Se o conjunto de documentos está marcado como público, as obras colocadas dentro dele serão acessíveis mesmo que a coleção seja marcada como privada.
+      public: Público
+      title: Título
     set_works:
       collaboration: Colaboração
+      n_pages:
+        one: '1 página:'
+        other: "%{count} páginas:"
       progress: Progresso
       remove_from_set: Remover do conjunto
       remove_title_from_document_set: Remover %{title} do Conjunto de Documentos
@@ -58,13 +71,35 @@ pt:
       make_document_set_private: Tornar o Conjunto de Documentos Privado
       make_document_set_public: Tornar o Conjunto de Documentos Público
       manage_works: Controlar Obras
+      n_contributions:
+        one: 1 contribuição
+        other: "%{count} contribuições"
+      n_pages:
+        one: '1 página:'
+        other: "%{count} páginas: pl"
       no_image: Sem Imagem
       picture_document_set_description: Uma imagem para ilustrar a descrição do conjunto de documentos.
       remove: Remover
       save: Guardar
       search: Buscar
       search_for_works: Buscar obras...
+      status: Status
       upload_image: Subir Imagem
       work: Obra
+    transfer:
+      source_and_target_can_not_be_the_same: Origem e destino não podem ser iguais.
+    transfer_form:
+      all: Todas as obras
+      cancel: Cancelar
+      completed: Apenas obras concluídas
+      copy: Copiar (não cria trabalhos duplicados)
+      move: Jogada
+      source_set: Conjunto de documentos de origem
+      status_filter: O que funciona
+      target_set: Conjunto de documentos de destino
+      transfer: Transferir
+      transfer_type_label: Tipo de transferência
+      transfer_works: Trabalhos de Transferência
+      transfer_works_description: A transferência funciona entre conjuntos de documentos. (A cópia colocará o mesmo trabalho em dois conjuntos de documentos ao mesmo tempo.)
     update:
       document_updated: O documento foi atualizado

--- a/config/locales/export/export-pt.yml
+++ b/config/locales/export/export-pt.yml
@@ -5,7 +5,14 @@ pt:
       connect: Conectar
       contentdm_credentials: Credenciais do CONTENTdm
       contentdm_credentials_description: Insira sua chave de licença do CONTENTdm e suas credenciais de login para exportar para o CONTENTdm
+      contentdm_password: senha do CONTENTdm
+      contentdm_user_name: nome de usuário do CONTENTdm
+      license_key: Chave de licença
+    facing_edition:
+      contributions_message: 'Este documento não seria possível sem as contribuições editoriais das seguintes pessoas:'
+      export_metadata: Exportação FromThePage de %{work} de %{collection} feita em %{time}.
     index:
+      api: API
       export_all_table_data_as_csv: Exportar todas as tabelas como CSV
       export_all_tables: Exportar todas as tabelas
       export_all_tables_description: Clique no botão para exportar os dados da tabela de toda a coleção em um único arquivo CSV. Observe que o processo de exportação pode levar algum tempo para ser concluído, portanto, aguarde até obter a caixa de diálogo Salvar arquivo.
@@ -26,14 +33,23 @@ pt:
       export_work_metadata: Exportar metadados de trabalho
       export_work_metadata_as_csv: Exportar metadados de trabalho como CSV
       export_work_metadata_description: Exporte uma planilha contendo uma linha para cada obra da coleção, com colunas para estatísticas sobre as páginas transcritas e metadados da obra.
+      here: aqui
+      html: HTML
+      iiif: IIIF
       iiif_api_description: Também temos uma API baseada em IIIF para exportar transcrições de forma programática de suas coleções. Saber mais %{link}
       iiif_collection_api_endpoint: 'IIIF Collection API Endpoint: %{link}'
       indexed: Indexado
+      more: Mais
+      more_export_formats: Formatos de exportação adicionais
+      n_pages:
+        one: 1 página
+        other: "%{count} páginas"
       pages: Páginas
       plain_text: texto simples
       progress: Progresso
       review: Análise
       table_csv: Tabela CSV
+      tei: TEI
       work_title: Título de trabalho
     show:
       categories: 'Categorias:'

--- a/config/locales/ia/ia-pt.yml
+++ b/config/locales/ia/ia-pt.yml
@@ -2,11 +2,44 @@
 pt:
   ia:
     confirm_import:
+      book_already_imported_description: 'As obras listadas abaixo podem ter sido importadas da mesma fonte:'
+      book_already_imported_warning: 'Aviso: Este livro pode já ter sido importado!'
+      book_was_imported: Livro de arquivo da Internet "%{book}"; foi importado por %{user} em %{date}
+      cancel_import: Cancelar importação
+      import_anyway: Importar mesmo assim
+      import_from_archive_org: Importar do Archive.org
+      not_converted_into_work: mas não foi convertido em um trabalho FromThePage.
       please_enter_valid_url: Introduza um URL válido de um livro de Archive.org para importar
+      was_converted_into_work: e foi convertido em trabalho FromThePage
     convert:
       converted_to_work: "%{title} foi convertido numa obra de FromThePage"
+    ia_book_form:
+      book_url: URL do livro
+      import_book_description: Para importar um livro, abra este livro em www.archive.org e copie o URL do livro da barra de endereços do navegador e cole-o abaixo.
+      import_from_archive_org: Importar do Archive.org
+      import_work: Importar Trabalho
     import_work:
       imported_into_staging: "%{title} foi importado para a sua área de preparação"
+    manage:
+      actions: Ações
+      book_imported_description: Este livro foi importado do Internet Archive, mas ainda não foi convertido em uma obra. Abaixo você vê a lista de páginas importadas e seu texto OCR. Use o menu de ações para definir a primeira página (ocultar todas as páginas anteriores) e a última página (ocultar todas as páginas seguintes). Você também pode gerenciar os títulos das páginas do texto OCR e, finalmente, converter essa importação em um trabalho publicando-o em uma coleção. Para obter mais informações sobre esta tela, consulte o artigo Wiki <a href="https://github.com/benwbrum/fromthepage/wiki/Importing-Works-from-the-Internet-Archive" target="_blank">Importing Works do Arquivo da Internet</a>.
+      conceal_following_pages: Ocultar as páginas seguintes
+      conceal_preceding_pages: Ocultar páginas anteriores
+      first_line_of_ocr: Primeira linha de OCR
+      first_line_of_ocr_description: "<b>Primeira linha do OCR</b> substitui os títulos das páginas pela linha superior do texto OCR em cada página. Isso é útil para diários e diários, já que a primeira linha geralmente é uma data."
+      last_line_of_ocr: Última linha do OCR
+      last_line_of_ocr_description: "<b>Última linha do OCR</b> substitui os títulos das páginas pela linha inferior do texto OCR em cada página. Isso é útil para trabalhos impressos nos quais os números de página aparecem na parte inferior."
+      manage_archive_org_import: Gerenciar importação do Archive.org
+      ocr_for_page_contents: Usar texto OCR para o conteúdo da página?
+      ocr_for_page_contents_description: Marque esta caixa de seleção para preencher a transcrição inicial de cada página com o conteúdo do OCR correspondente. (Não faça isso se suas páginas contiverem caligrafia que você deseja que seja transcrita.)
+      ocr_page_titles_description: Esse processo levará vários segundos para ser executado, pois requer a análise de todo o texto OCR do livro e a atualização de cada título de página. Depois que o livro for convertido em um trabalho FromThePage, você poderá corrigir os títulos das páginas manualmente.
+      page_n_of_n: Página %{n} de %{total} (%{n2})
+      page_titles: Títulos de página
+      publish_to_collaborators: Publicar para colaboradores
+      publish_work: Publicar trabalho
+      publish_work_description: Assim que tiver os títulos e as folhas prontas, clique em Publicar para converter o livro em um trabalho FromThePage pronto para transcrição. Esse processo levará vários minutos para ser executado.
+      select_a_collection: "- Selecione uma coleção -"
+      select_a_collection_1: Selecione uma coleção
     mark_beginning:
       preceding_the_beginning: As páginas que precedem o início do texto foram escondidas
     mark_end:

--- a/config/locales/layouts/application-pt.yml
+++ b/config/locales/layouts/application-pt.yml
@@ -11,11 +11,21 @@ pt:
       create_an_account: Criar uma Conta
       documentation: Documentação
       find_a_project: Buscar um Projeto
+      home: Casa
+      internet_archive_difficulties: O Internet Archive está passando por dificuldades. Por favor, tente novamente mais tarde.
       owner_dashboard: Painel de Controle do Dono
+      pricing: Preços
       privacy_policy: Política de Privacidade
       projects: Projetos
+      recaptcha_validation_failed: Falha na validação do ReCAPTCHA
       sign_in: Entrar
       sign_out: Sair
+      sign_up_to_transcribe: Inscreva-se para transcrever
+      signed_in_as: Assinado como
       terms_and_conditions: Termos e Condições
+      transcription_for_archives_special_collections: Transcrição para Arquivos e Coleções Especiais
+      transcription_for_digital_scholarship: Transcrição para bolsa digital
+      transcription_for_linguists: Transcrição para linguistas
+      transcription_for_state_provincial_archives: Transcrição para Arquivos Estaduais e Provinciais
       undo_login_as: Desfazer o Login Como
       your_profile: Seu Perfil

--- a/config/locales/metadata/metadata-pt.yml
+++ b/config/locales/metadata/metadata-pt.yml
@@ -1,0 +1,10 @@
+---
+pt:
+  metadata:
+    upload:
+      browse: Navegar
+      click_to_browse_a_file: Clique para procurar um arquivo...
+      template_file_anchor: este arquivo de modelo
+      upload: Envio
+      upload_metadata: Carregar metadados
+      upload_metadata_description: Para atualizar os metadados de várias obras desta coleção, carregue uma planilha com uma linha por obra. Faça o download do %{link} para começar.

--- a/config/locales/notes/notes-pt.yml
+++ b/config/locales/notes/notes-pt.yml
@@ -27,6 +27,7 @@ pt:
       note_body: Corpo da nota
       please_sign_in_to_write: Por favor %{link} para escrever uma nota para esta página
       save_note: Guardar Nota
+      sign_in: entrar
       write_a_new_note: Escrever uma nova nota...
     update:
       error_updating_note: Erro ao atualizar a nota

--- a/config/locales/page/page-pt.yml
+++ b/config/locales/page/page-pt.yml
@@ -15,10 +15,20 @@ pt:
       here_you_can_edit: Aqui você pode editar o título da página e subir uma nova imagem. Se quiser editar a transcrição da página ou o texto da tradução, por favor vá para a aba apropriada acima.
       page_image: Imagem da Página
       page_position: 'Posição da Página: %{position}'
+      page_status: Status da página
+      page_status_: não foi iniciado
+      page_status_blank: Página em branco
+      page_status_incomplete: Incompleto
+      page_status_indexed: Indexado
+      page_status_review: Precisa de revisão
+      page_status_transcribed: Completo
+      page_status_translated: Traduzido
       page_title: Título da Página
+      page_translation_status: Status da tradução da página
       rotate_clockwise: Girar Sentido Horário
       rotate_counterclockwise: Girar Sentido Anti-Horário
       save_changes: Guardar Alterações
+      status: 'Status:'
     new:
       add_new_page: Adicionar Página Nova
       browse: Navegar
@@ -28,5 +38,6 @@ pt:
       page_image: Imagem da Página
       save_and_add_next_page: Guardar & Adicionar Página Seguinte
       save_and_new_work: Guardar & Nova Obra
+      title: Título
     update:
       page_updated: Esta página foi atualizada

--- a/config/locales/page_version/page_version-pt.yml
+++ b/config/locales/page_version/page_version-pt.yml
@@ -8,3 +8,7 @@ pt:
       n_revisions:
         one: 1 revisão
         other: "%{count} revisões"
+      no_transcription_provided: Nenhuma transcrição fornecida
+      no_translation_provided: Nenhuma tradução fornecida
+      translation: Tradução
+      untitled: Sem título

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,5 +1,6 @@
 ---
 pt:
+  authentication_failed: Falha na autenticação
   dashboard:
     collaborator: Painel de Controle do Colaborador
     plain: Painel de Controle
@@ -15,3 +16,4 @@ pt:
       default: "%d de %b de %Y, %H:%M"
       short: "%d/%m/%Y às %H:%M"
   time_ago_in_words: Há %{time}
+  unauthorized_collection: Você não tem acesso a %{project}. Faça login ou entre em contato com o proprietário do projeto para ser adicionado.

--- a/config/locales/quality_samplings/quality_samplings-pt.yml
+++ b/config/locales/quality_samplings/quality_samplings-pt.yml
@@ -1,0 +1,42 @@
+---
+pt:
+  quality_samplings:
+    destroy:
+      quality_sampling_destroyed: A amostragem de qualidade foi destruída com sucesso.
+    index:
+      description: A amostragem de qualidade permite que você verifique as contribuições, coletando dados sobre a qualidade à medida que você revisa cada contribuição.
+      new_sampling: Iniciar amostragem
+    show:
+      actions: Ações
+      approval_delta_display_0: Muito baixo
+      approval_delta_display_1: Baixo
+      approval_delta_display_2: Média
+      approval_delta_display_3: Alto
+      approval_delta_display_4: Muito alto
+      description: A amostragem de qualidade permite que você verifique as contribuições aleatoriamente e avalie as páginas a serem revisadas com base na quantidade de texto corrigido para um determinado usuário ou trabalho. Esse número pode crescer à medida que mais páginas são transcritas.
+      not_applicable: N / D
+      not_fully_sampled_yet: Esta amostra ainda não foi totalmente revisada.
+      pages_corrected: Páginas corrigidas
+      pages_corrected_desc: Páginas que exigiram correção durante a aprovação (baixa é melhor).
+      pages_in_sample: Páginas na amostra
+      pages_in_sample_desc: Número de páginas na amostra para o usuário ou trabalho.
+      pages_sampled: Páginas amostradas
+      pages_sampled_desc: Número de páginas amostradas até agora do campo total da amostragem.
+      pages_to_be_reviewed: Páginas para revisão
+      pages_to_be_reviewed_desc: Número de páginas que ainda precisam de revisão em toda a coleção.
+      quality_score: Índice de qualidade
+      quality_score_desc: Porcentagem média de mudanças necessárias durante a aprovação.
+      relative_corrections: Correções relativas
+      relative_corrections_desc: Quantas correções foram necessárias antes da aprovação, em relação a outros usuários nesta amostra?
+      review: Análise
+      review_url: URL de revisão
+      review_url_desc: URL que permitirá que os revisores aprovem contribuições diretamente, sem exibir esta tela.
+      sample: Amostra de Revisão
+      sample_field_size: 'Páginas a serem revisadas:'
+      sample_set_has_increased: O conjunto de amostras aumentou em %{increase} páginas
+      sample_set_size: 'Tamanho do conjunto de amostra:'
+      total_pages_desc: Número de páginas nesta coleção.
+      user: Contribuinte
+      work: Trabalhar
+    update:
+      quality_sampling_updated: A amostragem de qualidade foi atualizada com sucesso.

--- a/config/locales/sc_collections/sc_collections-pt.yml
+++ b/config/locales/sc_collections/sc_collections-pt.yml
@@ -1,8 +1,45 @@
 ---
 pt:
   sc_collections:
+    cdm_bulk_import_create:
+      import_started: Sua importação foi iniciada. Quando estiver concluído, você deverá receber um e-mail em %{email}.
+    cdm_bulk_import_new:
+      bulk_contentdm_import: Importação de CONTENTdm em massa
+      compound_object_urls: URLs de objetos compostos
+      import: Importar
+      import_ocr_text: Importar texto OCR do CONTENTdm
+      select_a_collection_to_import_into: "- Selecione uma coleção para importar -"
+      separate_urls_with: URLs separados com espaços ou novas linhas.
     convert_manifest:
       metadata_is_being_imported: Os meta-dados %{ocr_ text} estão sendo importados do CONTENTdm e deverão aparecer em breve.
+    explore_collection:
+      already_imported_into: Já importado para
+      collection: 'Coleção: %{sc_collection}'
+      collections: 'Coleções:'
+      first_page: Primeira página
+      id: 'Código: %{id}'
+      import_checked_manifests: Importar manifestos verificados
+      import_ocr_text: Importar texto OCR do CONTENTdm
+      manifests: 'Manifestos:'
+      next_page: Próxima página
+      no_label: sem rótulo
+      previous_page: Página anterior
+      select_a_collection: Selecione uma coleção
+      select_a_collection_to_import_into: "- Selecione uma coleção para importar -"
+      select_all_manifests: Selecionar todos os manifestos
+      this_collection_is_divided: Esta coleção está dividida em várias páginas
+    explore_manifest:
+      canvases: 'Telas:'
+      collection: 'Coleção: %{sc_collection}'
+      description: 'Descrição: %{description}}'
+      id: 'Identidade:'
+      import_manifest: Importar Manifesto
+      import_ocr_text: Importar texto OCR do CONTENTdm
+      license: 'Licença: %{license}'
+      manifest: 'Manifesto: %{sc_manifest}}'
+      metadata: 'Metadados: %{metadata}}'
+      select_a_collection_to_import_into: "- Selecione uma coleção para importar -"
+      select_a_collection_to_import_into_label: Selecione uma coleção para importar
     import:
       no_manifest_exist: Não existe qualquer manifesto do IIIF para o item de CONTENTdm %{url}
       please_enter_valid_url: Por favor introduza um URL válido para o manifesto do IIIF.

--- a/config/locales/shared/shared-pt.yml
+++ b/config/locales/shared/shared-pt.yml
@@ -4,6 +4,7 @@ pt:
     article_tabs:
       overview: Resumo
       settings: Configurações
+      subject: sujeito
       versions: Versões
     codemirror:
       abbr_description: Marca as abreviações em um texto com expansões no atributo expan.
@@ -25,7 +26,9 @@ pt:
     collection_tabs:
       add_work: Adicionar Obra
       collaborators: Colaboradores
+      collection: coleção
       edit_fields: Campos
+      edit_metadata_fields: Campos de metadados
       export: Exportar
       facets: Facetas
       overview: Resumo
@@ -35,17 +38,51 @@ pt:
       statistics: Estatisticas
       subjects: Temas
       works_list: Lista de Obras
+    description_tabs:
+      describe: Metadados
+      help: Ajuda
+      metadata: Metadados
+      nav_info: Trabalho %{position} de %{size}
+      next_page: Próxima página
+      next_work: Próximo trabalho
+      overview: Visão geral
+      previous_page: Página anterior
+      previous_work: Trabalho prévio
+      versions: Versões
     handsontable:
       date_tooltip: As datas devem ser formatadas AAAA-MM-DD (ano de quatro dígitos, mês de dois dígitos, dia de dois dígitos, com hifens entre eles).
+    markup_help:
+      markup_help_description: '"Autolink" sugerirá assuntos aos quais certas palavras podem ser vinculadas ou você pode usar chaves duplas para vincular assuntos. <code>[[Jane Doe]]</code> vinculará o texto "Jane Doe" ao assunto Jane Doe, enquanto <code>[[Jane Doe|Jane]]</code> vinculará o texto "Jane" ao assunto Jane Doe. Recomendamos que o link seja deixado para um editor após a transcrição inicial.'
+    osd_div:
+      brightness: Brilho
+      contrast: Contraste
+      full_page: Alternar página inteira
+      home: Ir para casa
+      image_filters: Filtros de imagem
+      open_seadragon_needs_js: O OpenSeadragon não está disponível a menos que o JavaScript esteja ativado.
+      rotate_left: Vire à esquerda
+      rotate_right: Vire à direita
+      threshold: Limite
+      zoom_in: Mais Zoom
+      zoom_out: Reduzir o zoom
     page_tabs:
       correct: Corrigir
+      describe_work: Descreva o trabalho
       help: Ajuda
       nav_info: Página %{position} de %{size}
+      next_page: Próxima página
       overview: Resumo
+      page: página
+      previous_page: Página anterior
       settings: Configurações
       transcribe: Transcrever
       translate: Traduzir
       versions: Versões
+    review_breadcrumbs:
+      dashboard: Painel de revisão
+      page: Página
+    validation_summary:
+      form: Formato
     work_tabs:
       about: Sobre
       contents: Conteudo
@@ -54,3 +91,4 @@ pt:
       pages: Páginas
       read: Ler
       settings: Configurações
+      work: Trabalhar

--- a/config/locales/statistics/statistics-pt.yml
+++ b/config/locales/statistics/statistics-pt.yml
@@ -3,8 +3,12 @@ pt:
   statistics:
     collaborator_time:
       collaborator_time: Tempo do colaborador
+      collaborator_time_for_dates: Hora do Colaborador para Datas
+      end_date: Data final
       export_activity_as_csv: Exportar atividade detalhada como CSV
       no_activity_for_date_range: Não há atividade para este intervalo de datas.
+      start_date: Data de início
+      update: Atualizar
       user_totals_for_dates: Totais do usuário para datas
     collaborators:
       collaborators: Colaboradores
@@ -21,6 +25,12 @@ pt:
       collaborator:
         one: Colaborador
         other: Colaboradores
+      incomplete_page:
+        one: Página incompleta
+        other: Páginas incompletas
+      lines_transcribed:
+        one: Linha de texto
+        other: Linhas de texto
       note:
         one: Nota
         other: Notas
@@ -30,6 +40,27 @@ pt:
       page:
         one: Página
         other: Páginas
+      page_edit:
+        one: Edição de página
+        other: Edições de página
+      page_indexed:
+        one: Página indexada
+        other: Páginas indexadas
+      page_needing_review:
+        one: Página precisando de revisão
+        other: Páginas que precisam de revisão
+      page_reviewed:
+        one: Página revisada
+        other: Páginas revisadas
+      page_transcribed:
+        one: Página transcrita
+        other: Páginas transcritas
+      page_translated:
+        one: Página traduzida
+        other: Páginas traduzidas
+      records_indexed:
+        one: Registro indexado
+        other: Registros indexados
       reference:
         one: Referência
         other: Referências
@@ -39,6 +70,9 @@ pt:
       work:
         one: Trabalho
         other: Trabalhos
+      works_described:
+        one: Trabalho descrito
+        other: Trabalhos descritos
     recent_statistics:
       collaborator:
         one: Colaborador
@@ -52,6 +86,24 @@ pt:
       ocr_correction:
         one: Correção OCR
         other: Correções OCR
+      page_edit:
+        one: Edição de página
+        other: Edições de página
+      page_indexed:
+        one: Página indexada
+        other: Páginas indexadas
+      page_marked_needing_review:
+        one: Página marcada como precisando de revisão
+        other: Páginas marcadas como precisando de revisão
+      page_reviewed:
+        one: Página revisada
+        other: Páginas revisadas
+      page_transcribed:
+        one: Página transcrita
+        other: Páginas transcritas
+      page_translated:
+        one: Página traduzida
+        other: Páginas traduzidas
       reference:
         one: Referência
         other: Referências
@@ -62,6 +114,9 @@ pt:
       collaborator:
         one: Colaborador
         other: Colaboradores
+      incomplete_page:
+        one: Página incompleta
+        other: Páginas incompletas
       last_days_statistics: Estatísticas dos últimos 7 dias
       new_subject:
         one: Novo assunto
@@ -72,6 +127,27 @@ pt:
       ocr_correction:
         one: Correção OCR
         other: Correções OCR
+      page_edit:
+        one: Edição de página
+        other: Edições de página
+      page_indexed:
+        one: Página indexada
+        other: Páginas indexadas
+      page_marked_needing_review:
+        one: Página marcada como precisando de revisão
+        other: Páginas marcadas como precisando de revisão
+      page_needing_review:
+        one: Página precisando de revisão
+        other: Páginas que precisam de revisão
+      page_reviewed:
+        one: Página revisada
+        other: Páginas revisadas
+      page_transcribed:
+        one: Página transcrita
+        other: Páginas transcritas
+      page_translated:
+        one: Página traduzida
+        other: Páginas traduzidas
       reference:
         one: Referência
         other: Referências

--- a/config/locales/transcribe/transcribe-pt.yml
+++ b/config/locales/transcribe/transcribe-pt.yml
@@ -18,12 +18,15 @@ pt:
       image_at_the_left: Imagem à esquerda
       image_at_the_right: Imagem à direita
       image_at_the_top: Imagem superior
+      layout: Esquema
       mark_as_blank: Marcar como em branco
       microphone: Microfone
       more_help: Mais ajuda....
       needs_review: Precisa de Revisão
+      notes_and_questions: Notas e perguntas
       this_page_marked_blank: Esta página foi marcada como em branco
       this_page_marked_needs_review: Esta página foi marcada como "precisa de revisão\". Você pode melhorar esta página, revisando-a contra o original e adicionando ou corrigindo o texto. Quando terminar, desfaça a opção "precisa de revisão" e salve a página.
+      this_page_marked_needs_review_workflow_version: Esta página precisa de revisão. Você pode melhorar esta página revisando-a em relação ao original e adicionando ou corrigindo o texto e, em seguida, aprove o texto.
       title: 'Título:'
     goto_next_untranscribed_page:
       another_page_notice: Aqui está outra página nesta obra.
@@ -40,9 +43,15 @@ pt:
     save_buttons:
       approve: Confirmar
       approve_to_transcribed_tooltip: Salve e aprove esta página
+      autolink: Autolink
+      autolink_tooltip: Sugerir tags de assunto automaticamente
       done: Feito
+      edit: Editar
+      edit_tooltip: Edite essa página
       finish_to_needs_review_tooltip: Salvar uma página completa
       finish_to_transcribed_tooltip: Salvar uma página completa
+      preview: Visualizar
+      preview_tooltip: Visualizar esta página
       save_changes: Salvar
       save_to_incomplete_tooltip: Salvar uma página incompleta
       save_to_needs_review_tooltip: Salve suas alterações
@@ -56,8 +65,11 @@ pt:
       notice: Você pode guardar até %{guest_deed_ count} transcrições como hóspede.
     translate:
       autolink: Link automático
+      corrected: corrigido
       edit: Editar
       edit_translation: Editar tradução
+      help_correct: ajudar a corrigir
+      help_transcribe: ajude a transcrever
       mark_as_blank: Marcar como em branco
       mark_the_page_blank: marcar a página como em branco
       microphone: Microfone
@@ -68,6 +80,8 @@ pt:
       preview: Pré-Visualizar
       save_changes: Guardar Alterações
       show_image: Mostrar Imagem
+      show_transcription: Mostrar transcrição
       this_page_is_blank: Esta página está em branco
       this_page_is_not: Esta página não é %{text_type}
       this_page_marked_needs_review: Esta página foi marcada como "precisa de revisão". Você pode melhorar esta página, revisando-a contra o original e adicionando ou corrigindo o texto. Quando terminar, desfaça a opção "precisa de revisão" e salve a página.
+      transcribed: transcrito

--- a/config/locales/transcription_field/transcription_field-pt.yml
+++ b/config/locales/transcription_field/transcription_field-pt.yml
@@ -1,16 +1,87 @@
 ---
 pt:
   transcription_field:
+    add_columns:
+      must_have_options_list: Os campos selecionados devem ter uma lista de opções. Adicione opções a qualquer campo selecionado e salve novamente.
+      starting_rows_must_not_be_blank: As linhas iniciais não devem ficar em branco.
     add_fields:
       must_have_options_list: Os campos selecionados devem ter uma lista de opções. Adicione opções a qualquer campo selecionado e salve novamente.
+    choose_offset:
+      page_layout: Layout da página
+      page_layout_description: Redimensione o retângulo na imagem para cercar a parte da página que contém uma planilha e salve sua seleção.
+      replace_image: Substituir imagem
+      replace_image_description: Se a imagem de exemplo não contiver uma planilha, você poderá substituí-la por uma página diferente da coleção, escolhida aleatoriamente.
+      save_selection: Salvar seleção
+    column_form:
+      column_options: Opções de coluna (separadas por ponto e vírgula)
+      column_options_title: Opções para células suspensas.
+      input_type: Tipo de entrada
+      label: Etiqueta
+    edit_columns:
+      add_additional_column: Adicionar coluna adicional
+      cancel: Cancelar
+      disable_ruler: Desativar Régua
+      done: Feito
+      edit_spreadsheet_columns: Configuração da coluna
+      edit_spreadsheet_header: Configuração da planilha
+      enable_ruler: Ativar Régua
+      identify_rows: Identificar linhas
+      identify_rows_description: As páginas podem ter margens superior e inferior, campos de cabeçalho ou rodapé ou outro texto que não deve ser usado ao identificar onde as linhas estão na página.
+      page_layout: Layout da página
+      preview: Visualização da planilha
+      save: Salvar
+      screen_ruler: Régua de tela
+      screen_ruler_description: Para reduzir a usabilidade e reduzir os erros de transcrição, FromThePage pode exibir uma régua na imagem da página que destaca a parte de uma página que o usuário está transcrevendo. Isso é útil para documentos digitalizados consistentemente escritos em formulários pré-impressos, mas pode ser uma distração ou frustrante se os documentos forem irregulares e a régua da tela não corresponder.
+      start_rows_description: Número de linhas que a planilha deve exibir inicialmente. (Os transcritores poderão adicionar linhas adicionais, se necessário.)
+      start_rows_label: 'Contagem de linhas inicial:'
+      transcription_warning: Este projeto já foi parcialmente transcrito. Adicionar colunas é bom, mas excluir ou alterar colunas pode resultar em perda de dados. Entre em contato com support@fromthepage.com se tiver dúvidas ou precisar renomear colunas.
+    edit_field_form:
+      add_additional_field: Adicionar campo adicional
+      add_additional_line: Adicionar linha adicional
+      cancel: Cancelar
+      data_entry_type_label: Fluxo de metadados
+      data_entry_type_metadata_only: Os usuários só criam metadados
+      data_entry_type_text_and_metadata: Os usuários transcrevem texto e criam metadados
+      description_instructions_label: Instruções de descrição de metadados
+      done: Feito
+      line: Linha
+      preview: Visualizar
+      save: Salvar
     edit_fields:
       edit_transcription_fields: Editar Campos de Transcrição
+      transcription_warning: Este projeto já foi parcialmente transcrito. Adicionar campos é bom, mas excluir ou alterar campos pode resultar em perda de dados. Entre em contato com support@fromthepage.com se tiver dúvidas ou precisar renomear campos.
+    edit_metadata_fields:
+      edit_metadata_fields: Editar campos de metadados
     field_layout:
       instructions: Instruções
     line_form:
       field_options: Opções de campos (separar com ponto-e-vírgula)
       field_options_title: Opções para campos selecionados.
+      input_type: Tipo de entrada
+      label: Etiqueta
       page: Página
       page_title: Para formulários de várias páginas, em que página este campo deve aparecer? (Deixe em branco para exibir em cada página.)
       percentage_title: Percentagem da largura da linha a usar para este campo.
       percentage_width: Largura %
+    metadata_field_layout:
+      instructions: Instruções
+    multiselect_form:
+      options_form_description: Insira opções para o campo de metadados de seleção múltipla, com cada opção em uma linha separada
+      options_form_title: Opções de seleção múltipla
+      save: Salvar
+    new_column_form:
+      delete_column: Excluir coluna
+      field_label: Legenda do campo
+      field_options: Opções de campo
+      input_type: Tipo de entrada
+      reorder_column: Reordenar coluna
+    new_field_form:
+      configure_options: Configurar opções
+      configure_spreadsheet: Configurar planilha
+      delete_field: Excluir campo
+      field_label: Legenda do campo
+      field_options: Opções de campo
+      input_type: Tipo de entrada
+      page_number: Número de página
+      reorder_field: Reordenar campo
+      width_percentage: Porcentagem de largura

--- a/config/locales/user/user-pt.yml
+++ b/config/locales/user/user-pt.yml
@@ -1,12 +1,20 @@
 ---
 pt:
   user:
+    api_key:
+      api_key: Chave API
+      api_key_description: As <a href="https://content.fromthepage.com/api-keys/">chaves de API</a> permitem o acesso a coleções particulares por meio do <a href="https://github.com/benwbrum/fromthepage /wiki/FromThePage-Support-for-the-IIIF-Presentation-API-and-Web-Annotations">IIIF API</a> ou <a href="http://content.fromthepage.com/bulk-export- api/">API de exportação em massa</a>.
+      delete_key: Excluir chave
+      generate_key: Gerar chave
+      no_api_key_description: Sua conta não tem uma chave de API. Gere um para habilitar o acesso à API.
+      your_api_key_description: 'Sua conta tem a seguinte chave de API, que pode ser usada para acessar suas coleções particulares:'
     owner_profile:
       api_keys: API Keys
       edit_profile: Editar Perfil
       login_and_password: Usuário &amp; Senha
       next_image: Imagem seguinte
       previous_image: Imagem anterior
+      recent_activity: Atividade recente
       website: Site
     profile:
       contribution:
@@ -15,9 +23,12 @@ pt:
       edit_profile: Editar Perfil
       last_seen: Visto por última vez em %{date}
       login_and_password: Usuário &amp; Senha
+      newer_activity: Atividade mais recente
+      older_activity: Atividade mais antiga
       recent_activity_by: Actividade Recente de %{user_display_name}
       user_deleted: Perfil de usuário foi excluído
       user_since: Usuário desde %{date}
+      users_profile_at_fromthepage: Perfil de %{user} em FromThePage. %{about}
     update:
       user_updated: O perfil do usuário foi atualizado
     update_profile:
@@ -26,14 +37,25 @@ pt:
       add_as_owner: Adicionado como dono a uma obra privada
       add_as_reviewer: Adicionado à coleção como revisor autorizado
       default_dictation_language: 'Idioma de ditado automático: '
+      interface_language: Idioma da interface
+      location: Localização
       name: Nome
       name_only_required: O seu nome é o único campo requerido.
+      no_image: Sem imagem
+      ocrid_id: ID OCRID
       owner_stats: Um e-mail cada noite com a atividade nas coleções que você controla
       page_edited: Nota adicionada em resposta a um comentário que você fez
       picture: Foto do perfil
+      picture_to_be_used_message: Imagem a ser usada
       select_notification: 'Selecione quais das seguintes notificações você gostaria de receber:'
+      sign_up_url: 'URL de inscrição:'
       update_profile: Atualizar Perfil
       update_user_profile: Atualizar Perfil do Usuário
+      upload_image: Enviar Imagem
+      url: URL
       user_activity: Um e-mail cada noite com a atividade nas coleções nas quais você colabora
+      user_url: 'URL:'
+      website: Local na rede Internet
       where_are_you_from: Você é de onde?
       your_blog_or_homepage: Seu blog ou site pessoal
+      your_ocrid_id: Seu ID OCRID

--- a/config/locales/user_mailer/user_mailer-pt.yml
+++ b/config/locales/user_mailer/user_mailer-pt.yml
@@ -1,11 +1,39 @@
 ---
 pt:
   user_mailer:
+    added_note:
+      html:
+        view_note: " para ver a nota em %{collection}: %{work}."
+      message: Gostaríamos apenas de informar que a seguinte nota foi adicionada a uma página em que você trabalhou no trabalho %{work}, na coleção %{collection}.
+      text:
+        view_note: 'Você pode visualizar a nota em %{collection}: %{work} na URL: %{url}.'
+    bulk_export_finished:
+      html:
+        ready_message: foi processado e está pronto em %{this_link}.
+      text:
+        ready_message: 'Sua exportação foi processada e está pronta neste URL:'
+      this_link: esse link
+      your_export_is_ready: Sua exportação está pronta!
+      your_export_of: Sua exportação de
     click_here: Clique aqui
+    collection_collaborator:
+      html:
+        to_view: " para ver %{collection}"
+      message: Gostaríamos apenas de informar que %{owner} adicionou você como colaborador em %{collection}.
+      text:
+        to_view: 'Para visualizar %{collection}, visite o seguinte URL: %{url}'
+    collection_reviewer:
+      html:
+        to_view: " para ver %{collection}"
+      message: "%{owner} adicionou você como revisor autorizado em %{collection}. Você deve poder editar e aprovar qualquer página que precise de revisão."
+      text:
+        to_view: 'Para visualizar %{collection}, visite o seguinte URL: %{url}'
     greeting: Oi %{user} --
     html:
       closing: "Gratidão, <br><br> \nFromThePage\n"
       turn_off_notification: " para desligar esta notificação."
+    new_owner:
+      welcome: Bem-vindo
     nightly_user_activity:
       html:
         to_view_note: " para visualizar a nota na página %{page} em %{collection}: %{work}, que foi adicionada desde que você trabalhou nela."
@@ -13,4 +41,25 @@ pt:
       message: Só queríamos informar que houve atividade numa colecção em que você trabalhou.
       new_notes: Notas Novas
       new_works: Novas Obras
+      note_added: Uma nota foi adicionada a uma página na qual você trabalhou no trabalho %{work}, na coleção %{collection}.
+      text:
+        to_view_note: 'Para visualizar a nota na página %{work}: %{page}, visite o seguinte URL: %{url}'
+        to_view_work: 'Para visualizar %{collection}: %{work}, visite o seguinte URL: %{url}'
       work_added: "%{owner} adicionou %{work} à coleção %{collection}. "
+    text:
+      closing: |-
+        Obrigado,
+        Da página
+      turn_off_notification: 'Desative esta notificação no URL: %{url}'
+    upload_finished:
+      html:
+        message: Seu upload foi processado e está pronto em
+      text:
+        message: 'Seu upload foi processado e está pronto neste URL:'
+      your_upload_is_ready: Seu carregamento está pronto!
+    work_collaborator:
+      html:
+        to_view: " para ver %{collection} - %{work}."
+      message: Gostaríamos apenas de informar que %{owner} adicionou você como colaborador em %{collection} - %{work}.
+      text:
+        to_view: 'Você pode visualizar %{collection}: %{work} no URL: %{url}'

--- a/config/locales/will_paginate/will_paginate-pt.yml
+++ b/config/locales/will_paginate/will_paginate-pt.yml
@@ -1,19 +1,19 @@
 ---
 pt:
   will_paginate:
-    container_aria_label: 
-    next_label: 
-    page_aria_label: 
+    container_aria_label: Paginação
+    next_label: Próximo →
+    page_aria_label: Página %{page}
     page_entries_info:
-      multi_page: 
-      multi_page_html: 
+      multi_page: Exibindo %{model} %{from} - %{to} de %{count} no total
+      multi_page_html: Exibindo %{model} <b>%{from} - %{to}</b> de <b>%{count}</b> no total
       single_page:
-        one: 
-        other: 
-        zero: 
+        one: Exibindo 1 %{model}
+        other: Exibindo todos os %{count} %{model}
+        zero: Nenhum %{model} encontrado
       single_page_html:
-        one: 
-        other: 
-        zero: 
-    page_gap: 
-    previous_label: 
+        one: Exibindo <b>1</b> %{model}
+        other: Exibindo <b>todos os %{count}</b> %{model}
+        zero: Nenhum %{model} encontrado
+    page_gap: "&hellip;"
+    previous_label: "← Anterior"

--- a/config/locales/work/work-pt.yml
+++ b/config/locales/work/work-pt.yml
@@ -3,8 +3,154 @@ pt:
   work:
     create:
       work_created: Trabalho criado com sucesso
+    describe:
+      always_show_fullscreen: Sempre mostrar tela cheia
+      approve: Aprovar
+      approve_to_transcribed_tooltip: Salve e aprove estes metadados
+      done: Feito
+      finish_to_needs_review_tooltip: Salvar metadados concluídos
+      finish_to_transcribed_tooltip: Salvar metadados concluídos
+      fullscreen: Tela cheia
+      image_at_the_bottom: Imagem na parte inferior
+      image_at_the_left: Imagem à esquerda
+      image_at_the_right: Imagem à direita
+      image_at_the_top: Imagem no topo
+      layout: Esquema
+      metadata: Metadados
+      needs_review: Precisa de revisão
+      notes_and_questions: Notas e perguntas
+      original_metadata: Metadados originais
+      page_images: Imagens da página
+      save_changes: Salvar
+      save_to_incomplete_tooltip: Salvar metadados incompletos
+      save_to_needs_review_tooltip: Salve suas alterações
+      save_to_transcribed_tooltip: Salve suas alterações
+      text: Texto
+      this_page_is_blank: Esta página está em branco
+      view_original: Ver original
+    described: Metadados concluídos.
+    description_versions:
+      author_contributed_at: "%{author} em %{date}"
+      compared_with: Comparado com
+      help_description: Visualize e compare as alterações que foram feitas em cada revisão aos metadados de trabalho. A coluna da esquerda mostra os metadados na revisão selecionada, a coluna da direita mostra o que foi alterado. O texto inalterado é <span>destacado em branco</span>, o texto excluído é <del>destacado em vermelho</del> e o texto inserido é <ins>destacado em verde</ins>.
+      revision: revisão
+    download:
+      analyze: Analisar
+      docx_download_description: Baixe uma versão DOCX deste trabalho.
+      download: Download
+      expanded_plaintext: Texto simples expandido
+      expanded_plaintext_export_description: Exporte transcrições de texto simples substituindo texto literal por títulos de assunto canônicos como um arquivo zip contendo um arquivo por página.
+      experiment: Experimentar
+      export: Exportar
+      facing_pdf: PDF de frente
+      facing_pdf_export_description: Baixe uma versão em PDF deste trabalho incluindo imagens e texto nas páginas opostas.
+      html: HTML
+      html_export_description: Exporte as transcrições como um arquivo zip contendo um arquivo HTML por página.
+      ms_word: MS Word
+      pdf: PDF
+      pdf_download_description: Baixe uma versão em PDF deste trabalho.
+      searchable_plaintext: Texto simples pesquisável
+      searchable_plaintext_export_description: Exporte transcrições de texto simples otimizadas para pesquisa de texto completo como um arquivo zip contendo um arquivo por página.
+      table_field_csv: CSV de tabela/campo
+      table_field_csv_export_description: Exporte todos os dados tabulares, de planilha ou baseados em campo como um único arquivo CSV.
+      verbatim_plaintext: Texto simples literal
+      verbatim_plaintext_export_description: Exporte transcrições em texto simples como um arquivo zip contendo um arquivo por página.
+      voyant: Voyant
+      voyant_analysis_description: Envie a transcrição deste trabalho para a Voyant Tools para análise.
+      warning_work_not_complete: 'Atenção: este trabalho pode não estar completo.'
+      word_trees: Árvores de palavras
+      word_trees_analysis_description: Envie a transcrição deste trabalho para o visualizador Word Trees de Jason Davies para análise.
+      zip_export_only_project_owners: Formatos de exportação de arquivos zip acessíveis apenas para proprietários de projetos.
     edit:
+      add: Adicionar
       additional_metadata: Metadados adicionais
+      additional_metadata_description: Esses campos de metadados são exibidos na tela Sobre deste trabalho e nas exportações de TEI, mas não afetam a funcionalidade de FromThePage.
+      allowed_collaborators: Colaboradores permitidos
+      apply: Aplicar
+      author: Autor
+      collaborators_can_edit_titles: Permitir que os colaboradores editem os títulos das páginas
+      collection: Coleção
+      confirm_delete_work: Tem certeza de que deseja excluir este trabalho? Após a exclusão, você não poderá recuperá-lo!
+      current_url: A URL atual para este trabalho é %{current_url}. Se você quiser editar a seção de trabalho do URL, use letras minúsculas e traços entre as palavras.
+      delete_work: Excluir trabalho
+      description: Descrição
+      document_date: Data do documento
+      document_date_hint: A data do documento está no formato EDTF (por exemplo, 1843, 2001-02, 1643-06-30)
+      document_history: Documento histórico
+      editorial_notes: Notas editoriais
+      enable_ocr_correction: Ativar correção de OCR
+      enable_ocr_correction_description: Um trabalho pode começar com texto OCR que precisa ser corrigido. Quando marcada, a guia Transcrever será substituída por uma guia Correta.
+      genre: Gênero
+      identifier: Identificador
+      identifier_description: Identificador de sistemas fora de FromThePage, para ser usado correlacionando exportações para registros externos. (Este campo não é visível ao público.)
+      in_scope: Na mira
+      more_work_settings_info: Para obter mais informações sobre configurações de trabalho, consulte o artigo wiki <a href="https://github.com/benwbrum/fromthepage/wiki/Preparing-a-Work-for-Transcription" target="_blank">Preparando um trabalho para Transcrição</a>.
+      no_allowed_collaborators_selected: Nenhum colaborador permitido selecionado
+      no_image: Sem imagem
+      pages_are_meaningful: As páginas são significativas
+      pages_are_meaningful_description: As páginas podem ser divisões semânticas significativas de um trabalho (como em um diário com uma data para cada página), ou podem não ser (como em cartas ou livros, onde o texto não deve ser dividido em seções baseadas em páginas). Quando marcada, a obra terá os títulos das páginas exibidos com destaque.
+      permission_description: Descrição da permissão
+      physical_description: Descrição física
+      place_of_creation: Lugar de Criação
+      recipient: Destinatário
+      remove: Remover
+      restrict_collaborators: Restringir colaboradores
+      restricted_work_no_collaborators_warning: Somente os proprietários do projeto podem editar este trabalho. Adicione colaboradores para tornar o trabalho editável por outras pessoas.
+      revert: Reverter
+      revert_transcription_conventions_description: Reverter convenções de transcrição para padrão de coleção
+      save_changes: Salvar alterações
+      settings_only_work_owners: As configurações para este trabalho são acessíveis apenas aos proprietários do trabalho.
+      source_box_folder: Caixa/Pasta de Origem
+      source_collection_name: Nome da coleção de origem
+      source_location: Local de origem
+      support_translation: Tradução de suporte
+      support_translation_description: Uma obra pode ser traduzida assim como transcrita. Quando marcada, a obra terá uma guia Tradução para cada página.
+      transcription_conventions: Convenções de transcrição
+      translation_instructions: Instruções de tradução
+      upload_image: Enviar Imagem
+      uploaded_by: Enviado por
+      url: URL
+      work_image: Imagem de trabalho
+      work_image_description: Uma imagem a ser usada para ilustrar o trabalho. Se nenhuma imagem for carregada, uma imagem da página será usada.
+      work_thumbnail: Miniatura do trabalho
+      work_title: Título do trabalho
+    incomplete: Metadados incompletos.
+    metadata_overview:
+      notes_and_questions: Notas e perguntas
+      show_image: Mostrar imagem
+      this_page_is_blank: Esta página está em branco
+    needsreview: Metadados precisam de revisão.
+    new:
+      collection: Coleção
+      create_empty_work: Criar trabalho vazio
+      create_empty_work_description: Isso cria um trabalho vazio. Depois de criar o trabalho, você pode adicionar imagens de páginas individuais. Se você tiver um arquivo zip ou pdf com várias imagens, você deve criar o trabalho e fazer upload do arquivo em %{start_project}.
+      create_work: Criar trabalho
+      description: Descrição
+      start_a_project: Iniciar um projeto
+      title: Título
+      work_description: Uma obra é um documento único como uma carta, um diário, um livro de campo, um cartão postal ou um caderno.
+    pages_tab:
+      actions: Ações
+      add_new_page: Adicionar nova página
+      confirm_delete_page: Tem certeza de que deseja excluir esta página? Após a exclusão, você não poderá recuperá-lo!
+      delete: Excluir
+      featured_page: Página em destaque
+      image_status: Status da imagem
+      make_featured_page: Fazer página em destaque
+      move_down: Mover para baixo
+      move_up: Subir
+      no_pages_found: Nenhuma página encontrada
+      no_pages_found_description: Este trabalho ainda não contém páginas
+      page_title: Título da página
+      pages_tab_description: Aqui você vê a lista de todas as páginas do trabalho. Se você quiser alterar a posição de uma página, use as setas para cima e para baixo à direita. Para criar uma nova página para este trabalho clique no botão Adicionar Nova Página. Depois que uma nova página em branco for criada, encontre-a na lista abaixo e prossiga para as configurações onde você pode fazer upload da imagem da página.
+      position: Posição
+      ready_to_transcribe: Pronto para %{transcribe}
+      settings: Definições
+      transcribe: transcrever
+      upload: Envio
+      upload_page_image: "%{upload} imagem da página"
+    save_description:
+      work_described: Sua descrição foi salva
     show:
       author_name: Nome do Autor
       description: Descrição
@@ -12,15 +158,19 @@ pt:
       document_history: Histórico do Documento
       editorial_notes: Notas editoriais
       genre: Gênero
+      iiif_manifest: Manifesto IIIF
       location_of_composition: Localização da Composição
+      metadata: Metadados
       number_of_pages: Número de Páginas:&nbsp;
       out_of_scope: Fora do escopo
       permission_description: Descrição da Permissão
       physical_description: Descrição Física
+      recipient_name: Nome do Destinatário
       scope: Escopo
       source_box_folder: Caixa de fontes
       source_collection_name: Nome de coleção fonte
       source_location: Localização de fonte
       uploaded_by: Subido por
+    undescribed: Sem metadados.
     update:
       work_updated: Trabalho atualizado com sucesso


### PR DESCRIPTION
_Resolves #3180_

This translates all of the remaining untranslated Portuguese messages so that you shouldn't see any leftover English when you have your locale set to Portuguese. It was done via `i18n-tasks translate missing` and the Google Translate API.

This PR we can merge now because robot Portuguese is better than English (and so our `i18n-tasks` tests can run), and we'll have a separate PR (#3255) for reviewing these messages.