### PR TITLE
Made pages_view heading changeable for #3258

### DIFF
--- a/app/controllers/collection_controller.rb
+++ b/app/controllers/collection_controller.rb
@@ -635,12 +635,14 @@ class CollectionController < ApplicationController
     @count = @pages.count
     @incomplete_pages = Page.where(work_id: work_ids).joins(:work).merge(Work.unrestricted).needs_completion.order(work_id: :asc, position: :asc).paginate(page: params[:page], per_page: 10)
     @incomplete_count = @incomplete_pages.count
+    @heading = t('.pages_need_transcription')
   end
 
   def needs_review_pages
     work_ids = @collection.works.pluck(:id)
     @review='review'
     @pages = Page.where(work_id: work_ids).joins(:work).merge(Work.unrestricted).review.paginate(page: params[:page], per_page: 10)
+    @heading = t('.pages_need_review')
   end
 
   def start_transcribing

--- a/app/controllers/display_controller.rb
+++ b/app/controllers/display_controller.rb
@@ -24,26 +24,33 @@ class DisplayController < ApplicationController
       if @review == 'review'
         @pages = Page.where(work_id: params[:work_id]).review.order('position').paginate(page: params[:page], per_page: PAGES_PER_SCREEN)
         @count = @pages.count
+        @heading = t('.pages_need_review')
       elsif @review == 'transcription'
         @pages = Page.where(work_id: params[:work_id]).needs_transcription.order('position').paginate(page: params[:page], per_page: PAGES_PER_SCREEN)
         @count = @pages.count
         @incomplete_pages = Page.where(work_id: params[:work_id]).needs_completion.order('position').paginate(page: params[:page], per_page: PAGES_PER_SCREEN)
         @incomplete_count = @incomplete_pages.count
+        @heading = t('.pages_need_transcription')
       elsif @review == 'index'
         @pages = Page.where(work_id: params[:work_id]).needs_index.order('position').paginate(page: params[:page], per_page: PAGES_PER_SCREEN)
         @count = @pages.count
+        @heading = t('.pages_need_indexing')
       elsif @review == 'translation'
         @pages = Page.where(work_id: params[:work_id]).needs_translation.order('position').paginate(page: params[:page], per_page: PAGES_PER_SCREEN)
         @count = @pages.count
+        @heading = t('.pages_need_translation')
       elsif @review == 'translation_review'
         @pages = Page.order('position').where(work_id: params[:work_id]).translation_review.paginate(page: params[:page], per_page: PAGES_PER_SCREEN)
         @count = @pages.count
+        @heading = t('.translations_need_review')
       elsif @review == 'translation_index'
         @pages = Page.order('position').where(work_id: params[:work_id]).needs_translation_index.paginate(page: params[:page], per_page: PAGES_PER_SCREEN)
         @count = @pages.count
+        @heading = t('.translations_need_indexing')
       else
         @pages = Page.order('position').where(:work_id => @work.id).paginate(page: params[:page], per_page: PAGES_PER_SCREEN)
         @count = @pages.count
+        @heading = t('.pages')
       end
     end
     session[:col_id] = @collection.slug
@@ -54,10 +61,12 @@ class DisplayController < ApplicationController
       # restrict to pages that include that subject
       @pages = Page.order('work_id, position').joins('INNER JOIN page_article_links pal ON pages.id = pal.page_id').where([ 'pal.article_id = ?', @article.id ]).where(work_id: @collection.works.ids).paginate(page: params[:page], per_page: PAGES_PER_SCREEN)
       @pages.distinct!
+      @heading = t('.pages_that_mention', article: @article.title)
     else
       @pages = Page.paginate :all, :page => params[:page],
                                         :order => 'work_id, position',
                                         :per_page => 5
+      @heading = t('.pages')
     end
     session[:col_id] = @collection.slug
   end

--- a/app/views/collection/needs_review_pages.html.slim
+++ b/app/views/collection/needs_review_pages.html.slim
@@ -2,7 +2,6 @@ div
   h1 =@collection.title
 .columns
   article.maincol
-    h3 =t('.pages_that_need_review')
     =render 'display/pages_view'
 
     =render(:partial => 'shared/pagination', :locals => { :model => @pages, :entries_info => true })

--- a/app/views/display/_pages_view.html.slim
+++ b/app/views/display/_pages_view.html.slim
@@ -5,7 +5,7 @@
     p.nodata_text =t('.no_pages_needing_transcription_found_these_pages_are_incomplete')
     -working_pages += @incomplete_pages
 -else
-  h3 =t('.pages_that_need_transcription')
+  h3 =@heading
   -if @pages.size == 0 && (@incomplete_pages.blank? || @review.nil? || @review == 'review' || @review == 'translation_review' || @review == 'translation_index')
     .nodata
       h4.nodata_title =t('.no_pages_found')

--- a/config/locales/collection/collection-en.yml
+++ b/config/locales/collection/collection-en.yml
@@ -189,10 +189,11 @@ en:
       translation: Translation
     needs_review: needs review
     needs_review_pages:
-      pages_that_need_review: Pages That Need Review
+      pages_need_review: Pages That Need Review
       project_by: Project by
       return_to_collection: Return to collection
     needs_transcription_pages:
+      pages_need_transcription: Pages That Need Transcription
       project_by: Project by
       return_to_collection: Return to collection
     new:

--- a/config/locales/collection/collection-es.yml
+++ b/config/locales/collection/collection-es.yml
@@ -189,10 +189,11 @@ es:
       translation: Traducción
     needs_review: requiere revisión
     needs_review_pages:
-      pages_that_need_review: Páginas que Necesitan Revisión
+      pages_need_review: Páginas que Necesitan Revisión
       project_by: Proyecto de
       return_to_collection: Volver a la colección
     needs_transcription_pages:
+      pages_need_transcription: Páginas que necesitan transcripción
       project_by: Proyecto de
       return_to_collection: Volver a la colección
     new:

--- a/config/locales/collection/collection-fr.yml
+++ b/config/locales/collection/collection-fr.yml
@@ -58,7 +58,7 @@ fr:
       blank_collection_description: Appuyer sur ce bouton réinitialisera la collection à un état vide. Il effacera toutes les transcriptions et autres travaux sur la collection, comme si elle venait d'être importée.
       close_api: Fermer l'API
       collection_active_message: Ceci est une collection active. Rendre une collection inactive empêche les utilisateurs de modifier le contenu de la collection. L'état de la collection n'affecte pas le paramètre de confidentialité de la collection.
-      collection_collaborators: Collaborateurs de collecte
+      collection_collaborators: Collaborateurs de la collection
       collection_collaborators_description: Les collaborateurs peuvent transcrire et éditer des collections privées.
       collection_image: Image de la collection
       collection_inactive_message: Il s'agit d'une collection inactive. Activer une collection permet aux utilisateurs de modifier le contenu de cette collection. L'état de la collection n'affecte pas le paramètre de confidentialité de la collection.
@@ -103,10 +103,10 @@ fr:
       hide_completed: Masquer les œuvres terminés par défaut
       learn_more_footer: En savoir plus sur la configuration du pied de page.
       link_help: Texte d'aide sur la liaison par sujet (non affiché si les sujets sont désactivés)
-      make_collection_active: Rendre la collecte active
-      make_collection_inactive: Rendre la collecte inactive
+      make_collection_active: Rendre la collection active
+      make_collection_inactive: Rendre la collection inactive
       make_collection_private: Rendre la collection privée
-      make_collection_public: Rendre la collecte publique
+      make_collection_public: Rendre la collection publique
       metadata: Métadonnées
       metadata_description: Chargez les métadonnées des éléments de cette collection de manière groupée.
       metadata_entry: Description des métadonnées
@@ -191,11 +191,11 @@ fr:
     needs_review_pages:
       pages_need_review: Pages à réviser
       project_by: Projet par
-      return_to_collection: Retour à la collecte
+      return_to_collection: Retour à la collection
     needs_transcription_pages:
       pages_need_transcription: Pages nécessitant une transcription
       project_by: Projet par
-      return_to_collection: Retour à la collecte
+      return_to_collection: Retour à la collection
     new:
       collection_description: Description de la collection
       create_collection: Créer une collection

--- a/config/locales/collection/collection-fr.yml
+++ b/config/locales/collection/collection-fr.yml
@@ -189,10 +189,11 @@ fr:
       translation: Traduction
     needs_review: a besoin d'une révision
     needs_review_pages:
-      pages_that_need_review: Pages à réviser
+      pages_need_review: Pages à réviser
       project_by: Projet par
       return_to_collection: Retour à la collecte
     needs_transcription_pages:
+      pages_need_transcription: Pages nécessitant une transcription
       project_by: Projet par
       return_to_collection: Retour à la collecte
     new:

--- a/config/locales/collection/collection-pt.yml
+++ b/config/locales/collection/collection-pt.yml
@@ -189,10 +189,11 @@ pt:
       translation: Tradução
     needs_review: Precisa ser revisado
     needs_review_pages:
-      pages_that_need_review: Páginas para Revisar
+      pages_need_review: Páginas para Revisar
       project_by: Projeto por
       return_to_collection: Voltar à Coleção
     needs_transcription_pages:
+      pages_need_transcription: Páginas que precisam de transcrição
       project_by: Projeto por
       return_to_collection: Voltar à Coleção
     new:

--- a/config/locales/display/display-en.yml
+++ b/config/locales/display/display-en.yml
@@ -67,7 +67,6 @@ en:
       no_pages_needing_transcription_found_these_pages_are_incomplete: No pages need transcription from scratch.  These pages have been partially transcribed but need to be completed.
       page_not_translated: This page is not translated, please %{help_translate} this page
       pages_needing_completion: Pages needing completion
-      pages_that_need_transcription: Pages That Need Transcription
       review_metadata: Review Metadata
       this_page_is_blank: This page is blank
       this_page_is_incomplete: This page is incomplete
@@ -75,6 +74,17 @@ en:
       transcribed: transcribed
       translation: Translation
       unable_to_find_pages: We were unable to find any pages matching your request
+    read_all_works:
+      pages: Pages
+      pages_that_mention: Pages That Mention %{article}
+    read_work:
+      pages: Pages
+      pages_need_indexing: Pages That Need Indexing
+      pages_need_review: Pages That Need Review
+      pages_need_transcription: Pages That Need Transcription
+      pages_need_translation: Pages That Need Translation
+      translations_need_indexing: Translations That Need Indexing
+      translations_need_review: Translations That Need Review
   display_helper:
     page_action:
       blank_page: Blank page

--- a/config/locales/display/display-es.yml
+++ b/config/locales/display/display-es.yml
@@ -67,7 +67,6 @@ es:
       no_pages_needing_transcription_found_these_pages_are_incomplete: Ninguna página necesita transcripción desde cero. Estas páginas han sido parcialmente transcritas pero necesitan ser completadas.
       page_not_translated: Esta página no está traducida, por favor  %{help_translate} esta página
       pages_needing_completion: Páginas que necesitan completarse
-      pages_that_need_transcription: Páginas que necesitan transcripción
       review_metadata: Revisar metadatos
       this_page_is_blank: Esta página está en blanco
       this_page_is_incomplete: esta pagina esta incompleta
@@ -75,6 +74,17 @@ es:
       transcribed: transcrita
       translation: Traducción
       unable_to_find_pages: No pudimos encontrar ninguna página que coincida con la solicitud
+    read_all_works:
+      pages: Paginas
+      pages_that_mention: Páginas que mencionan %{article}
+    read_work:
+      pages: Paginas
+      pages_need_indexing: Páginas que necesitan indexación
+      pages_need_review: Páginas que necesitan revisión
+      pages_need_transcription: Páginas que necesitan transcripción
+      pages_need_translation: Páginas que necesitan traducción
+      translations_need_indexing: Traducciones que necesitan indexación
+      translations_need_review: Traducciones que necesitan revisión
   display_helper:
     page_action:
       blank_page: Página en blanco

--- a/config/locales/display/display-fr.yml
+++ b/config/locales/display/display-fr.yml
@@ -75,10 +75,10 @@ fr:
       translation: Traduction
       unable_to_find_pages: Nous n'avons trouvé aucune page correspondant à votre demande
     read_all_works:
-      pages: pages
+      pages: Pages
       pages_that_mention: Pages qui mentionnent %{article}
     read_work:
-      pages: pages
+      pages: Pages
       pages_need_indexing: Pages à indexer
       pages_need_review: Pages à réviser
       pages_need_transcription: Pages nécessitant une transcription

--- a/config/locales/display/display-fr.yml
+++ b/config/locales/display/display-fr.yml
@@ -67,7 +67,6 @@ fr:
       no_pages_needing_transcription_found_these_pages_are_incomplete: Aucune page n'a besoin d'être retranscrite à partir de zéro. Ces pages ont été partiellement transcrites mais doivent être complétées.
       page_not_translated: Cette page n'est pas traduite, veuillez %{help_translate} cette page
       pages_needing_completion: Pages à compléter
-      pages_that_need_transcription: Pages nécessitant une transcription
       review_metadata: Examiner les métadonnées
       this_page_is_blank: Cette page est vierge
       this_page_is_incomplete: Cette page est incomplète
@@ -75,6 +74,17 @@ fr:
       transcribed: transcrite
       translation: Traduction
       unable_to_find_pages: Nous n'avons trouvé aucune page correspondant à votre demande
+    read_all_works:
+      pages: pages
+      pages_that_mention: Pages qui mentionnent %{article}
+    read_work:
+      pages: pages
+      pages_need_indexing: Pages à indexer
+      pages_need_review: Pages à réviser
+      pages_need_transcription: Pages nécessitant une transcription
+      pages_need_translation: Pages à traduire
+      translations_need_indexing: Traductions nécessitant une indexation
+      translations_need_review: Traductions à revoir
   display_helper:
     page_action:
       blank_page: Page vierge

--- a/config/locales/display/display-pt.yml
+++ b/config/locales/display/display-pt.yml
@@ -67,7 +67,6 @@ pt:
       no_pages_needing_transcription_found_these_pages_are_incomplete: Nenhuma página precisa de transcrição do zero. Estas páginas foram parcialmente transcritas, mas precisam ser completadas.
       page_not_translated: Esta página não está traduzida, por favor %{help_translate} esta página
       pages_needing_completion: Páginas que precisam de conclusão
-      pages_that_need_transcription: Páginas que precisam de transcrição
       review_metadata: Revisar metadados
       this_page_is_blank: Esta página está em branco
       this_page_is_incomplete: Esta página está incompleta
@@ -75,6 +74,17 @@ pt:
       transcribed: transcreveu
       translation: Tradução
       unable_to_find_pages: Não conseguimos encontrar nenhuma página correspondente ao seu pedido
+    read_all_works:
+      pages: Páginas
+      pages_that_mention: Páginas que mencionam %{article}
+    read_work:
+      pages: Páginas
+      pages_need_indexing: Páginas que precisam de indexação
+      pages_need_review: Páginas que precisam de revisão
+      pages_need_transcription: Páginas que precisam de transcrição
+      pages_need_translation: Páginas que precisam de tradução
+      translations_need_indexing: Traduções que precisam de indexação
+      translations_need_review: Traduções que precisam de revisão
   display_helper:
     page_action:
       blank_page: Página em branco


### PR DESCRIPTION
_Resolves #3258_

### The issue

Anywhere that pages were being listed (for needing indexing, review, transcription, all pages, etc.) had the heading "Pages that need transcription", but that's not actually what was being shown.

This was because the `_pages_view` partial that all of these use had the heading statically set to "Pages that need transcription".

### The solution

I changed the heading to display a `@heading` variable which each controller can set depending on what type of pages will be shown.

![pages](https://user-images.githubusercontent.com/35716893/184004080-41a61c2a-3e51-4a20-882f-c5e36f419065.jpg)

![review](https://user-images.githubusercontent.com/35716893/184004106-c10c3b3e-a720-485a-97f1-b5a8e82f68f4.jpg)

![transcription](https://user-images.githubusercontent.com/35716893/184004018-ecff11ea-8a69-46ff-829b-0ed4da06c5fe.jpg)

![indexing](https://user-images.githubusercontent.com/35716893/184004361-0cfa432d-e828-4bb9-a76b-3bb541e19dac.jpg)

