### PR TITLE
Proof of concept for regional locales

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,7 +37,7 @@ class ApplicationController < ActionController::Base
     # if we can't find that, use browser locale
     if locale.nil?
       # the user might their locale set in the browser
-      locale = http_accept_language.compatible_language_from(I18n.available_locales)
+      locale = http_accept_language.preferred_language_from(I18n.available_locales)
     end
 
     if locale.nil? || !I18n.available_locales.include?(locale.to_sym)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,8 @@ class ApplicationController < ActionController::Base
   around_action :switch_locale
 
   def switch_locale(&action)
+    @dropdown_locales = I18n.available_locales.reject { |locale| locale.to_s.include? "-" }
+
     locale = nil
 
     # use user-record locale

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,6 +46,17 @@ class ApplicationController < ActionController::Base
       # use the default if the above optiosn didn't work
       locale = I18n.default_locale
     end
+
+    # append region to locale
+    related_locales = http_accept_language.user_preferred_languages.select{ |loc| 
+      loc.to_s.include?(locale) &&                # is related to the chosen locale (is the locale, or is a regional version of it)
+      I18n.available_locales.include?(loc.to_sym) # is an available locale
+    }
+    unless related_locales.empty?
+      # first preferred language from the related locales
+      locale = http_accept_language.preferred_language_from(related_locales)
+    end
+
     # execute the action with the locale
     I18n.with_locale(locale, &action)
   end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -83,7 +83,7 @@ html lang="en-US"
               span
                 big =locale.to_s.upcase
             dd
-              -I18n.available_locales.each do |locale_option|
+              -@dropdown_locales.each do |locale_option|
                 =link_to t(locale_option.to_s), user_choose_locale_path(locale_option.to_s)
 
     -if user_masquerade?

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -81,7 +81,7 @@ html lang="en-US"
           dl.dropdown.right
             dt.header_link.header_locale tabindex=0
               span
-                big =locale.to_s.upcase
+                big =locale.to_s.split("-")[0].upcase
             dd
               -@dropdown_locales.each do |locale_option|
                 =link_to t(locale_option.to_s), user_choose_locale_path(locale_option.to_s)

--- a/app/views/user/update_profile.html.slim
+++ b/app/views/user/update_profile.html.slim
@@ -51,7 +51,7 @@
         =f.hidden_field :about, value: "NOTOWNER"
       tr  
         th =f.label :preferred_locale, t('.interface_language'), class: 'collection-label'
-        td =f.select :preferred_locale, options_for_select(I18n.available_locales.map{|code| [I18n.translate(code), code]}, @user.preferred_locale), :include_blank => true
+        td =f.select :preferred_locale, options_for_select(@dropdown_locales.map{|code| [I18n.translate(code), code]}, @user.preferred_locale), :include_blank => true
       tr  
         td(colspan="2")
           =label_tag :dictation_language, t('.default_dictation_language'), class: 'collection-label'

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module Fromthepage
 
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**/*.{rb,yml}').to_s]
     config.i18n.default_locale = :en
-    config.i18n.available_locales = [:en, :es, :fr, :pt]
+    config.i18n.available_locales = [:en, :'en-GB', :es, :fr, :'fr-CA', :pt]
     config.i18n.fallbacks = true
     config.i18n.fallbacks = [:en]
   end

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -1,0 +1,14 @@
+---
+en-GB:
+  article:
+    show:
+      related_subjects_description: The graph displays the other subjects mentioned on the same pages as the subject "%{article}". If the same subject occurs on a page with "%{article}" more than once, it appears closer to "%{article}" on the graph, and is coloured in a darker shade. The closer a subject is to the center, the more "related" the subjects are.
+  article_version:
+    show:
+      description: Here you can see all subject revisions and compare the changes have been made in each revision. Left column shows the subject title and description in the selected revision, right column shows what have been changed. Unchanged text is <span>highlighted in white</span>, deleted text is <del>highlighted in red</del>, and inserted text is <ins>highlighted in green</ins> colour.
+  page_version:
+    show:
+      help_description: Here you can see all page revisions and compare the changes have been made in each revision. Left column shows the page title and transcription in the selected revision, right column shows what have been changed. Unchanged text is <span>highlighted in white</span>, deleted text is <del>highlighted in red</del>, and inserted text is <ins>highlighted in green</ins> colour.
+  work:
+    description_versions:
+      help_description: View and compare the changes that have been made in each revision to work metadata. The left column shows the metadata in the selected revision, right column shows what has been changed. Unchanged text is <span>highlighted in white</span>, deleted text is <del>highlighted in red</del>, and inserted text is <ins>highlighted in green</ins> colour.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,10 +8,8 @@ en:
     formats:
       default: "%b %d, %Y"
   en: English
-  en-GB: British English
   es: Español
   fr: Français
-  fr-CA: Francês canadense
   pt: Português
   time:
     formats:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,8 +8,10 @@ en:
     formats:
       default: "%b %d, %Y"
   en: English
+  en-GB: British English
   es: Español
   fr: Français
+  fr-CA: Francês canadense
   pt: Português
   time:
     formats:

--- a/config/locales/fr-CA.yml
+++ b/config/locales/fr-CA.yml
@@ -2,26 +2,26 @@
 fr-CA:
   collection:
     contributor_activity:
-      recent_ocr_correction: Correction d'ROC récente
+      recent_ocr_correction: Correction de ROC récente
     disable_ocr:
-      notice: La correction d'ROC a été désactivée pour toutes les œuvres.
+      notice: La correction de ROC a été désactivée pour toutes les œuvres.
     edit:
       disable_ocr: Désactiver la ROC
       enable_ocr: Activer ROC
-      ocr_correction: Correction d'ROC
-      ocr_correction_description: Activez ou désactivez la correction d'ROC pour toutes les œuvres de cette collection.
+      ocr_correction: Correction de ROC
+      ocr_correction_description: Activez ou désactivez la correction de ROC pour toutes les œuvres de cette collection.
     enable_ocr:
-      notice: La correction d'ROC a été activée pour toutes les œuvres.
+      notice: La correction de ROC a été activée pour toutes les œuvres.
   deed:
     ocr_corrected: ROC de page corrigé
   ia:
     manage:
-      first_line_of_ocr: Première ligne d'ROC
-      first_line_of_ocr_description: "<b>La première ligne de l'ROC</b> remplace les titres de page par la première ligne du texte ROC sur chaque page. Ceci est utile pour les agendas et les livres de jour, puisque la première ligne est généralement une date."
-      last_line_of_ocr: Dernière ligne de l'ROC
-      last_line_of_ocr_description: "<b>La dernière ligne de l'ROC</b> remplace les titres de page par la dernière ligne du texte ROC sur chaque page. Ceci est utile pour les œuvres imprimés dans lesquels les numéros de page apparaissent en bas."
+      first_line_of_ocr: Première ligne de ROC
+      first_line_of_ocr_description: "<b>La première ligne de la ROC</b> remplace les titres de page par la première ligne du texte ROC sur chaque page. Ceci est utile pour les agendas et les livres de jour, puisque la première ligne est généralement une date."
+      last_line_of_ocr: Dernière ligne de la ROC
+      last_line_of_ocr_description: "<b>La dernière ligne de la ROC</b> remplace les titres de page par la dernière ligne du texte ROC sur chaque page. Ceci est utile pour les œuvres imprimés dans lesquels les numéros de page apparaissent en bas."
       ocr_for_page_contents: Utiliser le texte ROC pour le contenu de la page ?
-      ocr_for_page_contents_description: Cochez cette case pour remplir la transcription initiale de chaque page avec le contenu de l'ROC correspondant. (Ne le faites pas si vos pages contiennent une écriture manuscrite que vous souhaitez transcrire.)
+      ocr_for_page_contents_description: Cochez cette case pour remplir la transcription initiale de chaque page avec le contenu de la ROC correspondant. (Ne le faites pas si vos pages contiennent une écriture manuscrite que vous souhaitez transcrire.)
       ocr_page_titles_description: Ce processus prendra plusieurs secondes pour s'exécuter, car il nécessite l'analyse de l'intégralité du texte ROC du livre et la mise à jour de chaque titre de page. Une fois le livre converti en une œuvre FromThePage, vous pourrez corriger les titres de page manuellement.
     title_from_ocr_bottom:
       pages_has_been_renamed: Les pages ont été renommées avec la ligne inférieure du texte ROC
@@ -37,14 +37,14 @@ fr-CA:
   statistics:
     collection_statistics:
       ocr_correction:
-        one: Correction d'ROC
-        other: Corrections d'ROC
+        one: Correction de ROC
+        other: Corrections de ROC
     recent_statistics:
-      ocr_correction: Correction d'ROC
+      ocr_correction: Correction de ROC
     statistics:
       ocr_correction:
-        one: Correction d'ROC
-        other: Corrections d'ROC
+        one: Correction de ROC
+        other: Corrections de ROC
   work:
     edit:
-      enable_ocr_correction: Activer la correction d'ROC
+      enable_ocr_correction: Activer la correction de ROC

--- a/config/locales/fr-CA.yml
+++ b/config/locales/fr-CA.yml
@@ -1,0 +1,50 @@
+---
+fr-CA:
+  collection:
+    contributor_activity:
+      recent_ocr_correction: Correction d'ROC récente
+    disable_ocr:
+      notice: La correction d'ROC a été désactivée pour toutes les œuvres.
+    edit:
+      disable_ocr: Désactiver la ROC
+      enable_ocr: Activer ROC
+      ocr_correction: Correction d'ROC
+      ocr_correction_description: Activez ou désactivez la correction d'ROC pour toutes les œuvres de cette collection.
+    enable_ocr:
+      notice: La correction d'ROC a été activée pour toutes les œuvres.
+  deed:
+    ocr_corrected: ROC de page corrigé
+  ia:
+    manage:
+      first_line_of_ocr: Première ligne d'ROC
+      first_line_of_ocr_description: "<b>La première ligne de l'ROC</b> remplace les titres de page par la première ligne du texte ROC sur chaque page. Ceci est utile pour les agendas et les livres de jour, puisque la première ligne est généralement une date."
+      last_line_of_ocr: Dernière ligne de l'ROC
+      last_line_of_ocr_description: "<b>La dernière ligne de l'ROC</b> remplace les titres de page par la dernière ligne du texte ROC sur chaque page. Ceci est utile pour les œuvres imprimés dans lesquels les numéros de page apparaissent en bas."
+      ocr_for_page_contents: Utiliser le texte ROC pour le contenu de la page ?
+      ocr_for_page_contents_description: Cochez cette case pour remplir la transcription initiale de chaque page avec le contenu de l'ROC correspondant. (Ne le faites pas si vos pages contiennent une écriture manuscrite que vous souhaitez transcrire.)
+      ocr_page_titles_description: Ce processus prendra plusieurs secondes pour s'exécuter, car il nécessite l'analyse de l'intégralité du texte ROC du livre et la mise à jour de chaque titre de page. Une fois le livre converti en une œuvre FromThePage, vous pourrez corriger les titres de page manuellement.
+    title_from_ocr_bottom:
+      pages_has_been_renamed: Les pages ont été renommées avec la ligne inférieure du texte ROC
+    title_from_ocr_top:
+      pages_has_been_renamed: Les pages ont été renommées avec la ligne supérieure du texte ROC
+  sc_collections:
+    cdm_bulk_import_new:
+      import_ocr_text: Importer du texte ROC à partir de CONTENTdm
+    explore_collection:
+      import_ocr_text: Importer du texte ROC à partir de CONTENTdm
+    explore_manifest:
+      import_ocr_text: Importer du texte ROC à partir de CONTENTdm
+  statistics:
+    collection_statistics:
+      ocr_correction:
+        one: Correction d'ROC
+        other: Corrections d'ROC
+    recent_statistics:
+      ocr_correction: Correction d'ROC
+    statistics:
+      ocr_correction:
+        one: Correction d'ROC
+        other: Corrections d'ROC
+  work:
+    edit:
+      enable_ocr_correction: Activer la correction d'ROC


### PR DESCRIPTION
_For #3249_

This adds 2 regional locales (`en-GB` and `fr-CA`) to see if regional locales work as expected. 
In `en-GB`, I replaced all messages that include "color" to use "colour"; in `fr-CA`, I replaced all messages that include "OCR" to use "ROC".

![colour](https://user-images.githubusercontent.com/35716893/184011372-02410944-dec0-4117-af05-bb5ac1550e17.jpg)
<img alt="roc" src="https://user-images.githubusercontent.com/35716893/184011530-24f49464-39f8-478e-81de-44636afa9e8c.jpg" width="45%">

As hoped, you only have to include the messages you want to override from the base language. `en-GB.yml` only includes messages with "colour", and `fr-CA.yml` only includes messages with "ROC". 

If you have your browser's language set to English (UK), your locale will be `en-GB`; the same goes for `fr-CA`. You can also pick a regional locale from the locale switcher dropdown.

<img alt="locale switcher" src="https://user-images.githubusercontent.com/35716893/184010357-731cfdbf-1aac-4467-83ac-6f60e8f2bb8b.jpg" width="30%">

### Questions

1. Do we want to keep the regional locales on the locale switcher? If so, how do we want to display them there?
2. Are there any other regional locales we want to add? 
3. Are there any other messages we want to override for these locales?