### PR TITLE
Localized prerendered deeds

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -119,14 +119,12 @@ module ApplicationHelper
   def show_prerender(prerender, locale) 
     begin
       prerenders = JSON.parse(prerender)
-      if prerenders.key? locale.to_s
-        # show prerender in specified locale
-        prerenders[locale.to_s]
-      else
+      unless render = prerenders[locale.to_s] # show prerender in specified locale
         # prerender doesn't have specified locale, show first fallback that prerender has
-        fallback = I18n.fallbacks[locale].select { |locale| prerenders.key? locale.to_s }.first
-        prerenders[fallback.to_s]
+        fallback = (I18n.fallbacks[locale].map(&:to_s) & prerenders.keys).first
+        render = prerenders[fallback]
       end
+      render
     rescue JSON::ParserError => e
       # prerender is a string, not hash
       prerender

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -116,6 +116,22 @@ module ApplicationHelper
     render({ :partial => 'deed/deeds', :locals => { :limit => limit, :deeds => deeds, :options => options} })
   end
 
+  def show_prerender(prerender, locale) 
+    begin
+      prerenders = JSON.parse(prerender)
+      if prerenders.key? locale.to_s
+        # show prerender in specified locale
+        prerenders[locale.to_s]
+      else
+        # prerender doesn't have specified locale, show default
+        prerenders[I18n.default_locale.to_s]
+      end
+    rescue JSON::ParserError => e
+      # prerender is a string, not hash
+      prerender
+    end
+  end
+
   def validation_summary(errors)
     if errors.is_a?(Enumerable) && errors.any?
       render({ :partial => 'shared/validation_summary', :locals => { :errors => errors } })

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -123,8 +123,9 @@ module ApplicationHelper
         # show prerender in specified locale
         prerenders[locale.to_s]
       else
-        # prerender doesn't have specified locale, show default
-        prerenders[I18n.default_locale.to_s]
+        # prerender doesn't have specified locale, show first fallback that prerender has
+        fallback = I18n.fallbacks[locale].select { |locale| prerenders.key? locale.to_s }.first
+        prerenders[fallback.to_s]
       end
     rescue JSON::ParserError => e
       # prerender is a string, not hash

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -119,12 +119,12 @@ module ApplicationHelper
   def show_prerender(prerender, locale) 
     begin
       prerenders = JSON.parse(prerender)
-      unless render = prerenders[locale.to_s] # show prerender in specified locale
+      unless rendered = prerenders[locale.to_s] # show prerender in specified locale
         # prerender doesn't have specified locale, show first fallback that prerender has
         fallback = (I18n.fallbacks[locale].map(&:to_s) & prerenders.keys).first
-        render = prerenders[fallback]
+        rendered = prerenders[fallback]
       end
-      render
+      rendered
     rescue JSON::ParserError => e
       # prerender is a string, not hash
       prerender

--- a/app/models/deed.rb
+++ b/app/models/deed.rb
@@ -34,12 +34,22 @@ class Deed < ApplicationRecord
   def calculate_prerender
     unless self.deed_type == DeedType::COLLECTION_INACTIVE || self.deed_type == DeedType::COLLECTION_ACTIVE
       renderer = ApplicationController.renderer.new
-      self.prerender = renderer.render(:partial => 'deed/deed.html', :locals => { :deed => self, :long_view => false, :prerender => true  })
+      locales = I18n.available_locales.reject { |locale| locale.to_s.include? "-" } # don't include regional locales
+      self.prerender = locales.to_h { |locale| 
+        [ locale, 
+          renderer.render(:partial => 'deed/deed.html', :locals => { :deed => self, :long_view => false, :prerender => true, locale: locale })
+        ] 
+      }.to_json
     end
   end
 
   def calculate_prerender_mailer
     renderer = ApplicationController.renderer.new
-    self.prerender_mailer = renderer.render(:partial => 'deed/deed.html', :locals => { :deed => self, :long_view => true, :prerender => true, :mailer => true })
+    locales = I18n.available_locales.reject { |locale| locale.to_s.include? "-" } # don't include regional locales
+    self.prerender_mailer = locales.to_h { |locale|
+      [ locale,
+        renderer.render(:partial => 'deed/deed.html', :locals => { :deed => self, :long_view => true, :prerender => true, :mailer => true, locale: locale })
+      ]
+    }.to_json
   end
 end

--- a/app/views/deed/_deed.html.slim
+++ b/app/views/deed/_deed.html.slim
@@ -2,111 +2,113 @@
 -suppress_collection = local_assigns[:suppress_collection]
 -mailer = local_assigns[:mailer] ? true : false
 -prerender = local_assigns[:prerender] ? true : false
+-locale = I18n.locale if local_assigns[:locale].nil?
 
--access_object = nil
--if prerender
-  -access_object = deed.collection
--else
-  -if deed.collection && deed.work
-    -access_object = deed.work.access_object(current_user)
-
--user_name = deed.user.display_name if deed.user
-
--user = link_to(user_name, user_profile_url(deed.user, only_path: !mailer))
-
--if deed.page.nil?
-  -page = ''
--else
-  -if access_object
-    -page = link_to(deed.page.title, collection_display_page_url(access_object.owner, access_object, deed.work, deed.page, only_path: !mailer))
-  -else
-    -page = deed.page.title
--article = deed.article.nil? ? '' : link_to(deed.article.title, collection_article_show_url(deed.article.collection.owner, deed.article.collection, deed.article, only_path: !mailer))
-
--if(!deed.work.nil? && !deed.work.collection.nil? )
-  -if access_object
-    -work = link_to(deed.work.title, collection_read_work_url(access_object.owner, access_object, deed.work, only_path: !mailer))
-  -else
-    -work = deed.work.title
-
--unless(deed.collection.nil?)
+-I18n.with_locale(locale) do
+  -access_object = nil
   -if prerender
-     -collection = link_to(deed.collection.title, collection_url(deed.collection.owner, deed.collection, only_path: !mailer ))
+    -access_object = deed.collection
   -else
-    -if deed.collection.show_to?(current_user)
+    -if deed.collection && deed.work
+      -access_object = deed.work.access_object(current_user)
+
+  -user_name = deed.user.display_name if deed.user
+
+  -user = link_to(user_name, user_profile_url(deed.user, only_path: !mailer))
+
+  -if deed.page.nil?
+    -page = ''
+  -else
+    -if access_object
+      -page = link_to(deed.page.title, collection_display_page_url(access_object.owner, access_object, deed.work, deed.page, only_path: !mailer))
+    -else
+      -page = deed.page.title
+  -article = deed.article.nil? ? '' : link_to(deed.article.title, collection_article_show_url(deed.article.collection.owner, deed.article.collection, deed.article, only_path: !mailer))
+
+  -if(!deed.work.nil? && !deed.work.collection.nil? )
+    -if access_object
+      -work = link_to(deed.work.title, collection_read_work_url(access_object.owner, access_object, deed.work, only_path: !mailer))
+    -else
+      -work = deed.work.title
+
+  -unless(deed.collection.nil?)
+    -if prerender
       -collection = link_to(deed.collection.title, collection_url(deed.collection.owner, deed.collection, only_path: !mailer ))
-    -elsif access_object
-      -collection = link_to(access_object.title, collection_url(access_object.owner, access_object, only_path: !mailer ))
     -else
-      -collection = deed.collection.title
--output = "#{user} "
+      -if deed.collection.show_to?(current_user)
+        -collection = link_to(deed.collection.title, collection_url(deed.collection.owner, deed.collection, only_path: !mailer ))
+      -elsif access_object
+        -collection = link_to(access_object.title, collection_url(access_object.owner, access_object, only_path: !mailer ))
+      -else
+        -collection = deed.collection.title
+  -output = "#{user} "
 
--case deed.deed_type
--when DeedType::PAGE_TRANSCRIPTION
-  -output += t('.transcribed_page', page: page)
+  -case deed.deed_type
+  -when DeedType::PAGE_TRANSCRIPTION
+    -output += t('.transcribed_page', page: page)
 
--when DeedType::PAGE_EDIT
-  -output += t('.edited_page', page: page)
+  -when DeedType::PAGE_EDIT
+    -output += t('.edited_page', page: page)
 
--when DeedType::PAGE_INDEXED
-  -output += t('.indexed_page', page: page)
-  
--when DeedType::PAGE_MARKED_BLANK
-  -output += t('.marked_page_as_blank', page: page)
-
--when DeedType::ARTICLE_EDIT
-  -output += t('.edited_article', article: article)
-
--when DeedType::NOTE_ADDED
-  -output += t('.added_a_note_to_page', page: page)
-
--when DeedType::PAGE_TRANSLATED
-  -output += t('.translated_page', page: page)
-
--when DeedType::PAGE_TRANSLATION_EDIT
-  -output += t('.edited_translation_of_page', page: page)
-
--when DeedType::OCR_CORRECTED
-  -output += t('.corrected_page', page: page)
-
--when DeedType::NEEDS_REVIEW
-  -output += t('.marked_page_as_needing_review', page: page)
-
--when DeedType::PAGE_REVIEWED
-  -output += t('.reviewed_page', page: page)
-
--when DeedType::TRANSLATION_INDEXED
-  -output += t('.indexed_translation_of_page', page: page)
-
--when DeedType::TRANSLATION_REVIEW
-  -output += t('.marked_translation_page_as_needing_review', page: page)
-
--when DeedType::TRANSLATION_REVIEWED
-  -output += t('.reviewed_translation', page: page)
-
--when DeedType::WORK_ADDED
-  -output += t('.added_work', work: work)
-
--when DeedType::COLLECTION_JOINED
-    -output += t('.joined')
+  -when DeedType::PAGE_INDEXED
+    -output += t('.indexed_page', page: page)
     
-    -if deed.collection.nil?
-      -output += t('.this_collection')
-    -else
-      -output += collection
+  -when DeedType::PAGE_MARKED_BLANK
+    -output += t('.marked_page_as_blank', page: page)
 
--when DeedType::DESCRIBED_METADATA
-  -output += t('.described_metadata')
+  -when DeedType::ARTICLE_EDIT
+    -output += t('.edited_article', article: article)
 
--when DeedType::EDITED_METADATA
-  -output += t('.edited_metadata')
+  -when DeedType::NOTE_ADDED
+    -output += t('.added_a_note_to_page', page: page)
 
--if(!deed.work.nil?)
-  -output += t('.in_the_work', work: work)
+  -when DeedType::PAGE_TRANSLATED
+    -output += t('.translated_page', page: page)
 
--if(!collection.nil? && deed.deed_type != DeedType::COLLECTION_JOINED && !suppress_collection)
-  -output += t('.in_collection', collection: collection)
+  -when DeedType::PAGE_TRANSLATION_EDIT
+    -output += t('.edited_translation_of_page', page: page)
 
--if(long_view && deed.deed_type == DeedType::NOTE_ADDED && !deed.note.nil?)
-  -output += t('.saying_deed', title: deed.note.title).html_safe
-==output
+  -when DeedType::OCR_CORRECTED
+    -output += t('.corrected_page', page: page)
+
+  -when DeedType::NEEDS_REVIEW
+    -output += t('.marked_page_as_needing_review', page: page)
+
+  -when DeedType::PAGE_REVIEWED
+    -output += t('.reviewed_page', page: page)
+
+  -when DeedType::TRANSLATION_INDEXED
+    -output += t('.indexed_translation_of_page', page: page)
+
+  -when DeedType::TRANSLATION_REVIEW
+    -output += t('.marked_translation_page_as_needing_review', page: page)
+
+  -when DeedType::TRANSLATION_REVIEWED
+    -output += t('.reviewed_translation', page: page)
+
+  -when DeedType::WORK_ADDED
+    -output += t('.added_work', work: work)
+
+  -when DeedType::COLLECTION_JOINED
+      -output += t('.joined')
+      
+      -if deed.collection.nil?
+        -output += t('.this_collection')
+      -else
+        -output += collection
+
+  -when DeedType::DESCRIBED_METADATA
+    -output += t('.described_metadata')
+
+  -when DeedType::EDITED_METADATA
+    -output += t('.edited_metadata')
+
+  -if(!deed.work.nil?)
+    -output += t('.in_the_work', work: work)
+
+  -if(!collection.nil? && deed.deed_type != DeedType::COLLECTION_JOINED && !suppress_collection)
+    -output += t('.in_collection', collection: collection)
+
+  -if(long_view && deed.deed_type == DeedType::NOTE_ADDED && !deed.note.nil?)
+    -output += t('.saying_deed', title: deed.note.title).html_safe
+  ==output

--- a/app/views/deed/_deeds.html.slim
+++ b/app/views/deed/_deeds.html.slim
@@ -7,7 +7,7 @@
       =t('.time_ago_in_words', time: time_ago_in_words(d.created_at))
     span.deed-short_content
         -if d.prerender
-          =raw(d.prerender)
+          ==show_prerender(d.prerender, I18n.locale)
         -else
           =render(:partial => 'deed/deed.html', :locals => { :deed => d, :long_view => long_view, :suppress_collection => suppress_collection })
 

--- a/db/migrate/20220812203801_change_deeds_prerender_size.rb
+++ b/db/migrate/20220812203801_change_deeds_prerender_size.rb
@@ -1,7 +1,7 @@
 class ChangeDeedsPrerenderSize < ActiveRecord::Migration[6.0]
   def up
-    change_column :deeds, :prerender, :string, :limit => 4095
-    change_column :deeds, :prerender_mailer, :string, :limit => 4095
+    change_column :deeds, :prerender, :string, :limit => 8191
+    change_column :deeds, :prerender_mailer, :string, :limit => 8191
   end
   def down 
     change_column :deeds, :prerender, :string, :limit => 2047

--- a/db/migrate/20220812203801_change_deeds_prerender_size.rb
+++ b/db/migrate/20220812203801_change_deeds_prerender_size.rb
@@ -1,0 +1,10 @@
+class ChangeDeedsPrerenderSize < ActiveRecord::Migration[6.0]
+  def up
+    change_column :deeds, :prerender, :string, :limit => 4095
+    change_column :deeds, :prerender_mailer, :string, :limit => 4095
+  end
+  def down 
+    change_column :deeds, :prerender, :string, :limit => 2047
+    change_column :deeds, :prerender_mailer, :string, :limit => 2047
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -225,8 +225,8 @@ ActiveRecord::Schema.define(version: 2022_08_12_203801) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "visit_id"
-    t.string "prerender", limit: 4095
-    t.string "prerender_mailer", limit: 4095
+    t.string "prerender", limit: 8191
+    t.string "prerender_mailer", limit: 8191
     t.boolean "is_public", default: true
     t.index ["article_id"], name: "index_deeds_on_article_id"
     t.index ["collection_id", "user_id", "created_at"], name: "index_deeds_on_collection_id_user_id_created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_28_190940) do
+ActiveRecord::Schema.define(version: 2022_08_12_203801) do
 
   create_table "ahoy_activity_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "date"
@@ -155,7 +155,7 @@ ActiveRecord::Schema.define(version: 2022_07_28_190940) do
     t.datetime "updated_at"
   end
 
-  create_table "collection_reviewers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "collection_reviewers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.integer "collection_id"
     t.datetime "created_at", null: false
@@ -193,7 +193,6 @@ ActiveRecord::Schema.define(version: 2022_07_28_190940) do
     t.boolean "facets_enabled", default: false
     t.boolean "user_download", default: false
     t.string "review_type", default: "optional"
-    t.boolean "review_workflow", default: false
     t.string "data_entry_type", default: "text"
     t.text "description_instructions"
     t.boolean "enable_spellcheck", default: false
@@ -226,8 +225,8 @@ ActiveRecord::Schema.define(version: 2022_07_28_190940) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "visit_id"
-    t.string "prerender", limit: 2047
-    t.string "prerender_mailer", limit: 2047
+    t.string "prerender", limit: 4095
+    t.string "prerender_mailer", limit: 4095
     t.boolean "is_public", default: true
     t.index ["article_id"], name: "index_deeds_on_article_id"
     t.index ["collection_id", "user_id", "created_at"], name: "index_deeds_on_collection_id_user_id_created_at"
@@ -385,7 +384,7 @@ ActiveRecord::Schema.define(version: 2022_07_28_190940) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "metadata_description_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "metadata_description_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "metadata_description"
     t.integer "user_id", null: false
     t.integer "work_id", null: false
@@ -565,7 +564,7 @@ ActiveRecord::Schema.define(version: 2022_07_28_190940) do
     t.integer "version"
   end
 
-  create_table "quality_samplings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "quality_samplings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "collection_id", null: false
     t.text "sample_set", size: :medium
@@ -837,6 +836,7 @@ ActiveRecord::Schema.define(version: 2022_07_28_190940) do
     t.string "identifier"
     t.integer "next_untranscribed_page_id"
     t.text "original_metadata"
+    t.string "uploaded_filename"
     t.string "genre"
     t.string "source_location"
     t.string "source_collection_name"
@@ -844,7 +844,6 @@ ActiveRecord::Schema.define(version: 2022_07_28_190940) do
     t.boolean "in_scope", default: true
     t.text "editorial_notes"
     t.string "document_date"
-    t.string "uploaded_filename"
     t.text "metadata_description"
     t.integer "metadata_description_version_id"
     t.string "description_status", default: "undescribed"


### PR DESCRIPTION
_Resolves #3262_

Deeds for short-form lists (i.e. on a collection's page, an owner dashboard, etc.) are pre-rendered and were previously stored as a string of HTML, in the locale of the user who created them. 
This changes the deeds' prerender to store the string of HTML in _each_ locale. When the deed is displayed, it's displayed in the _current_ user's locale.

### Storing

When the deed's prerender is stored, a hash is created that maps each locale (excluding regional locales, to save space as they aren't currently any different for deeds) to the string of HTML in that locale. The deed is rendered in different locales by putting the `_deed` partial in a `I18n.with_locale` block. The hash is then converted to JSON to be stored in the db as a string.

A migration was made to increase the size of `prerender`s in the db from 2047 to 8191; some can be pretty long depending on the length of their titles & links.

### Displaying

There are 3 possible cases for each deed when accessing/displaying it:
1. It's a string, not a hash, because it was created before this change
In this case, attempting to parse the prerender's JSON will fail, will be caught by a `rescue`, and this string is displayed.
2. It's a hash that includes the current user's locale
The JSON will parse and the prerender with the current user's locale is displayed.
3. It's a hash that doesn't include the current user's locale
The JSON will parse but will not have a key for the current user's locale. Look in the `I18n.fallbacks` for that locale, and the first fallback to be a key in the `prerenders` is the locale that the deed is displayed in.
Examples: if the current user's locale is `fr-CA`, the fallbacks would be `[:fr-CA, :fr, :en]`, and the deed is displayed in `:fr`. If the current user's locale is `:it`, the fallbacks would be `[:it, :en]` and the deed is displayed in `:en`.