### PR TITLE
Made owner deed list show owner's collection's deeds

### DIFF
--- a/app/controllers/deed_controller.rb
+++ b/app/controllers/deed_controller.rb
@@ -10,8 +10,13 @@ class DeedController < ApplicationController
       # show more link on collections and document sets
       @deed = @collection.deeds
     elsif @user
-      # user activity stream show more link
-      @deed = @user.deeds.includes(:note, :page, :user, :work, :collection).paginate :page => params[:page], :per_page => PAGES_PER_SCREEN
+      if @user.owner?
+        # owner profile show more link
+        @deed = Deed.where(collection_id: @user.all_owner_collections.ids)
+      else
+        # user activity stream show more link
+        @deed = @user.deeds.includes(:note, :page, :user, :work, :collection).paginate :page => params[:page], :per_page => PAGES_PER_SCREEN
+      end
     else
       # show more link for site-wide/find-a-project Show More links
       if current_user && current_user.admin && params[:private]=='true'

--- a/app/views/deed/_deeds.html.slim
+++ b/app/views/deed/_deeds.html.slim
@@ -14,6 +14,6 @@
 
 small.legend
   =link_to t('.show_more'),
-    deed_list_path(:collection_id => @collection ? @collection.slug : nil, :user_id => options[:user_id]),
+    deed_list_path(:collection_id => @collection ? @collection.slug : nil, :user_id => options[:user_id] || options[:owner]),
     class: 'button outline round',
     id: 'show-more-deeds'

--- a/app/views/deed/list.html.slim
+++ b/app/views/deed/list.html.slim
@@ -9,7 +9,10 @@ h1 =t('.activity_stream')
 -if @collection
   h3 =t('.collection_title', title: @collection.title)
 -if @user
-  h3 =t('.user_title', title: @user.display_name)
+  -if @user.owner?
+    h3 =t('.owner_title', title: @user.display_name)
+  -else
+    h3 =t('.user_title', title: @user.display_name)
 
 table.datagrid.striped
   -@deeds.each do |d|

--- a/config/locales/deed/deed-en.yml
+++ b/config/locales/deed/deed-en.yml
@@ -39,6 +39,7 @@ en:
       collection_title: 'Collection: %{title}'
       newer_activity: Newer Activity
       older_activity: Older Activity
+      owner_title: 'Owner: %{title}'
       time_ago_in_words: "%{time} ago"
       user_title: 'User: %{title}'
     needs_review: Page Needs Review

--- a/config/locales/deed/deed-es.yml
+++ b/config/locales/deed/deed-es.yml
@@ -37,6 +37,7 @@ es:
       collection_title: 'Colección: %{title}'
       newer_activity: Actividad Más Reciente
       older_activity: Actividad Anterior
+      owner_title: 'Propietario: %{title}'
       time_ago_in_words: Hace %{time}
       user_title: 'Usuario: %{title}'
     needs_review: Página necesita revisión

--- a/config/locales/deed/deed-fr.yml
+++ b/config/locales/deed/deed-fr.yml
@@ -39,6 +39,7 @@ fr:
       collection_title: 'Collection : %{title}'
       newer_activity: Activité plus récente
       older_activity: Activité plus ancienne
+      owner_title: 'Propriétaire : %{title}'
       time_ago_in_words: Il y a %{time}
       user_title: 'Utilisateur : %{title}'
     needs_review: La page doit être révisée

--- a/config/locales/deed/deed-pt.yml
+++ b/config/locales/deed/deed-pt.yml
@@ -37,6 +37,7 @@ pt:
       collection_title: 'Coleção: %{title}'
       newer_activity: Atividade Mais Recente
       older_activity: Atividade Mais Antiga
+      owner_title: 'Proprietário: %{title}'
       time_ago_in_words: Há %{time}
       user_title: 'Usuário: %{title}'
     needs_review: A página precisa de revisão


### PR DESCRIPTION
_Resolves #3261_

Previously, the "show more" (deed list) page for a collection owner was showing _all_ of the FTP deeds instead of just deeds related to that owner.

This is because only `options[:user_id]` was being passed to the deed list page, which was `nil`, as `options[:owner]` is what carried the owner's id. Now `options[:owner]` is passed if `options[:user_id]` is `nil`. 
In the deed list, it's checked if `@user` is an owner or not, and if it is, the deeds to display will be deeds on that owner's collections, just like on the shortened deed list.

![image](https://user-images.githubusercontent.com/35716893/184922829-038f0592-ed80-49ad-8cd6-56a2a48e8c47.png)
