### PR TITLE
Extracted & localized "wrote" in recent notes

### DIFF
--- a/app/views/collection/show.html.slim
+++ b/app/views/collection/show.html.slim
@@ -124,7 +124,7 @@
           =time_tag(note.created_at, class: 'legend legend-left')
             =t('.time_ago_in_words', time: time_ago_in_words(note.created_at))
           span.deed-short_content
-            =="#{user} wrote #{text}"
+            ==t('.user_wrote_note', user: user, note: text)
     small.legend
       =link_to t('.show_more'), deed_notes_path(@collection.slug), class: 'button outline round'
 

--- a/config/locales/collection/collection-en.yml
+++ b/config/locales/collection/collection-en.yml
@@ -257,6 +257,7 @@ en:
       this_work_has_not_been_described: This work needs better metadata.
       this_work_has_pages_that_need_work: Some pages still need work.
       time_ago_in_words: "%{time} ago"
+      user_wrote_note: "%{user} wrote %{note}"
       works: Works
     start_transcribing:
       notice: Sorry, but there are no qualifying pages in this collection.

--- a/config/locales/collection/collection-es.yml
+++ b/config/locales/collection/collection-es.yml
@@ -257,6 +257,7 @@ es:
       this_work_has_not_been_described: Este trabajo necesita mejores metadatos.
       this_work_has_pages_that_need_work: Algunas páginas todavía necesitan trabajo.
       time_ago_in_words: Hace %{time}
+      user_wrote_note: "%{user} escribió %{note}"
       works: Obras
     start_transcribing:
       notice: Lo sentimos, pero no hay páginas cualificadas en esta colección.

--- a/config/locales/collection/collection-fr.yml
+++ b/config/locales/collection/collection-fr.yml
@@ -257,6 +257,7 @@ fr:
       this_work_has_not_been_described: Ce œuvre a besoin de meilleures métadonnées.
       this_work_has_pages_that_need_work: Certaines pages ont encore besoin de œuvre.
       time_ago_in_words: Il y a %{time}
+      user_wrote_note: "%{user} a écrit %{note}"
       works: Œuvres
     start_transcribing:
       notice: Désolé, mais il n'y a pas de pages de qualification dans cette collection.

--- a/config/locales/collection/collection-pt.yml
+++ b/config/locales/collection/collection-pt.yml
@@ -257,6 +257,7 @@ pt:
       this_work_has_not_been_described: Este trabalho precisa de melhores metadados.
       this_work_has_pages_that_need_work: Algumas páginas ainda precisam de trabalho.
       time_ago_in_words: Há %{time}
+      user_wrote_note: "%{user} escreveu %{note}"
       works: Obras
     start_transcribing:
       notice: Desculpe, mas não há páginas com esses critérios nesta coleção.


### PR DESCRIPTION
_Resolves #3265_

User "wrote" note previously was in plaintext in the collection `show` view. This PR extracts it to locales and adds translations in all 4 languages.

![translated recent notes](https://user-images.githubusercontent.com/35716893/185465508-93b2bc9e-fc88-444f-80fd-50c0bdca4f1b.jpg)
