### PR TITLE
Strip style elements from snippets for #3146

### DIFF
--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -15,9 +15,12 @@ module DashboardHelper
     end
   end
 
-  def strip_style(html)
-    doc = Nokogiri::HTML(html)
-    doc.xpath('//style').each { |n| n.remove }
-    doc.to_s
+  # makes an intro block into a snippet by removing style tag, stripping tags, and truncating
+  def to_snippet(intro_block)
+    # remove style tag, Loofah.fragment.text doesn't do this (strip_tags does)
+    doc = Nokogiri::HTML(intro_block)
+    doc.xpath('//style').each { |n| n.remove } 
+    # strip tags and truncate
+    truncate(Loofah.fragment(doc.to_s).text(encode_special_chars: false), length: 300, separator: ' ') || '' 
   end
 end

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -14,4 +14,10 @@ module DashboardHelper
       content_for :page_title, "Summary - Owner Dashboard"
     end
   end
+
+  def strip_style(html)
+    doc = Nokogiri::HTML(html)
+    doc.xpath('//style').each { |n| n.remove }
+    doc.to_s
+  end
 end

--- a/app/views/dashboard/landing_page.html.slim
+++ b/app/views/dashboard/landing_page.html.slim
@@ -3,7 +3,7 @@
     -@collections.each do |c|
       -cache c do
         -link_page = c.next_untranscribed_page
-        -snippet = truncate(Loofah.fragment(c.intro_block).text(encode_special_chars: false), length: 300, separator: ' ') || ''
+        -snippet = truncate(Loofah.fragment(strip_style(c.intro_block)).text(encode_special_chars: false), length: 300, separator: ' ') || ''
         .carousel_slide
           =link_to image_tag(c.picture_url, alt: c.title), collection_path(c.owner, c), class: 'carousel_slide_image'
           .carousel_slide_content
@@ -31,7 +31,7 @@
                 h5
                   =link_to sr.title, collection_path(sr.owner.slug, sr.id)
                 .projects_collection_snippet
-                  = truncate(Loofah.fragment(sr.intro_block).text(encode_special_chars: false), length: 300, separator: ' ') || ''
+                  = truncate(Loofah.fragment(strip_style(sr.intro_block)).text(encode_special_chars: false), length: 300, separator: ' ') || ''
     -@owners.each do |owner|
       -if params[:search]
         -projects = @search_results.select{ |p| p.owner_user_id == owner.id}
@@ -47,7 +47,7 @@
                 =owner.about
           .projects
             -projects.each do |project|
-              -snippet = truncate(Loofah.fragment(project.intro_block).text(encode_special_chars: false), length: 300, separator: ' ') || ''
+              -snippet = truncate(Loofah.fragment(strip_style(project.intro_block)).text(encode_special_chars: false), length: 300, separator: ' ') || ''
               div.projects_details
                 -unless project.picture.blank?
                   .projects_details_image

--- a/app/views/dashboard/landing_page.html.slim
+++ b/app/views/dashboard/landing_page.html.slim
@@ -3,7 +3,7 @@
     -@collections.each do |c|
       -cache c do
         -link_page = c.next_untranscribed_page
-        -snippet = truncate(Loofah.fragment(strip_style(c.intro_block)).text(encode_special_chars: false), length: 300, separator: ' ') || ''
+        -snippet = to_snippet(c.intro_block)
         .carousel_slide
           =link_to image_tag(c.picture_url, alt: c.title), collection_path(c.owner, c), class: 'carousel_slide_image'
           .carousel_slide_content
@@ -31,7 +31,7 @@
                 h5
                   =link_to sr.title, collection_path(sr.owner.slug, sr.id)
                 .projects_collection_snippet
-                  = truncate(Loofah.fragment(strip_style(sr.intro_block)).text(encode_special_chars: false), length: 300, separator: ' ') || ''
+                  = to_snippet(sr.intro_block)
     -@owners.each do |owner|
       -if params[:search]
         -projects = @search_results.select{ |p| p.owner_user_id == owner.id}
@@ -47,7 +47,7 @@
                 =owner.about
           .projects
             -projects.each do |project|
-              -snippet = truncate(Loofah.fragment(strip_style(project.intro_block)).text(encode_special_chars: false), length: 300, separator: ' ') || ''
+              -snippet = to_snippet(project.intro_block)
               div.projects_details
                 -unless project.picture.blank?
                   .projects_details_image


### PR DESCRIPTION
_Resolves #3146_

This uses Nokogiri to remove the `style` element and its contents from collections' `intro_block`s when they're being shown as a snippet on the Find a Project page, because previously the contents of the `style` element were showing up instead of the collection's description.

With this PR, there is no HTML in the snippet _and_ ampersands show up correctly.

![snippet](https://user-images.githubusercontent.com/35716893/185497656-df80ada7-6ce9-4372-acf4-cbe0ff7bb61b.jpg)

### `strip_tags(intro_block)` vs. `Loofah.fragment(intro_block).text`

We were initially using `strip_tags` to remove HTML tags from the collection's description and shorten it for the Find a Project page. `strip_tags` automatically removed the `style` element and its contents, so there was no HTML shown like there is in this issue. However, `strip_tags` escaped special characters like `&` to `&amp;`, which we did not want.
So [we switched to](https://github.com/benwbrum/fromthepage/pull/2994) `Loofah.fragment.text`, which gives the option to not `encode_special_chars`. However, `Loofah.fragment.text` does _not_ remove the contents of the `style` element, making this PR necessary.

### Changes made

I added a helper function `to_snippet(intro_block)` that does the following:
1. Removes the `style` element and its contents from the intro block
2. Strips the tags from the `intro_block` using `Loofah.fragment.text` 
3. Truncates the `intro_block`

2 and 3 were previously done in the view, but I moved them to this helper function to consolidate everything into one place, as this sequence is repeated in multiple places in the Find a Project view.