### PR TITLE
Fixed French "needs work" translation for #3271

### DIFF
--- a/config/locales/collection/collection-fr.yml
+++ b/config/locales/collection/collection-fr.yml
@@ -255,7 +255,7 @@ fr:
       start_transcribing: Commencer à transcrire
       subject_categories: Catégories de sujets
       this_work_has_not_been_described: Ce œuvre a besoin de meilleures métadonnées.
-      this_work_has_pages_that_need_work: Certaines pages ont encore besoin de œuvre.
+      this_work_has_pages_that_need_work: Certaines pages ont encore besoin d'amélioration.
       time_ago_in_words: Il y a %{time}
       user_wrote_note: "%{user} a écrit %{note}"
       works: Œuvres


### PR DESCRIPTION
_Resolves #3271_

This changes the French translation of "needs work" from "besoin de œuvre" to "besoin d'amélioration"

This was the only one place I could find that says "...need(s) work"