### PR TITLE
First attempt at improving owner dashboard summary for #3245

### DIFF
--- a/app/models/owner_statistic.rb
+++ b/app/models/owner_statistic.rb
@@ -49,7 +49,9 @@ module OwnerStatistic
   end
 
   def contributor_count(days=nil)
-    User.joins(:deeds).where(deeds: {collection_id: collection_ids}).where(date_range_clause(days, 'deeds.created_at')).distinct.count
+    User.joins(:deeds).where(deeds: {collection_id: collection_ids})
+      .where.not(deeds: {deed_type: DeedType::COLLECTION_JOINED})
+      .where(date_range_clause(days, 'deeds.created_at')).distinct.count
   end
 
   def comment_count(days=nil)

--- a/app/models/owner_statistic.rb
+++ b/app/models/owner_statistic.rb
@@ -20,15 +20,15 @@ module OwnerStatistic
       .where(status: Page::NEEDS_WORK_STATUSES).count
   end
   
-  def needs_review_count(last_days=nil)
+  def needs_review_count(days=nil)
     Page.where(work_id: self.owner_works.ids)
-      .where("#{last_days_clause(last_days, "edit_started_at")}")
+      .where(date_range_clause(days, "edit_started_at"))
       .where(status: Page::STATUS_NEEDS_REVIEW).count
   end
   
-  def review_count(last_days=nil)
+  def review_count(days=nil)
     Deed.where(work_id: self.owner_works.ids)
-      .where("#{last_days_clause(last_days)}")
+      .where(date_range_clause(days))
       .where(deed_type: DeedType::PAGE_REVIEWED).count
   end
 
@@ -40,50 +40,50 @@ module OwnerStatistic
     [self.all_owner_collections.ids]
   end
 
-  def subject_count(last_days=nil)
-    owner_subjects.where("#{last_days_clause(last_days, 'created_on')}").count
+  def subject_count(days=nil)
+    owner_subjects.where(date_range_clause(days, 'created_on')).count
   end
 
-  def mention_count(last_days=nil)
-    PageArticleLink.where(article_id: owner_subjects.ids).where("#{last_days_clause(last_days, 'created_on')}").count
+  def mention_count(days=nil)
+    PageArticleLink.where(article_id: owner_subjects.ids).where(date_range_clause(days, 'created_on')).count
   end
 
-  def contributor_count(last_days=nil)
-    User.joins(:deeds).where(deeds: {collection_id: collection_ids}).where("#{last_days_clause(last_days, 'deeds.created_at')}").distinct.count
+  def contributor_count(days=nil)
+    User.joins(:deeds).where(deeds: {collection_id: collection_ids}).where(date_range_clause(days, 'deeds.created_at')).distinct.count
   end
 
-  def comment_count(last_days=nil)
-    Deed.where(collection_id: collection_ids).where(deed_type: DeedType::NOTE_ADDED).where("#{last_days_clause(last_days)}").count
+  def comment_count(days=nil)
+    Deed.where(collection_id: collection_ids).where(deed_type: DeedType::NOTE_ADDED).where(date_range_clause(days)).count
 
   end
 
-  def transcription_count(last_days=nil)
-    Deed.where(collection_id: collection_ids).where(deed_type: DeedType::PAGE_TRANSCRIPTION).where("#{last_days_clause(last_days)}").count
+  def transcription_count(days=nil)
+    Deed.where(collection_id: collection_ids).where(deed_type: DeedType::PAGE_TRANSCRIPTION).where(date_range_clause(days)).count
   end
 
-  def edit_count(last_days=nil)
-    Deed.where(collection_id: collection_ids).where(deed_type: DeedType::PAGE_EDIT).where("#{last_days_clause(last_days)}").count
+  def edit_count(days=nil)
+    Deed.where(collection_id: collection_ids).where(deed_type: DeedType::PAGE_EDIT).where(date_range_clause(days)).count
   end
 
-  def index_count(last_days=nil)
-    Deed.where(collection_id: collection_ids).where(deed_type: DeedType::PAGE_INDEXED).where("#{last_days_clause(last_days)}").count
+  def index_count(days=nil)
+    Deed.where(collection_id: collection_ids).where(deed_type: DeedType::PAGE_INDEXED).where(date_range_clause(days)).count
   end
 
-  def translation_count(last_days=nil)
-    Deed.where(collection_id: collection_ids).where(deed_type: DeedType::PAGE_TRANSLATED).where("#{last_days_clause(last_days)}").count
+  def translation_count(days=nil)
+    Deed.where(collection_id: collection_ids).where(deed_type: DeedType::PAGE_TRANSLATED).where(date_range_clause(days)).count
   end
 
-  def ocr_count(last_days=nil)
-    Deed.where(collection_id: collection_ids).where(deed_type: DeedType::OCR_CORRECTED).where("#{last_days_clause(last_days)}").count
+  def ocr_count(days=nil)
+    Deed.where(collection_id: collection_ids).where(deed_type: DeedType::OCR_CORRECTED).where(date_range_clause(days)).count
   end
 
-  def last_days_clause(last_days, column = "created_at")
-    clause = ""
-    if last_days
-      timeframe = last_days.days.ago
-      clause = "#{column} >= '#{timeframe}'"
+  def date_range_clause(days, column = "created_at")
+    if days.nil?
+      return ""
+    elsif days.is_a? Integer
+      days = (days.days.ago)..(Time.now)
     end
-    return clause
+    return {column.to_sym => days}
   end
 
   def all_collaborators

--- a/app/views/statistics/_collaborator_time.slim
+++ b/app/views/statistics/_collaborator_time.slim
@@ -1,19 +1,3 @@
-h4.legend.fglight= t('.collaborator_time_for_dates')
-
-=form_tag('/dashboard/summary', method: "get") do
-  =hidden_field_tag(:collection_id, @collection)
-  =label_tag(:start_date, t('.start_date'))
-  |  
-  =text_field_tag(:start_date, l(@start_date.to_date), style: "width:30%")
-  |  
-  =label_tag(:end_date, t('.end_date'))
-  |  
-  =text_field_tag(:end_date, l(@end_date.to_date), style: "width:30%")
-  |  
-  =submit_tag(t('.update'))
-
-hr
-
 h3 =t('.collaborator_time')
 -unless @contributors.empty?
   =link_to({:controller => 'dashboard', :action => 'collaborator_time_export',
@@ -30,28 +14,3 @@ h3 =t('.collaborator_time')
             span.vmiddle =user.display_name
 -else
     p =t('.no_activity_for_date_range')
-
-
--content_for :javascript
-=javascript_include_tag 'datepicker/datepicker'
-javascript:
-  var today = new Date()
-  var yesterday = new Date(today)
-  yesterday.setDate(yesterday.getDate() - 1)
-  
-  //Attach a date picker for start and end dates
-  datePickerController.createDatePicker({
-      formElements:{
-          "start_date":"%M %d, %Y"
-      },
-      rangeHigh: yesterday,
-      noFadeEffect: true
-  });
-
-  datePickerController.createDatePicker({
-      formElements:{
-          "end_date":"%M %d, %Y"
-      },
-      noFadeEffect: true,
-      rangeHigh: yesterday
-  });

--- a/app/views/statistics/_statistics.html.slim
+++ b/app/views/statistics/_statistics.html.slim
@@ -23,19 +23,60 @@
       -if @works.where(ocr_correction: true).exists?
         .counter(data-prefix="#{number_with_delimiter @statistics_object.ocr_count}") #{t('.ocr_correction', count: @statistics_object.ocr_count)}
 
-  h4.legend.fglight =t('.last_days_statistics')
+  h2=t('.statistics_from', start_date: l(@start_date.to_date), end_date: l(@end_date.to_date))
+
+  h4=t('.select_new_date')
+
+  =form_tag('/dashboard/summary', method: "get") do
+    =hidden_field_tag(:collection_id, @collection)
+    =label_tag(:start_date, t('.start_date'))
+    |  
+    =text_field_tag(:start_date, l(@start_date.to_date), style: "width:30%")
+    |  
+    =label_tag(:end_date, t('.end_date'))
+    |  
+    =text_field_tag(:end_date, l(@end_date.to_date), style: "width:30%")
+    |  
+    =submit_tag(t('.update'))
+  br
+  
+  -date_range = @start_date..@end_date
   section.collection-stats_recent
-    .counter(data-prefix="#{number_with_delimiter @statistics_object.contributor_count(7)}") #{t('.collaborator', count: @statistics_object.contributor_count(7))}
-    .counter(data-prefix="#{number_with_delimiter @statistics_object.transcription_count(7)}") #{t('.page_transcribed', count: @statistics_object.transcription_count(7))}
-    .counter(data-prefix="#{number_with_delimiter @statistics_object.needs_review_count(7)}") #{t('.page_marked_needing_review', count: @statistics_object.needs_review_count(7))}
-    .counter(data-prefix="#{number_with_delimiter @statistics_object.review_count(7)}") #{t('.page_reviewed', count: @statistics_object.review_count(7))}
-    .counter(data-prefix="#{number_with_delimiter @statistics_object.edit_count(7)}") #{t('.page_edit', count: @statistics_object.edit_count)}
+    .counter(data-prefix="#{number_with_delimiter @statistics_object.contributor_count(date_range)}") #{t('.collaborator', count: @statistics_object.contributor_count(date_range))}
+    .counter(data-prefix="#{number_with_delimiter @statistics_object.transcription_count(date_range)}") #{t('.page_transcribed', count: @statistics_object.transcription_count(date_range))}
+    .counter(data-prefix="#{number_with_delimiter @statistics_object.needs_review_count(date_range)}") #{t('.page_marked_needing_review', count: @statistics_object.needs_review_count(date_range))}
+    .counter(data-prefix="#{number_with_delimiter @statistics_object.review_count(date_range)}") #{t('.page_reviewed', count: @statistics_object.review_count(date_range))}
+    .counter(data-prefix="#{number_with_delimiter @statistics_object.edit_count(date_range)}") #{t('.page_edit', count: @statistics_object.edit_count)}
     -unless subjects_disabled
-      .counter(data-prefix="#{number_with_delimiter @statistics_object.index_count(7)}") #{t('.page_indexed', count: @statistics_object.index_count(7))}
-      .counter(data-prefix="#{number_with_delimiter @statistics_object.mention_count(7)}") #{t('.reference', count: @statistics_object.mention_count(7))}
-      .counter(data-prefix="#{number_with_delimiter @statistics_object.subject_count(7)}") #{t('.new_subject', count: @statistics_object.subject_count(7))}
-    .counter(data-prefix="#{number_with_delimiter @statistics_object.comment_count(7)}") #{t('.note', count: @statistics_object.comment_count(7))}
+      .counter(data-prefix="#{number_with_delimiter @statistics_object.index_count(date_range)}") #{t('.page_indexed', count: @statistics_object.index_count(date_range))}
+      .counter(data-prefix="#{number_with_delimiter @statistics_object.mention_count(date_range)}") #{t('.reference', count: @statistics_object.mention_count(date_range))}
+      .counter(data-prefix="#{number_with_delimiter @statistics_object.subject_count(date_range)}") #{t('.new_subject', count: @statistics_object.subject_count(date_range))}
+    .counter(data-prefix="#{number_with_delimiter @statistics_object.comment_count(date_range)}") #{t('.note', count: @statistics_object.comment_count(date_range))}
     -if @works.where(supports_translation: true).exists?
-      .counter(data-prefix="#{number_with_delimiter @statistics_object.translation_count(7)}") #{t('.page_translated', count: @statistics_object.translation_count(7))}
+      .counter(data-prefix="#{number_with_delimiter @statistics_object.translation_count(date_range)}") #{t('.page_translated', count: @statistics_object.translation_count(date_range))}
     -if @works.where(ocr_correction: true).exists?
-      .counter(data-prefix="#{number_with_delimiter @statistics_object.ocr_count(7)}") #{t('.ocr_correction', count: @statistics_object.ocr_count(7))}
+      .counter(data-prefix="#{number_with_delimiter @statistics_object.ocr_count(date_range)}") #{t('.ocr_correction', count: @statistics_object.ocr_count(date_range))}
+
+-content_for :javascript
+=javascript_include_tag 'datepicker/datepicker'
+javascript:
+  var today = new Date()
+  var yesterday = new Date(today)
+  yesterday.setDate(yesterday.getDate() - 1)
+  
+  //Attach a date picker for start and end dates
+  datePickerController.createDatePicker({
+      formElements:{
+          "start_date":"%M %d, %Y"
+      },
+      rangeHigh: yesterday,
+      noFadeEffect: true
+  });
+
+  datePickerController.createDatePicker({
+      formElements:{
+          "end_date":"%M %d, %Y"
+      },
+      noFadeEffect: true,
+      rangeHigh: yesterday
+  });

--- a/config/locales/statistics/statistics-en.yml
+++ b/config/locales/statistics/statistics-en.yml
@@ -114,6 +114,7 @@ en:
       collaborator:
         one: Collaborator
         other: Collaborators
+      end_date: End date
       incomplete_page:
         one: Incomplete page
         other: Incomplete pages
@@ -151,12 +152,16 @@ en:
       reference:
         one: Reference
         other: References
+      select_new_date: Select a new date range
+      start_date: Start date
+      statistics_from: Statistics from %{start_date} to %{end_date}
       subject:
         one: Subject
         other: Subjects
       total_page:
         one: Total page
         other: Total pages
+      update: Update
       work:
         one: Work
         other: Works

--- a/config/locales/statistics/statistics-en.yml
+++ b/config/locales/statistics/statistics-en.yml
@@ -3,12 +3,8 @@ en:
   statistics:
     collaborator_time:
       collaborator_time: Collaborator Time
-      collaborator_time_for_dates: Collaborator Time for Dates
-      end_date: End date
       export_activity_as_csv: Export Detailed Activity as CSV
       no_activity_for_date_range: There is no activity for this date range.
-      start_date: Start date
-      update: Update
       user_totals_for_dates: User Totals for Dates
     collaborators:
       collaborators: Collaborators
@@ -118,7 +114,6 @@ en:
       incomplete_page:
         one: Incomplete page
         other: Incomplete pages
-      last_days_statistics: Last 7 Days Statistics
       new_subject:
         one: New subject
         other: New subjects

--- a/config/locales/statistics/statistics-es.yml
+++ b/config/locales/statistics/statistics-es.yml
@@ -3,12 +3,8 @@ es:
   statistics:
     collaborator_time:
       collaborator_time: Tiempo del colaborador
-      collaborator_time_for_dates: Hora del colaborador para fechas
-      end_date: Fecha final
       export_activity_as_csv: Exportar actividad detallada como CSV
       no_activity_for_date_range: TNo hay actividad para este intervalo de fechas.
-      start_date: Fecha de inicio
-      update: Actualizar
       user_totals_for_dates: Totales de usuarios para fechas
     collaborators:
       collaborators: Colaboradores
@@ -114,10 +110,10 @@ es:
       collaborator:
         one: Colaborador
         other: Colaboradores
+      end_date: Fecha final
       incomplete_page:
         one: página incompleta
         other: páginas incompletas
-      last_days_statistics: Estadísticas de los últimos 7 días
       new_subject:
         one: Nuevo tema
         other: Nuevos temas
@@ -151,12 +147,16 @@ es:
       reference:
         one: Referencia
         other: Referencias
+      select_new_date: Seleccione un nuevo intervalo de fechas
+      start_date: Fecha de inicio
+      statistics_from: Estadísticas de %{start_date} a %{end_date}
       subject:
         one: Tema
         other: Temas
       total_page:
         one: Página total
         other: Páginas totales
+      update: Actualizar
       work:
         one: Trabajo
         other: Trabajos

--- a/config/locales/statistics/statistics-fr.yml
+++ b/config/locales/statistics/statistics-fr.yml
@@ -3,12 +3,8 @@ fr:
   statistics:
     collaborator_time:
       collaborator_time: Temps de collaboration
-      collaborator_time_for_dates: Heures du travail par collaborateurs pour les dates
-      end_date: Date de fin
       export_activity_as_csv: Exporter l'activité détaillée au format CSV
       no_activity_for_date_range: Il n'y a aucune activité pour cette plage de dates.
-      start_date: Date de début
-      update: Mise à jour
       user_totals_for_dates: Totaux utilisateur pour les dates
     collaborators:
       collaborators: Collaborateurs
@@ -102,10 +98,10 @@ fr:
       collaborator:
         one: Collaborateur
         other: Collaborateurs
+      end_date: Date de fin
       incomplete_page:
         one: Page incomplète
         other: Pages incomplètes
-      last_days_statistics: Statistiques des 7 derniers jours
       new_subject: Nouveau sujet
       note:
         one: Note
@@ -137,12 +133,16 @@ fr:
       reference:
         one: Référence
         other: Références
+      select_new_date: Sélectionnez une nouvelle plage de dates
+      start_date: Date de début
+      statistics_from: Statistiques de %{start_date} à %{end_date}
       subject:
         one: Sujet
         other: Sujets
       total_page:
         one: Page totale
         other: Pages totales
+      update: Mise à jour
       work:
         one: Œuvre
         other: Œuvres

--- a/config/locales/statistics/statistics-fr.yml
+++ b/config/locales/statistics/statistics-fr.yml
@@ -66,16 +66,16 @@ fr:
         other: Œuvres
       works_described: Œuvre décrite
     recent_statistics:
-      collaborator: 
+      collaborator:
         one: Collaborateur
         other: Collaborateurs
-      new_subject: 
+      new_subject:
         one: Nouveau sujet
         other: Nouveaux sujets
-      note: 
+      note:
         one: Note
         other: Notes
-      ocr_correction: 
+      ocr_correction:
         one: Correction d'OCR
         other: Corrections d'OCR
       page_edit:
@@ -110,7 +110,7 @@ fr:
       incomplete_page:
         one: Page incomplète
         other: Pages incomplètes
-      new_subject: 
+      new_subject:
         one: Nouveau sujet
         other: Nouveaux sujets
       note:

--- a/config/locales/statistics/statistics-fr.yml
+++ b/config/locales/statistics/statistics-fr.yml
@@ -66,10 +66,18 @@ fr:
         other: Œuvres
       works_described: Œuvre décrite
     recent_statistics:
-      collaborator: Collaborateur
-      new_subject: Nouveau sujet
-      note: Noter
-      ocr_correction: Correction d'OCR
+      collaborator: 
+        one: Collaborateur
+        other: Collaborateurs
+      new_subject: 
+        one: Nouveau sujet
+        other: Nouveaux sujets
+      note: 
+        one: Note
+        other: Notes
+      ocr_correction: 
+        one: Correction d'OCR
+        other: Corrections d'OCR
       page_edit:
         one: Modification
         other: Modifications
@@ -102,7 +110,9 @@ fr:
       incomplete_page:
         one: Page incomplète
         other: Pages incomplètes
-      new_subject: Nouveau sujet
+      new_subject: 
+        one: Nouveau sujet
+        other: Nouveaux sujets
       note:
         one: Note
         other: Notes

--- a/config/locales/statistics/statistics-pt.yml
+++ b/config/locales/statistics/statistics-pt.yml
@@ -3,12 +3,8 @@ pt:
   statistics:
     collaborator_time:
       collaborator_time: Tempo do colaborador
-      collaborator_time_for_dates: Hora do Colaborador para Datas
-      end_date: Data final
       export_activity_as_csv: Exportar atividade detalhada como CSV
       no_activity_for_date_range: Não há atividade para este intervalo de datas.
-      start_date: Data de início
-      update: Atualizar
       user_totals_for_dates: Totais do usuário para datas
     collaborators:
       collaborators: Colaboradores
@@ -114,10 +110,10 @@ pt:
       collaborator:
         one: Colaborador
         other: Colaboradores
+      end_date: Data final
       incomplete_page:
         one: Página incompleta
         other: Páginas incompletas
-      last_days_statistics: Estatísticas dos últimos 7 dias
       new_subject:
         one: Novo assunto
         other: Novos assuntos
@@ -151,12 +147,16 @@ pt:
       reference:
         one: Referência
         other: Referências
+      select_new_date: Selecione um novo intervalo de datas
+      start_date: Data de início
+      statistics_from: Estatísticas de %{start_date} a %{end_date}
       subject:
         one: Assunto
         other: Assuntos
       total_page:
         one: Página total
         other: Páginas totais
+      update: Atualizar
       work:
         one: Trabalho
         other: Trabalhos

--- a/spec/features/owner_view_spec.rb
+++ b/spec/features/owner_view_spec.rb
@@ -35,7 +35,7 @@ describe "owner view - collection" do
     visit dashboard_owner_path
     page.find('.tabs').click_link("Summary")
     expect(page).to have_selector('.collection-stats_counters')
-    expect(page).to have_content("Last 7 Days Statistics")
+    expect(page).to have_content("Statistics from")
     expect(page.find('.collection-stats_counters[1] .counter[1]')['data-prefix'].to_i).to eq @works.count
     expect(page.find('.collection-users')).to have_content('Transcribing')
     expect(page.find('.collection-users')).to have_content('Editing')


### PR DESCRIPTION
_Resolves #3245_

Here's a draft of improving the owner dashboard summary statistics.

![summary](https://user-images.githubusercontent.com/35716893/186214263-29959f06-ae38-476f-86a0-e3226bb9230f.jpg)

### Changes made
- I moved the date range input from the `collaborator_time` partial to the `statistics` one. 
- The second group of statistics now shows the statistics in the given date range instead of the last 7 days.
- Heading changed from "Last 7 days statistics" to "Statistics from date to date" 
- I updated the statistic methods in `owner_statistic.rb` to take date ranges (by changing `last_days_clause` to `date_range_clause`). An input of `7` for "the last 7 days" still works.

I didn't include the "Active collaborators" or "All collaborator emails" sections from the collection collaborators page, but I can add that if it's wanted.