### PR TITLE
Changed transcriber actvity time to a table for #3273

### DIFF
--- a/app/views/collection/_contributors_body.html.slim
+++ b/app/views/collection/_contributors_body.html.slim
@@ -26,7 +26,7 @@
     h3 =t('.active_collaborators')
 
     -unless @active_transcribers.empty?
-      table.tabular
+      table.datagrid.striped(style="width:45%")
         thead 
           tr
             th= t('.user') 

--- a/app/views/collection/_contributors_body.html.slim
+++ b/app/views/collection/_contributors_body.html.slim
@@ -26,11 +26,21 @@
     h3 =t('.active_collaborators')
 
     -unless @active_transcribers.empty?
-      p
-      -@active_transcribers.each do |user|
-          =link_to user.display_name, user_profile_path(:user_id => user.id, only_path: false)
-          =t('.collection', collection_time: (@user_time_proportional[user.id] / 60 + 1).floor, total_time: (@user_time[user.id] / 60 + 1).floor) if @user_time[user.id]
-          | <br>
+      table.tabular
+        thead 
+          tr
+            th= t('.user') 
+            th= t('.time_on_this')
+            th= t('.time_on_ftp')
+        tbody 
+        -@active_transcribers.each do |user|
+          tr 
+            td= link_to user.display_name, user_profile_path(:user_id => user.id, only_path: false)
+            -if @user_time[user.id]
+              td= (@user_time_proportional[user.id] / 60 + 1).floor
+              td= (@user_time[user.id] / 60 + 1).floor
+            -else
+              <td><td>
       p
         -total_minutes = (@user_time.values.sum / 60).floor + 1
         =t('.total_time', hours: (total_minutes / 60), minutes: (total_minutes % 60))

--- a/config/locales/collection/collection-en.yml
+++ b/config/locales/collection/collection-en.yml
@@ -31,15 +31,17 @@ en:
       all_collaborator_emails: All Collaborator Emails
       collaborator_stats: Collaborator Stats %{start_deed} through %{end_deed}
       collaborators: Collaborators
-      collection: " (Collection: %{collection_time} minutes | Total: %{total_time} minutes)"
       detailed_spreadsheet_export: A detailed spreadsheet export of all collaborators is available on your owner dashboard.
       export_activity_as_csv: Export Activity as CSV
-      export_as_csv: Export as CSV
+      export_as_csv: Export detailed activity as CSV
       find_project_newsletters_recommendations: Find recommendations for project newsletters.
       new_collaborators: New Collaborators
       no_activity_this_time_frame: No activity in this time frame
       no_collaborators: No Collaborators
+      time_on_ftp: Time on FromThePage
+      time_on_this: Time on this collection
       total_time: 'Total time: %{hours} hours, %{minutes} minutes.'
+      user: User
       view_activity: View Activity
     corrected: corrected
     create:

--- a/config/locales/collection/collection-es.yml
+++ b/config/locales/collection/collection-es.yml
@@ -31,15 +31,17 @@ es:
       all_collaborator_emails: Todos los Correos Electrónicos del Colaborador
       collaborator_stats: Estadísticas del Colaborador %{start_deed} hasta %{end_deed}
       collaborators: Colaboradores
-      collection: " (Colección: %{collection_time} minutos | Total: %{total_time} minutos)"
       detailed_spreadsheet_export: Una hoja de cálculo exportable y detallada de todos los colaboradores está disponible en el panel del dueño.
       export_activity_as_csv: Exportar Actividad Como CSV
-      export_as_csv: Exportar como CSV
+      export_as_csv: Exportar actividad detallada como CSV
       find_project_newsletters_recommendations: Encuentre recomendaciones para boletines de proyectos.
       new_collaborators: Nuevos Colaboradores
       no_activity_this_time_frame: No hubo actividad en este lapso de tiempo
       no_collaborators: No hay colaboradores
+      time_on_ftp: Tiempo en FromThePage
+      time_on_this: Tiempo en esta colección
       total_time: 'Tiempo total: %{hours} horas, %{minutes} minutos.'
+      user: Usuario
       view_activity: Ver Actividad
     corrected: corregido
     create:

--- a/config/locales/collection/collection-fr.yml
+++ b/config/locales/collection/collection-fr.yml
@@ -31,15 +31,17 @@ fr:
       all_collaborator_emails: Tous les e-mails des collaborateurs
       collaborator_stats: Statistiques des collaborateurs %{start_deed} à %{end_deed}
       collaborators: Collaborateurs
-      collection: " (Collection : %{collection_time} minutes | Total : %{total_time} minutes)"
       detailed_spreadsheet_export: Une exportation détaillée de la feuille de calcul de tous les collaborateurs est disponible sur votre tableau de bord propriétaire.
       export_activity_as_csv: Exporter l'activité au format CSV
-      export_as_csv: Exporter au format CSV
+      export_as_csv: Exporter l'activité détaillée au format CSV
       find_project_newsletters_recommendations: Trouvez des recommandations pour les newsletters du projet.
       new_collaborators: Nouveaux collaborateurs
       no_activity_this_time_frame: Aucune activité pendant cette période
       no_collaborators: Aucun collaborateur
+      time_on_ftp: Heure sur FromThePage
+      time_on_this: Temps sur cette collection
       total_time: 'Durée totale : %{hours} heures, %{minutes} minutes.'
+      user: Utilisateur
       view_activity: Afficher l'activité
     corrected: corrigée
     create:

--- a/config/locales/collection/collection-pt.yml
+++ b/config/locales/collection/collection-pt.yml
@@ -31,15 +31,17 @@ pt:
       all_collaborator_emails: Todos os e-mails dos Colaboradores
       collaborator_stats: Estatísticas de Colaborador %{start_deed} até %{end_deed}
       collaborators: Colaboradores
-      collection: " (Coleção: %{collection_time} minutos / Total: %{total_time} minutos)"
       detailed_spreadsheet_export: Uma planilha detalhada de todos os colaboradores está disponível para exportar no painel de controle do dono.
       export_activity_as_csv: Exportar Atividade em formato .CSV
-      export_as_csv: Exportar em formato .CSV
+      export_as_csv: Exportar atividade detalhada como CSV
       find_project_newsletters_recommendations: Encontre recomendações para boletins de projetos.
       new_collaborators: Novos Colaboradores
       no_activity_this_time_frame: Nenhuma atividade neste período de tempo
       no_collaborators: Sem Colaboradores
+      time_on_ftp: Tempo em FromThePage
+      time_on_this: Tempo nesta coleção
       total_time: 'Tempo Total: %{hours} horas, %{minutes} minutos.'
+      user: Do utilizador
       view_activity: Visualizar Atividade
     corrected: Corrigido
     create:


### PR DESCRIPTION
_Resolves #3273_

This changes the "Active collaborators" section of the collection collaborators page to have a table with collaborator's time instead of the times in parentheses.
It also changes the "Export as CSV" button to say "Export detailed activity as CSV"

<img alt="active collaborators" src="https://user-images.githubusercontent.com/35716893/186440093-25da8c8c-1955-4e43-a34e-4f479f327a21.jpg" width="50%">

I'm pretty sure this is the only page that has this section.

