### PR TITLE
Fixed typo on category's "save changes" for #3277

### DIFF
--- a/config/locales/category/category-en.yml
+++ b/config/locales/category/category-en.yml
@@ -14,7 +14,7 @@ en:
     edit:
       edit_category: Edit Category
       enable_gis: Enable GIS
-      save_changes: Save Changest
+      save_changes: Save Changes
       title: Title
     enable_gis:
       gis_enabled_for: GIS enabled for %{title}


### PR DESCRIPTION
_Resolves #3277_

This removes the "t" from "Save changest"

<img src="https://user-images.githubusercontent.com/35716893/186452108-ef147a02-64c6-40c6-972a-a2a06de448c6.jpg" width="50%">
