### PR TITLE
Paginated works_to_review page for #3279

### DIFF
--- a/app/controllers/collection_controller.rb
+++ b/app/controllers/collection_controller.rb
@@ -46,6 +46,7 @@ class CollectionController < ApplicationController
 
   def works_to_review
     @works = @collection.works.joins(:work_statistic).includes(:notes, :pages).where.not('work_statistics.needs_review' => 0).reorder("works.title")
+                        .paginate(:page => params[:page], :per_page => 15)
   end
 
   def one_off_list

--- a/app/views/collection/works_to_review.html.slim
+++ b/app/views/collection/works_to_review.html.slim
@@ -43,7 +43,7 @@
             -if user_deed_count.size > max_contributor_rows
               i =t('.and_n_more', n: (user_deed_count.size - max_contributor_rows))
               
-
+  =render(:partial => 'shared/pagination', :locals => { :model => @works, :entries_info => true })
 
 
   


### PR DESCRIPTION
_Resolves #3279_

This paginates the `/works_to_review` page to resolve its performance issue when it includes a lot of works.

Here's how the page looks now:

![image](https://user-images.githubusercontent.com/35716893/186689119-2dccb4b7-906b-463f-9de8-efe30cccde23.png)

This makes the page load only 15 works at a time, reducing the page's load time from 9 minutes (LVA - 13,000 works) or 50 seconds (1,700 works) to around or less than a second.