### PR TITLE
Added help text for descriptions and transcription conventions for #3267

### DIFF
--- a/app/views/collection/edit.html.slim
+++ b/app/views/collection/edit.html.slim
@@ -17,6 +17,7 @@
         tr
           td(colspan="2")
             =f.label :intro_block, t('.description'), class: "above"
+            br: i =t('.description_message')
             =f.text_area :intro_block, rows: 10, value: @collection.intro_block
         tr
           td(colspan="2")
@@ -27,6 +28,7 @@
           tr
             td(colspan="2")
               =f.label :transcription_conventions, t('.transcription_conventions'), class: "above"
+              br: i =t('.transcription_conventions_message')
               =f.text_area :transcription_conventions, rows: 8, value: @collection.transcription_conventions
               p.nomargin.settings =link_to t('.suggestions_transcription_conventions'), "https://content.fromthepage.com/writing-transcription-conventions-the-project-help-page/", target: :_blank
         tr

--- a/app/views/collection/new.html.slim
+++ b/app/views/collection/new.html.slim
@@ -15,6 +15,7 @@
         tr
           td(colspan="2")
             =f.label :intro_block, t('.collection_description'), class: 'above'
+            br: i =t('.collection_description_message')
             =f.text_area :intro_block, rows: 4
       .toolbar
         .toolbar_group.aright =f.button t('.create_collection'), id: 'create-collection'

--- a/app/views/dashboard/_empty.html.slim
+++ b/app/views/dashboard/_empty.html.slim
@@ -18,6 +18,7 @@
             td(colspan="2")
               =f.label :description, class: "hidden"
               =f.text_area :description, rows: 4, placeholder: t('.description')
+              br: i =t('.description_message')
         .toolbar
           .toolbar_group.aright =f.button t('.create_work')
 

--- a/app/views/document_sets/_edit.html.slim
+++ b/app/views/document_sets/_edit.html.slim
@@ -17,6 +17,7 @@
       tr
         td(colspan="2")
           =f.label :description, t('.description'), class: 'above'
+          br: i =t('.description_message')
           =f.text_area :description, rows: 6
     .toolbar
       .toolbar_group.aright =f.button t('.save_document_set')

--- a/app/views/document_sets/new.html.slim
+++ b/app/views/document_sets/new.html.slim
@@ -15,6 +15,7 @@
       tr
         td(colspan="2")
           =f.label :description, t('.description'), class: 'above'
+          br: i =t('.description_message')
           =f.text_area :description, rows: 6
     .toolbar
       .toolbar_group.aright =f.button t('.create_document_set')

--- a/app/views/work/edit.html.slim
+++ b/app/views/work/edit.html.slim
@@ -53,10 +53,12 @@
         tr
           td(colspan="2")
             =f.label :description, t('.description'), class: 'above'
+            br: i =t('.description_message')
             =f.text_area :description, rows: 5, value: @work.description
         tr
           td(colspan="2")
             =f.label :transcription_conventions, t('.transcription_conventions'), class: 'above'
+            br: i =t('.transcription_conventions_message')
             =f.text_area :transcription_conventions, rows: 5, value: @work.set_transcription_conventions
         tr
           td(colspan="2")

--- a/app/views/work/new.html.slim
+++ b/app/views/work/new.html.slim
@@ -15,6 +15,7 @@
       tr
         td(colspan="2")
           =f.label :description, t('.description'), class: 'above'
+          br: i =t('.description_message')
           =f.text_area :description, rows: 4
     .toolbar
       .toolbar_group.aright =f.button t('.create_work')

--- a/config/locales/collection/collection-en.yml
+++ b/config/locales/collection/collection-en.yml
@@ -79,6 +79,7 @@ en:
       default_orientation: Select the default page transcription orientation
       delete_collection: Delete Collection
       description: Description
+      description_message: The description will be displayed on the project Overview screen and the project About screen. An abbreviated portion of the description will be displayed in the Organization Home screen and the Find A Project screen.
       disable_document_sets: Disable Document Sets
       disable_facets: Disable Facets
       disable_ocr: Disable OCR
@@ -148,6 +149,7 @@ en:
       text_language: Select the language of the transcription text
       title: Title
       transcription_conventions: Transcription Conventions
+      transcription_conventions_message: These instructions will be displayed under the transcription form for each page being transcribed or indexed.
       transcription_type: Transcription Type
       transcription_type_description: Each page can have one free form text entry area (the default) or multiple short entry fields designed for forms.  All pages in the collection have the same type of transcription entries. Voice dictation is not supported and will be disabled.
       upload_image: Upload Image
@@ -200,6 +202,7 @@ en:
       return_to_collection: Return to collection
     new:
       collection_description: Collection Description
+      collection_description_message: The description will be displayed on the project Overview screen and the project About screen. An abbreviated portion of the description will be displayed in the Organization Home screen and the Find A Project screen.
       create_collection: Create Collection
       create_new_collection: Create New Collection
       enter_collection_title: To create a new collection please start from entering the collection title. On the next step you will be able to add works into the collection.

--- a/config/locales/collection/collection-es.yml
+++ b/config/locales/collection/collection-es.yml
@@ -79,6 +79,7 @@ es:
       default_orientation: Selecciona la orientación predeterminada para la página de transcripción
       delete_collection: Eliminar Colección
       description: Descripción
+      description_message: La descripción se mostrará en la pantalla Resumen del proyecto y en la pantalla Acerca del proyecto. Se mostrará una parte abreviada de la descripción en la pantalla de inicio de la organización y en la pantalla Buscar un proyecto.
       disable_document_sets: Deshabilitar Conjuntos de Documentos
       disable_facets: Deshabilitar facetas
       disable_ocr: Deshabilitar OCR
@@ -148,6 +149,7 @@ es:
       text_language: Selecciona el idioma para texto de transcripción
       title: Título
       transcription_conventions: Convenciones de Transcripción
+      transcription_conventions_message: Estas instrucciones se mostrarán debajo del formulario de transcripción para cada página que se transcriba o indexe.
       transcription_type: Tipo de Transcripción
       transcription_type_description: Cada página puede tener un área para entrada de texto de formato libre (este es el valor predeterminado) o varios campos de entrada cortos diseñados para formularios. Todas las páginas de la colección tienen el mismo tipo de entradas de transcripción. El dictado de voz no es compatible y se deshabilitará.
       upload_image: Subir Imagen
@@ -200,6 +202,7 @@ es:
       return_to_collection: Volver a la colección
     new:
       collection_description: Descripción de la Colección
+      collection_description_message: La descripción se mostrará en la pantalla Resumen del proyecto y en la pantalla Acerca del proyecto. Se mostrará una parte abreviada de la descripción en la pantalla de inicio de la organización y en la pantalla Buscar un proyecto.
       create_collection: Crear Colección
       create_new_collection: Crear Nueva Colección
       enter_collection_title: Para crear una colección nueva, comienza por ingresar el título de la colección. En el siguiente paso, podrás añadir obras a la colección.

--- a/config/locales/collection/collection-fr.yml
+++ b/config/locales/collection/collection-fr.yml
@@ -79,6 +79,7 @@ fr:
       default_orientation: Sélectionnez l'orientation de transcription de page par défaut
       delete_collection: Supprimer la collection
       description: Description
+      description_message: La description sera affichée sur l'écran Aperçu du projet et sur l'écran À propos du projet. Une partie abrégée de la description sera affichée sur l'écran d'accueil de l'organisation et sur l'écran Rechercher un projet.
       disable_document_sets: Désactiver les jeux de documents
       disable_facets: Désactiver les facettes
       disable_ocr: Désactiver la OCR
@@ -148,6 +149,7 @@ fr:
       text_language: Sélectionnez la langue du texte de transcription
       title: Titre
       transcription_conventions: Conventions de transcription
+      transcription_conventions_message: Ces instructions seront affichées sous le formulaire de transcription pour chaque page en cours de transcription ou d'indexation.
       transcription_type: Type de transcription
       transcription_type_description: Chaque page peut avoir une zone de saisie de texte libre (par défaut) ou plusieurs champs de saisie courts conçus pour les formulaires. Toutes les pages de la collection ont le même type d'entrées de transcription. La dictée vocale n'est pas prise en charge et sera désactivée.
       upload_image: Télécharger une image
@@ -200,6 +202,7 @@ fr:
       return_to_collection: Retour à la collection
     new:
       collection_description: Description de la collection
+      collection_description_message: La description sera affichée sur l'écran Aperçu du projet et sur l'écran À propos du projet. Une partie abrégée de la description sera affichée sur l'écran d'accueil de l'organisation et sur l'écran Rechercher un projet.
       create_collection: Créer une collection
       create_new_collection: Créer une nouvelle collection
       enter_collection_title: Pour créer une nouvelle collection, commencez par entrer le titre de la collection. À l'étape suivante, vous pourrez ajouter des œuvres à la collection.

--- a/config/locales/collection/collection-pt.yml
+++ b/config/locales/collection/collection-pt.yml
@@ -79,6 +79,7 @@ pt:
       default_orientation: Selecione a orientação da página predeterminada da transcrição
       delete_collection: Apagar Coleção
       description: Descrição
+      description_message: A descrição será exibida na tela Visão geral do projeto e na tela Sobre o projeto. Uma parte abreviada da descrição será exibida na tela inicial da organização e na tela Find A Project.
       disable_document_sets: Desativar Conjuntos de Documentos
       disable_facets: Desativar facetas
       disable_ocr: Desativar OCR
@@ -148,6 +149,7 @@ pt:
       text_language: Selecione o idioma da transcrição
       title: Titulo
       transcription_conventions: Convenções de Transcrição
+      transcription_conventions_message: Essas instruções serão exibidas sob o formulário de transcrição para cada página que está sendo transcrita ou indexada.
       transcription_type: Tipo de Transcrição
       transcription_type_description: Cada página pode ter uma área livre de entrada de texto (o padrão) ou vários campos de entrada curtos criados para formulários.  Todas as páginas da coleção têm o mesmo tipo de entrada de texto da transcrição. O ditado de voz não é suportado e será desativado.
       upload_image: Subir Imagem
@@ -200,6 +202,7 @@ pt:
       return_to_collection: Voltar à Coleção
     new:
       collection_description: Descrição Da Colecção
+      collection_description_message: A descrição será exibida na tela Visão geral do projeto e na tela Sobre do projeto. Uma parte abreviada da descrição será exibida na tela inicial da organização e na tela Find A Project.
       create_collection: Criar Coleção
       create_new_collection: Criar Nova Coleção
       enter_collection_title: Para criar uma nova coleção, introduza o título da coleção. No próximo passo você poderá adicionar obras na coleção.

--- a/config/locales/dashboard/dashboard-en.yml
+++ b/config/locales/dashboard/dashboard-en.yml
@@ -27,6 +27,7 @@ en:
       create_empty_work_description: Use this option to create an empty work. You can then upload individual page images into the work.
       create_work: Create Work
       description: Description
+      description_message: The description will be displayed on the project Overview screen and the project About screen. An abbreviated portion of the description will be displayed in the Organization Home screen and the Find A Project screen.
       select_a_collection: "- Select a collection -"
       title: Title
     exports:

--- a/config/locales/dashboard/dashboard-es.yml
+++ b/config/locales/dashboard/dashboard-es.yml
@@ -27,6 +27,7 @@ es:
       create_empty_work_description: Utilice esta opción para crear una obra vacía. A continuación, puede cargar imágenes de páginas individuales en el trabajo.
       create_work: Crear trabajo
       description: Descripción
+      description_message: La descripción se mostrará en la pantalla Resumen del proyecto y en la pantalla Acerca del proyecto. Se mostrará una parte abreviada de la descripción en la pantalla de inicio de la organización y en la pantalla Buscar un proyecto.
       select_a_collection: "- Seleccione una colección -"
       title: Título
     exports:

--- a/config/locales/dashboard/dashboard-fr.yml
+++ b/config/locales/dashboard/dashboard-fr.yml
@@ -27,6 +27,7 @@ fr:
       create_empty_work_description: Utilisez cette option pour créer une œuvre sans pages. Vous pouvez ensuite téléverser des images de page individuelles dans l'œuvre.
       create_work: Créer une œuvre
       description: La description
+      description_message: La description sera affichée sur l'écran Aperçu du projet et sur l'écran À propos du projet. Une partie abrégée de la description sera affichée sur l'écran d'accueil de l'organisation et sur l'écran Rechercher un projet.
       select_a_collection: "- Sélectionnez une collection -"
       title: Titre
     exports:

--- a/config/locales/dashboard/dashboard-pt.yml
+++ b/config/locales/dashboard/dashboard-pt.yml
@@ -27,6 +27,7 @@ pt:
       create_empty_work_description: Use esta opção para criar um trabalho vazio. Você pode então carregar imagens de páginas individuais no trabalho.
       create_work: Criar trabalho
       description: Descrição
+      description_message: A descrição será exibida na tela Visão geral do projeto e na tela Sobre do projeto. Uma parte abreviada da descrição será exibida na tela inicial da organização e na tela Find A Project.
       select_a_collection: "- Selecione uma coleção -"
       title: Título
     exports:

--- a/config/locales/document_sets/document_sets-en.yml
+++ b/config/locales/document_sets/document_sets-en.yml
@@ -6,6 +6,7 @@ en:
     edit:
       current_url_for_this_work: The current URL for this work is %{current_url}.  If you want to edit the document set section of the URL, please use lowercase letters and dashes between any words.
       description: Description
+      description_message: The description will be displayed on the project Overview screen and the project About screen. An abbreviated portion of the description will be displayed in the Organization Home screen and the Find A Project screen.
       document_is_marked_public: If the document set is marked as public, works put within it will be readable even if the collection is marked as private.
       save_document_set: Save Document Set
       title: Title
@@ -41,6 +42,7 @@ en:
       create_document_set: Create Document Set
       create_new_document_set: Create New Document Set
       description: Description
+      description_message: The description will be displayed on the project Overview screen and the project About screen. An abbreviated portion of the description will be displayed in the Organization Home screen and the Find A Project screen.
       document_set_is_marked_public: If the document set is marked as public, works put within it will be readable even if the collection is marked as private.
       public: Public
       title: Title

--- a/config/locales/document_sets/document_sets-es.yml
+++ b/config/locales/document_sets/document_sets-es.yml
@@ -6,6 +6,7 @@ es:
     edit:
       current_url_for_this_work: La dirección URL actual de esta colección es %{current_url}. Si deseas editar la sección del conjunto de documentos en el URL, por favor utiliza letras minúsculas y guiones entre cualquiera de las palabras.
       description: Descripción
+      description_message: La descripción se mostrará en la pantalla Resumen del proyecto y en la pantalla Acerca del proyecto. Se mostrará una parte abreviada de la descripción en la pantalla de inicio de la organización y en la pantalla Buscar un proyecto.
       document_is_marked_public: Si el conjunto de documentos está marcado como público, las obras colocadas en él serán legibles incluso si la colección está marcada como privada.
       save_document_set: Guardar Conjunto de Documentos
       title: Título
@@ -41,6 +42,7 @@ es:
       create_document_set: Crear Conjunto de Documentos
       create_new_document_set: Crear Nuevo Conjunto de Documentos
       description: Descripción
+      description_message: La descripción se mostrará en la pantalla Resumen del proyecto y en la pantalla Acerca del proyecto. Se mostrará una parte abreviada de la descripción en la pantalla de inicio de la organización y en la pantalla Buscar un proyecto.
       document_set_is_marked_public: Si el conjunto de documentos está marcado como público, las obras colocadas en él serán legibles incluso si la colección está marcada como privada.
       public: Público
       title: Título

--- a/config/locales/document_sets/document_sets-fr.yml
+++ b/config/locales/document_sets/document_sets-fr.yml
@@ -6,6 +6,7 @@ fr:
     edit:
       current_url_for_this_work: L'URL actuelle de ce œuvre est %{current_url}. Si vous souhaitez modifier la section de l'ensemble de documents de l'URL, veuillez utiliser des lettres minuscules et des tirets entre les mots.
       description: La description
+      description_message: La description sera affichée sur l'écran Aperçu du projet et sur l'écran À propos du projet. Une partie abrégée de la description sera affichée sur l'écran d'accueil de l'organisation et sur l'écran Rechercher un projet.
       document_is_marked_public: Si le jeu de documents est marqué comme public, les œuvres qui y sont placées seront lisibles même si la collection est marquée comme privée.
       save_document_set: Enregistrer le jeu de documents
       title: Titre
@@ -41,6 +42,7 @@ fr:
       create_document_set: Créer un ensemble de documents
       create_new_document_set: Créer un nouveau jeu de documents
       description: La description
+      description_message: La description sera affichée sur l'écran Aperçu du projet et sur l'écran À propos du projet. Une partie abrégée de la description sera affichée sur l'écran d'accueil de l'organisation et sur l'écran Rechercher un projet.
       document_set_is_marked_public: Si le jeu de documents est marqué comme public, les œuvres qui y sont placées seront lisibles même si la collection est marquée comme privée.
       public: Public
       title: Titre

--- a/config/locales/document_sets/document_sets-pt.yml
+++ b/config/locales/document_sets/document_sets-pt.yml
@@ -6,6 +6,7 @@ pt:
     edit:
       current_url_for_this_work: O URL atual desta obra é %{current_url}. Se quiser editar a parte do conjunto de documentos no URL, por favor use letras minúsculas e traços entre as palavras.
       description: Descrição
+      description_message: A descrição será exibida na tela Visão geral do projeto e na tela Sobre o projeto. Uma parte abreviada da descrição será exibida na tela inicial da organização e na tela Find A Project.
       document_is_marked_public: Se o conjunto de documentos está marcado como público, as obras colocadas dentro dele serão acessíveis mesmo que a coleção seja marcada como privada.
       save_document_set: Guardar o Conjunto de Documentos
       title: Título
@@ -41,6 +42,7 @@ pt:
       create_document_set: Criar Conjunto de Documentos
       create_new_document_set: Criar Novo Conjunto de Documentos
       description: Descrição
+      description_message: A descrição será exibida na tela Visão geral do projeto e na tela Sobre do projeto. Uma parte abreviada da descrição será exibida na tela inicial da organização e na tela Find A Project.
       document_set_is_marked_public: Se o conjunto de documentos está marcado como público, as obras colocadas dentro dele serão acessíveis mesmo que a coleção seja marcada como privada.
       public: Público
       title: Título

--- a/config/locales/work/work-en.yml
+++ b/config/locales/work/work-en.yml
@@ -74,6 +74,7 @@ en:
       current_url: The current URL for this work is %{current_url}. If you want to edit the work section of the URL, please use lowercase letters and dashes between any words.
       delete_work: Delete Work
       description: Description
+      description_message: The description will be displayed on the project Overview screen and the project About screen. An abbreviated portion of the description will be displayed in the Organization Home screen and the Find A Project screen.
       document_date: Document Date
       document_date_hint: Document Date is in the EDTF format (e.g. 1843, 2001-02, 1643-06-30)
       document_history: Document history
@@ -106,6 +107,7 @@ en:
       support_translation: Enable Translation
       support_translation_description: A work can be translated as well as transcribed. When checked, the work will have a Translation tab for each page.
       transcription_conventions: Transcription conventions
+      transcription_conventions_message: These instructions will be displayed under the transcription form for each page being transcribed or indexed.
       translation_instructions: Translation instructions
       upload_image: Upload Image
       uploaded_by: Uploaded by
@@ -126,6 +128,7 @@ en:
       create_empty_work_description: This creates an empty work. Once you create the work you can add individual page images. If you have a zip file or pdf with multiple images, you should create the work and upload the file under %{start_project} instead.
       create_work: Create Work
       description: Description
+      description_message: The description will be displayed on the project Overview screen and the project About screen. An abbreviated portion of the description will be displayed in the Organization Home screen and the Find A Project screen.
       start_a_project: Start A Project
       title: Title
       work_description: A work is a single document like a letter, a diary, a field book, post card, or notebook.

--- a/config/locales/work/work-es.yml
+++ b/config/locales/work/work-es.yml
@@ -74,6 +74,7 @@ es:
       current_url: La URL actual para este trabajo es %{current_url}. Si desea editar la sección de trabajo de la URL, utilice letras minúsculas y guiones entre las palabras.
       delete_work: Eliminar trabajo
       description: Descripción
+      description_message: La descripción se mostrará en la pantalla Resumen del proyecto y en la pantalla Acerca del proyecto. Se mostrará una parte abreviada de la descripción en la pantalla de inicio de la organización y en la pantalla Buscar un proyecto.
       document_date: Fecha del documento
       document_date_hint: La fecha del documento está en el formato EDTF (por ejemplo, 1843, 2001-02, 1643-06-30)
       document_history: Historia del documento
@@ -106,6 +107,7 @@ es:
       support_translation: Traducción de soporte
       support_translation_description: Una obra puede traducirse y transcribirse. Cuando esté marcado, el trabajo tendrá una pestaña de Traducción para cada página.
       transcription_conventions: Convenciones de transcripción
+      transcription_conventions_message: Estas instrucciones se mostrarán debajo del formulario de transcripción para cada página que se transcriba o indexe.
       translation_instructions: Instrucciones de traducción
       upload_image: Cargar imagen
       uploaded_by: subido por
@@ -126,6 +128,7 @@ es:
       create_empty_work_description: Esto crea un trabajo vacío. Una vez que cree el trabajo, puede agregar imágenes de página individuales. Si tiene un archivo zip o pdf con varias imágenes, debe crear el trabajo y cargar el archivo en %{start_project} en su lugar.
       create_work: Crear trabajo
       description: Descripción
+      description_message: La descripción se mostrará en la pantalla Resumen del proyecto y en la pantalla Acerca del proyecto. Se mostrará una parte abreviada de la descripción en la pantalla de inicio de la organización y en la pantalla Buscar un proyecto.
       start_a_project: Iniciar un proyecto
       title: Título
       work_description: Un trabajo es un documento único como una carta, un diario, un libro de campo, una tarjeta postal o un cuaderno.

--- a/config/locales/work/work-fr.yml
+++ b/config/locales/work/work-fr.yml
@@ -74,6 +74,7 @@ fr:
       current_url: L'URL actuelle de ce œuvre est %{current_url}. Si vous souhaitez modifier la section de œuvre de l'URL, veuillez utiliser des lettres minuscules et des tirets entre les mots.
       delete_work: Supprimer l'œuvre
       description: Description
+      description_message: La description sera affichée sur l'écran Aperçu du projet et sur l'écran À propos du projet. Une partie abrégée de la description sera affichée sur l'écran d'accueil de l'organisation et sur l'écran Rechercher un projet.
       document_date: Date du document
       document_date_hint: La date du document est au format EDTF (par exemple, 1843, 2001-02, 1643-06-30)
       document_history: Historique du document
@@ -106,6 +107,7 @@ fr:
       support_translation: Autoriser la traduction
       support_translation_description: Une œuvre peut aussi bien être traduite que transcrite. Lorsque cette case est cochée, l'œuvre aura un onglet Traduction pour chaque page.
       transcription_conventions: Conventions de transcription
+      transcription_conventions_message: Ces instructions seront affichées sous le formulaire de transcription pour chaque page en cours de transcription ou d'indexation.
       translation_instructions: Instructions de traduction
       upload_image: Télécharger une image
       uploaded_by: Téléversé par
@@ -126,6 +128,7 @@ fr:
       create_empty_work_description: Cela crée une œuvre vide. Une fois que vous avez créé l'œuvre, vous pouvez ajouter des images de page individuelles. Si vous avez un fichier zip ou pdf avec plusieurs images, vous devez créer l'œuvre et télécharger le fichier sous %{start_project} à la place.
       create_work: Créer un œuvre
       description: La description
+      description_message: La description sera affichée sur l'écran Aperçu du projet et sur l'écran À propos du projet. Une partie abrégée de la description sera affichée sur l'écran d'accueil de l'organisation et sur l'écran Rechercher un projet.
       start_a_project: Démarrer un projet
       title: Titre
       work_description: Une œuvre est un document unique comme une lettre, un journal intime, un carnet de terrain, une carte postale ou un cahier.

--- a/config/locales/work/work-pt.yml
+++ b/config/locales/work/work-pt.yml
@@ -74,6 +74,7 @@ pt:
       current_url: A URL atual para este trabalho é %{current_url}. Se você quiser editar a seção de trabalho do URL, use letras minúsculas e traços entre as palavras.
       delete_work: Excluir trabalho
       description: Descrição
+      description_message: A descrição será exibida na tela Visão geral do projeto e na tela Sobre do projeto. Uma parte abreviada da descrição será exibida na tela inicial da organização e na tela Find A Project.
       document_date: Data do documento
       document_date_hint: A data do documento está no formato EDTF (por exemplo, 1843, 2001-02, 1643-06-30)
       document_history: Documento histórico
@@ -106,6 +107,7 @@ pt:
       support_translation: Tradução de suporte
       support_translation_description: Uma obra pode ser traduzida assim como transcrita. Quando marcada, a obra terá uma guia Tradução para cada página.
       transcription_conventions: Convenções de transcrição
+      transcription_conventions_message: Essas instruções serão exibidas sob o formulário de transcrição para cada página que está sendo transcrita ou indexada.
       translation_instructions: Instruções de tradução
       upload_image: Enviar Imagem
       uploaded_by: Enviado por
@@ -126,6 +128,7 @@ pt:
       create_empty_work_description: Isso cria um trabalho vazio. Depois de criar o trabalho, você pode adicionar imagens de páginas individuais. Se você tiver um arquivo zip ou pdf com várias imagens, você deve criar o trabalho e fazer upload do arquivo em %{start_project}.
       create_work: Criar trabalho
       description: Descrição
+      description_message: A descrição será exibida na tela Visão geral do projeto e na tela Sobre do projeto. Uma parte abreviada da descrição será exibida na tela inicial da organização e na tela Find A Project.
       start_a_project: Iniciar um projeto
       title: Título
       work_description: Uma obra é um documento único como uma carta, um diário, um livro de campo, um cartão postal ou um caderno.


### PR DESCRIPTION
_Resolves #3267_

This adds help text for collection, document sets, and works for description and transcription convention input.

Here's how the help text looks in a few places:

![collection description](https://user-images.githubusercontent.com/35716893/186756934-9545e81b-e8d2-4b86-ae81-e631d354c9d3.jpg)
![collection transcription conventions](https://user-images.githubusercontent.com/35716893/186756949-6117bbee-6de5-4c1d-b2d9-5aeb1e0e4017.jpg)
![empty work](https://user-images.githubusercontent.com/35716893/186756958-8be4fe15-667d-45ec-981f-4675ec3c20b8.jpg)
<img alt="new docset" src="https://user-images.githubusercontent.com/35716893/186757007-6f00f3a4-5785-402c-91ae-01bc0140d161.jpg" width="60%">
