### PR TITLE
Moved db queries to view to only load them if needed for #3281

### DIFF
--- a/app/controllers/collection_controller.rb
+++ b/app/controllers/collection_controller.rb
@@ -36,8 +36,6 @@ class CollectionController < ApplicationController
 
   def reviewer_dashboard
     # works which have at least one page needing review
-    @one_off_page_count = @collection.pages_needing_review_for_one_off.count
-    @unreviewed_users = @collection.never_reviewed_users
     @total_pages=@collection.pages.count
     @pages_needing_review=@collection.pages.where(status: Page::STATUS_NEEDS_REVIEW).count
     @transcribed_pages=@collection.pages.where(status: Page::NOT_INCOMPLETE_STATUSES).count

--- a/app/views/collection/reviewer_dashboard.html.slim
+++ b/app/views/collection/reviewer_dashboard.html.slim
@@ -20,10 +20,12 @@
 
         .collection-stats_counters
           -if current_user.like_owner?(@collection) || (@collection.review_type == Collection::ReviewType::RESTRICTED && current_user.can_review?(@collection))
-            =link_to collection_recent_contributor_list_path, class: 'counter', 'data-prefix': number_with_delimiter(@unreviewed_users.count) do
-              span =t('.unreviewed_contributors').pluralize(@unreviewed_users.count)
-            =link_to collection_one_off_list_path, class: 'counter', 'data-prefix': number_with_delimiter(@one_off_page_count) do
-              span =t('.one_off_contributions').pluralize(@one_off_page_count)
+            -unreviewed_users = @collection.never_reviewed_users
+            =link_to collection_recent_contributor_list_path, class: 'counter', 'data-prefix': number_with_delimiter(unreviewed_users.count) do
+              span =t('.unreviewed_contributors').pluralize(unreviewed_users.count)
+            -one_off_page_count = @collection.pages_needing_review_for_one_off.count
+            =link_to collection_one_off_list_path, class: 'counter', 'data-prefix': number_with_delimiter(one_off_page_count) do
+              span =t('.one_off_contributions').pluralize(one_off_page_count)
           =link_to collection_works_to_review_path, class: 'counter', 'data-prefix': number_with_delimiter(@works_to_review) do
             span =t('.works_to_review')
 


### PR DESCRIPTION
_Helps #3281 (not sure if it fixes it)_ 

There are 6 statistics on the `/review` page, but only 4 are shown if you aren't an owner of the collection (or a reviewer if the collection has a restricted review type). However, all 6 of the statistics are still loaded. This is problematic because with a lot of works, some of the db queries for these statistics take a long time (the one off page count, one that's not shown, takes up to 7-15 seconds for the LVA WWI collection!). 

This PR moves these queries to the view so that they're only executed if they're needed, which should improve the performance of the page if you're not an owner or authorized reviewer of the collection.