### PR TITLE
Make all description snippets use to_snippet for #3284

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -235,5 +235,13 @@ module ApplicationHelper
     session[:features] && session[:features][feature.to_s]
   end
 
+  # makes an intro block into a snippet by removing style tag, stripping tags, and truncating
+  def to_snippet(intro_block)
+    # remove style tag, Loofah.fragment.text doesn't do this (strip_tags does)
+    doc = Nokogiri::HTML(intro_block)
+    doc.xpath('//style').each { |n| n.remove } 
+    # strip tags and truncate
+    truncate(Loofah.fragment(doc.to_s).text(encode_special_chars: false), length: 300, separator: ' ') || '' 
+  end
 
 end

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -14,13 +14,4 @@ module DashboardHelper
       content_for :page_title, "Summary - Owner Dashboard"
     end
   end
-
-  # makes an intro block into a snippet by removing style tag, stripping tags, and truncating
-  def to_snippet(intro_block)
-    # remove style tag, Loofah.fragment.text doesn't do this (strip_tags does)
-    doc = Nokogiri::HTML(intro_block)
-    doc.xpath('//style').each { |n| n.remove } 
-    # strip tags and truncate
-    truncate(Loofah.fragment(doc.to_s).text(encode_special_chars: false), length: 300, separator: ' ') || '' 
-  end
 end

--- a/app/views/collection/show.html.slim
+++ b/app/views/collection/show.html.slim
@@ -36,7 +36,7 @@
             -unless work.thumbnail.nil?
                 =link_to image_tag(work.thumbnail, alt: work.title), default_path
           h4.collection-work_title =link_to work.title, default_path
-          p.collection-work_snippet =truncate(strip_tags(work.description), length: 300, separator: ' ') || ''
+          p.collection-work_snippet = to_snippet(work.description)
           -if @collection.text_entry? && work.next_untranscribed_page
             p.collection-work_action 
               =t('.this_work_has_pages_that_need_work')

--- a/app/views/dashboard/_alphabetical_collections_and_document_sets.html.slim
+++ b/app/views/dashboard/_alphabetical_collections_and_document_sets.html.slim
@@ -1,5 +1,5 @@
 .collections
-  -snippet = truncate(strip_tags(cds.intro_block), length: 300, separator: ' ') || ''
+  -snippet = to_snippet(cds.intro_block)
   -owner_link = link_to cds.owner.display_name, user_profile_path(cds.owner) unless cds.owner.nil?
   .collection
     -unless cds.picture.blank?

--- a/app/views/dashboard/_hierarchical_collections_and_document_sets.html.slim
+++ b/app/views/dashboard/_hierarchical_collections_and_document_sets.html.slim
@@ -1,6 +1,6 @@
 .collections
   -if cds.class == Collection
-    -snippet = truncate(strip_tags(cds.intro_block), length: 300, separator: ' ') || ''
+    -snippet = to_snippet(cds.intro_block)
     -owner_link = link_to cds.owner.display_name, user_profile_path(cds.owner)
     .collection
       -unless cds.picture.blank?
@@ -24,7 +24,7 @@
               li =link_to doc_set.title, collection_path(doc_set.owner, doc_set)
   -elsif cds.class == DocumentSet
     -unless @collections_and_document_sets.include? cds.collection
-      -snippet = truncate(strip_tags(cds.intro_block), length: 300, separator: ' ') || ''
+      -snippet = to_snippet(cds.intro_block)
       -owner_link = link_to cds.owner.display_name, user_profile_path(cds.owner)
       .collection
         -unless cds.picture.blank?

--- a/app/views/dashboard/guest.html.slim
+++ b/app/views/dashboard/guest.html.slim
@@ -4,7 +4,7 @@
   article.maincol
     -@collections.each do |c|
       h4 =link_to c.title, collection_path(c.owner, c), class: 'nodecor'
-      -snippet = truncate(strip_tags(c.intro_block), length: 300, separator: ' ') || ''
+      -snippet = to_snippet(c.intro_block)
       -unless snippet.empty?
         p.collection_snippet =snippet
         br 

--- a/app/views/user/_owner_profile.html.slim
+++ b/app/views/user/_owner_profile.html.slim
@@ -28,7 +28,7 @@ section.user-profile
 -unless carousel_collections.blank?
   .carousel
     -carousel_collections.each do |c|
-      -snippet = truncate(strip_tags(c.intro_block), length: 300, separator: ' ') || ''
+      -snippet = to_snippet(c.intro_block)
       .carousel_slide
         =link_to image_tag(c.picture_url, alt: c.title), collection_path(c.owner, c), class: 'carousel_slide_image'
         .carousel_slide_content


### PR DESCRIPTION
_Resolves #3284_

This makes all places where a work or collection's description is showed as a shortened snippet use the `to_snippet` helper method so that all ampersands are shown correctly and no HTML is shown.
It also moves the `to_snippet` helper method to the `application_helper`.

The pages this affects: 
- Collection overview
- Guest dashboard
- Owner profile carousel 
- `alphabetical_collections_and_document_sets` - collaborator dashboard watchlist, owner profile
- `hierarchical_collections_and_document_sets` - collections list, collaborator dashboard watchlist, owner profile