### PR TITLE
Localized account types for #3286

### DIFF
--- a/app/views/dashboard/_owner_header.html.slim
+++ b/app/views/dashboard/_owner_header.html.slim
@@ -40,7 +40,8 @@
 
 -if !(current_user.account_type == nil)
   .owner-info
-    =t('.account_type', type: current_user.account_type)
+    -account_type_key = current_user.account_type.downcase.tr(' ', '_')
+    =t('.account_type', type: t(".account_types.#{account_type_key}"))
     -unless (current_user.start_date == nil)
       span 
         |&nbsp;

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -132,6 +132,7 @@ ignore_unused:
   - 'page.edit.page_status_*'
   - 'quality_samplings.show.approval_delta_display_{0,1,2,3,4}'
   - 'article.graph.dot.title'
+  - 'dashboard.owner_header.account_types.{legacy,staff,trial,individual_researcher,small_organization,large_institution}'
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/config/locales/dashboard/dashboard-en.yml
+++ b/config/locales/dashboard/dashboard-en.yml
@@ -100,6 +100,13 @@ en:
       your_activity: Your Activity
     owner_header:
       account_type: "%{type} account"
+      account_types:
+        individual_researcher: Individual researcher
+        large_institution: Large institution
+        legacy: Legacy
+        small_organization: Small organization
+        staff: Staff
+        trial: Trial
       actions: Actions
       collection:
         one: Collection

--- a/config/locales/dashboard/dashboard-es.yml
+++ b/config/locales/dashboard/dashboard-es.yml
@@ -100,6 +100,13 @@ es:
       your_activity: Tu Actividad
     owner_header:
       account_type: "%{type} cuenta"
+      account_types:
+        individual_researcher: Investigador individual
+        large_institution: Institución grande
+        legacy: Legado
+        small_organization: Organización pequeña
+        staff: Personal
+        trial: Prueba
       actions: Comportamiento
       collection:
         one: Recopilación

--- a/config/locales/dashboard/dashboard-fr.yml
+++ b/config/locales/dashboard/dashboard-fr.yml
@@ -100,6 +100,13 @@ fr:
       your_activity: Votre activité
     owner_header:
       account_type: "%{type} compte"
+      account_types:
+        individual_researcher: Chercheur individuel
+        large_institution: Grand établissement
+        legacy: Héritage
+        small_organization: Petite organisation
+        staff: Personnel
+        trial: Essai
       actions: Actions
       collection:
         one: Collection

--- a/config/locales/dashboard/dashboard-pt.yml
+++ b/config/locales/dashboard/dashboard-pt.yml
@@ -100,6 +100,13 @@ pt:
       your_activity: Sua Atividade
     owner_header:
       account_type: conta %{type}
+      account_types:
+        individual_researcher: Pesquisador individual
+        large_institution: Grande instituição
+        legacy: Legado
+        small_organization: Pequena organização
+        staff: Funcionários
+        trial: Tentativas
       actions: Ações
       collection:
         one: Coleção


### PR DESCRIPTION
_Resolves #3286_

This localizes account types for the owner dashboard header.
Translations were added for 6 account types ("Small Organization", "Individual Researcher", "Trial", "Staff", "Large Institution", and "Legacy") in all 4 languages. To access these account types, a keyfied version of the type is used as a locale key (i.e. `large_institution`).

![spanish small organization](https://user-images.githubusercontent.com/35716893/186974310-5d8bb4e5-b96b-485e-93f3-a742213944f6.jpg)
