### PR TITLE
Address #3293 by casting to string implicitly

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,7 +49,7 @@ class ApplicationController < ActionController::Base
 
     # append region to locale
     related_locales = http_accept_language.user_preferred_languages.select do |loc| 
-      loc.to_s.include?(locale) &&                              # is related to the chosen locale (is the locale, or is a regional version of it)
+      loc.to_s.include?(locale.to_s) &&                              # is related to the chosen locale (is the locale, or is a regional version of it)
       I18n.available_locales.map{|e| e.to_s}.include?(loc.to_s) # is an available locale
     end
 


### PR DESCRIPTION
This time I think I've found the problem: `locale` is a symbol occasionally, which makes it blow up on the call to string `include?`.  Since `locale` is set in a series of fall-backs, I'm not sure how it became a symbol, but I think this may fix the problem.