### PR TITLE
Only show "help out" link to work collaborators for #1043

### DIFF
--- a/app/views/collection/show.html.slim
+++ b/app/views/collection/show.html.slim
@@ -39,17 +39,17 @@
           p.collection-work_snippet = to_snippet(work.description)
           -if @collection.text_entry? && work.next_untranscribed_page
             p.collection-work_action 
-              =t('.this_work_has_pages_that_need_work')
-              span &nbsp;
               -if (current_user && current_user.can_transcribe?(work))
+                =t('.this_work_has_pages_that_need_work')
+                span &nbsp;
                 =link_to(t('.help_transcribe_or_correct'), collection_transcribe_page_path(@collection.owner, @collection, work, work.next_untranscribed_page))
               -else
                 =t('.restricted_collaboratoration')
           -if @collection.metadata_entry? && work.description_status != Work::DescriptionStatus::DESCRIBED && !work.has_untranscribed_pages?
             p.collection-work_action 
-              =t('.this_work_has_not_been_described')
-              span &nbsp;
               -if (current_user && current_user.can_transcribe?(work))
+                =t('.this_work_has_not_been_described')
+                span &nbsp;
                 =link_to(t('.help_create_metadata'), describe_collection_work_path(@collection.owner, @collection, work))
               -else
                 =t('.restricted_collaboratoration')

--- a/app/views/collection/show.html.slim
+++ b/app/views/collection/show.html.slim
@@ -41,12 +41,18 @@
             p.collection-work_action 
               =t('.this_work_has_pages_that_need_work')
               span &nbsp;
-              =link_to(t('.help_transcribe_or_correct'), collection_transcribe_page_path(@collection.owner, @collection, work, work.next_untranscribed_page))
+              -if (current_user && current_user.can_transcribe?(work))
+                =link_to(t('.help_transcribe_or_correct'), collection_transcribe_page_path(@collection.owner, @collection, work, work.next_untranscribed_page))
+              -else
+                =t('.restricted_collaboratoration')
           -if @collection.metadata_entry? && work.description_status != Work::DescriptionStatus::DESCRIBED && !work.has_untranscribed_pages?
             p.collection-work_action 
               =t('.this_work_has_not_been_described')
               span &nbsp;
-              =link_to(t('.help_create_metadata'), describe_collection_work_path(@collection.owner, @collection, work))
+              -if (current_user && current_user.can_transcribe?(work))
+                =link_to(t('.help_create_metadata'), describe_collection_work_path(@collection.owner, @collection, work))
+              -else
+                =t('.restricted_collaboratoration')
           -if @collection.text_entry?
             .collection-work_stats
               -work_stats(work)

--- a/config/locales/collection/collection-en.yml
+++ b/config/locales/collection/collection-en.yml
@@ -288,6 +288,7 @@ en:
       project_by: Project by
       recent_edits: Recent Edits
       recent_notes: Recent Notes
+      restricted_collaboratoration: Collaboration is restricted.
       search: Search
       search_by_title: Search by title or metadata...
       search_by_title_1: Search by title
@@ -301,7 +302,6 @@ en:
       time_ago_in_words: "%{time} ago"
       user_wrote_note: "%{user} wrote %{note}"
       works: Works
-      restricted_collaboratoration: Collaboration is restricted.
     start_transcribing:
       notice: Sorry, but there are no qualifying pages in this collection.
     transcribed: transcribed

--- a/config/locales/collection/collection-en.yml
+++ b/config/locales/collection/collection-en.yml
@@ -301,6 +301,7 @@ en:
       time_ago_in_words: "%{time} ago"
       user_wrote_note: "%{user} wrote %{note}"
       works: Works
+      restricted_collaboratoration: Collaboration is restricted.
     start_transcribing:
       notice: Sorry, but there are no qualifying pages in this collection.
     transcribed: transcribed

--- a/config/locales/collection/collection-es.yml
+++ b/config/locales/collection/collection-es.yml
@@ -288,6 +288,7 @@ es:
       project_by: Proyecto de
       recent_edits: Ediciones Recientes
       recent_notes: Notas Recientes
+      restricted_collaboratoration: La colaboración está restringida.
       search: Búsqueda
       search_by_title: Buscar por título...
       search_by_title_1: Buscar por título

--- a/config/locales/collection/collection-fr.yml
+++ b/config/locales/collection/collection-fr.yml
@@ -288,6 +288,7 @@ fr:
       project_by: Projet par
       recent_edits: Modifications récentes
       recent_notes: Notes récentes
+      restricted_collaboratoration: La collaboration est restreinte.
       search: Chercher
       search_by_title: Rechercher par titre ou métadonnées...
       search_by_title_1: Rechercher par titre

--- a/config/locales/collection/collection-pt.yml
+++ b/config/locales/collection/collection-pt.yml
@@ -288,6 +288,7 @@ pt:
       project_by: Projeto por
       recent_edits: Edições Recentes
       recent_notes: Notas Recentes
+      restricted_collaboratoration: A colaboração é restrita.
       search: Buscar
       search_by_title: Buscar por título...
       search_by_title_1: Pesquisar por título


### PR DESCRIPTION
_Resolves #1043_

Previously, the "help out!" link on the collection show page was shown to all users, even if the work was restricted and the user wasn't a collaborator. This PR makes the "help out!" link only show if the user `can_transcribe?` the work (if the work isn't restricted, if they're an owner of the work, or if they're a collaborator on the work). Otherwise, it'll say that "Collaboration is restricted" and won't have a link to transcribe.

 Here's how it looks, the work on the top is restricted and the work on the bottom is not.
![restricted collaboration](https://user-images.githubusercontent.com/35716893/207460932-bc863f68-65a8-4b1f-9fa5-6a40b2c92e52.jpg)
