### PR TITLE
Ignore false missing & unsued translations for #3430

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -107,12 +107,14 @@ ignore_missing:
     - '{!, !0, next, throw}'
     - 'deed.deed.*'
     - 'article.graph.title'
+    - 'thredded.*'
   es: &NOT_EN
     - '{!, !0, next, throw}'
     - 'deed.deed.*'
     - 'article.graph.title'
     - 'admin.*'
     - 'admin_mailer.*'
+    - 'thredded.*'
   pt: *NOT_EN
   fr: *NOT_EN
 
@@ -133,6 +135,8 @@ ignore_unused:
   - 'quality_samplings.show.approval_delta_display_{0,1,2,3,4}'
   - 'article.graph.dot.title'
   - 'dashboard.owner_header.account_types.{legacy,staff,trial,individual_researcher,small_organization,large_institution}'
+  - 'collection.edit_buttons.*_label'
+  - 'collection.edit_buttons.*_description'
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe I18n do
   let(:inconsistent_interpolations) { i18n.inconsistent_interpolations }
 
   it 'does not have missing keys' do
-    expect(missing_keys.leaves.count).to eq(68),
+    expect(missing_keys).to be_empty,
                             "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
   end
 


### PR DESCRIPTION
_Resolves #3430_

This fixes the falsely reported missing and unused translations by adding them to `ignore_missing` and `ignore_unused` of `config/i18n-tasks.yml`.

The "unused" translations were reported because they're used dynamically:
https://github.com/benwbrum/fromthepage/blob/66c67e78f30ec7960428743743a2a635f18ac3f1/app/views/collection/edit_buttons.html.slim#L11-L12

The "missing" translations were reported because the translations aren't in our locale files, but they're not actually missing on the site.