### PR TITLE
Don't use fork of i18n-tasks anymore for #3432

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ group :development, :test do
   # https://github.com/dejan/rails_panel
   gem 'bullet'
   gem 'listen'
-  gem 'i18n-tasks', git: "https://github.com/sylvieed/i18n-tasks", branch: 'main'
+  gem 'i18n-tasks'
   gem 'easy_translate'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,23 +25,6 @@ GIT
     iiif-image-api (0.2.0)
       activesupport
 
-GIT
-  remote: https://github.com/sylvieed/i18n-tasks
-  revision: d41b5ee1dc1126cdc319f32ce8204365da1e3252
-  branch: main
-  specs:
-    i18n-tasks (1.0.11)
-      activesupport (>= 4.0.2)
-      ast (>= 2.1.0)
-      better_html (~> 1.0)
-      erubi
-      highline (>= 2.0.0)
-      i18n
-      parser (>= 2.2.3.0)
-      rails-i18n
-      rainbow (>= 2.2.2, < 4.0)
-      terminal-table (>= 1.5.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -133,12 +116,11 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
-    better_html (1.0.16)
-      actionview (>= 4.0)
-      activesupport (>= 4.0)
+    better_html (2.0.1)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
       ast (~> 2.0)
       erubi (~> 1.4)
-      html_tokenizer (~> 0.0.6)
       parser (>= 2.4)
       smart_properties
     binding_of_caller (1.0.0)
@@ -255,7 +237,6 @@ GEM
     html-pipeline (2.14.2)
       activesupport (>= 2)
       nokogiri (>= 1.4)
-    html_tokenizer (0.0.7)
     htmlentities (4.3.4)
     http_accept_language (2.1.1)
     httpi (2.5.0)
@@ -263,6 +244,17 @@ GEM
       socksify
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.0.12)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      better_html (>= 1.0, < 3.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 2.2.3.0)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
@@ -373,7 +365,7 @@ GEM
       sanitize
     open3 (0.1.1)
     orm_adapter (0.5.0)
-    parser (3.1.2.1)
+    parser (3.1.3.0)
       ast (~> 2.4.1)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -573,7 +565,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (2.2.0)
+    unicode-display_width (2.3.0)
     uniform_notifier (1.16.0)
     user_agent_parser (2.11.0)
     vcr (6.1.0)
@@ -631,7 +623,7 @@ DEPENDENCIES
   friendly_id
   gravatar_image_tag
   http_accept_language
-  i18n-tasks!
+  i18n-tasks
   iiif-image-api!
   iiif-presentation!
   intercom (~> 3.9.0)


### PR DESCRIPTION
_Resolves #3432_

This changes our Gemfile to use the base `i18n-tasks` gem instead of my fork of it so the gem can continue getting future updates.