### PR TITLE
Made transcribe save buttons disable after click for #3365

### DIFF
--- a/app/views/transcribe/_save_buttons.html.slim
+++ b/app/views/transcribe/_save_buttons.html.slim
@@ -8,19 +8,19 @@
 
   / check status of page and configuration of collection
   -if @page.status.blank? || @page.status == Page::STATUS_INCOMPLETE || @page.status == Page::STATUS_BLANK
-    =button_tag t('.save_changes'), :name => 'save_to_incomplete', type: 'submit', id: 'save_button_top', onclick: 'unsavedNotes(event);', title: "#{t('.save_to_incomplete_tooltip')}"
+    =button_tag t('.save_changes'), :name => 'save_to_incomplete', type: 'submit', id: 'save_button_top', onclick: 'unsavedNotes(event);', title: "#{t('.save_to_incomplete_tooltip')}", data: { disable_with: t('.please_wait') }
 
   -if [Page::STATUS_NEEDS_REVIEW, Page::STATUS_INDEXED, Page::STATUS_TRANSCRIBED].include?(@page.status)
     -if @collection.review_workflow
-      =button_tag t('.save_changes'), :name => 'save_to_needs_review', type: 'submit', id: 'save_button_top', onclick: 'unsavedNotes(event);', title: "#{t('.save_to_needs_review_tooltip')}"
+      =button_tag t('.save_changes'), :name => 'save_to_needs_review', type: 'submit', id: 'save_button_top', onclick: 'unsavedNotes(event);', title: "#{t('.save_to_needs_review_tooltip')}", data: { disable_with: t('.please_wait') }
     -else
-      =button_tag t('.save_changes'), :name => 'save_to_transcribed', type: 'submit', id: 'save_button_top', onclick: 'unsavedNotes(event);', title: "#{t('.save_to_transcribed_tooltip')}", class: "bggreen"
+      =button_tag t('.save_changes'), :name => 'save_to_transcribed', type: 'submit', id: 'save_button_top', onclick: 'unsavedNotes(event);', title: "#{t('.save_to_transcribed_tooltip')}", class: "bggreen", data: { disable_with: t('.please_wait') }
 
   -if [nil, "", Page::STATUS_INCOMPLETE].include?(@page.status)
     -if @collection.review_workflow
-      =button_tag t('.done'), :name => 'save_to_needs_review', type: 'submit', id: 'finish_button_top', onclick: 'unsavedNotes(event);', title: "#{t('.finish_to_needs_review_tooltip')}", class: "bggreen"
+      =button_tag t('.done'), :name => 'save_to_needs_review', type: 'submit', id: 'finish_button_top', onclick: 'unsavedNotes(event);', title: "#{t('.finish_to_needs_review_tooltip')}", class: "bggreen", data: { disable_with: t('.please_wait') }
     -else
-      =button_tag t('.done'), :name => 'save_to_transcribed', type: 'submit', id: 'finish_button_top', onclick: 'unsavedNotes(event);', title: "#{t('.finish_to_transcribed_tooltip')}", class: "bggreen"
+      =button_tag t('.done'), :name => 'save_to_transcribed', type: 'submit', id: 'finish_button_top', onclick: 'unsavedNotes(event);', title: "#{t('.finish_to_transcribed_tooltip')}", class: "bggreen", data: { disable_with: t('.please_wait') }
 
   -if @collection.review_workflow && @page.status == Page::STATUS_NEEDS_REVIEW && current_user.can_review?(@collection)
-    =button_tag t('.approve'), :name => 'approve_to_transcribed', type: 'submit', id: 'approve_button_top', onclick: 'unsavedNotes(event);', title: "#{t('.approve_to_transcribed_tooltip')}", class: "bggreen"
+    =button_tag t('.approve'), :name => 'approve_to_transcribed', type: 'submit', id: 'approve_button_top', onclick: 'unsavedNotes(event);', title: "#{t('.approve_to_transcribed_tooltip')}", class: "bggreen", data: { disable_with: t('.please_wait') }

--- a/config/locales/transcribe/transcribe-en.yml
+++ b/config/locales/transcribe/transcribe-en.yml
@@ -50,6 +50,7 @@ en:
       edit_tooltip: Edit this page
       finish_to_needs_review_tooltip: Save a completed page
       finish_to_transcribed_tooltip: Save a completed page
+      please_wait: Please wait...
       preview: Preview
       preview_tooltip: Preview this page
       save_changes: Save

--- a/config/locales/transcribe/transcribe-es.yml
+++ b/config/locales/transcribe/transcribe-es.yml
@@ -50,6 +50,7 @@ es:
       edit_tooltip: Edita esta página
       finish_to_needs_review_tooltip: Guardar una página completada
       finish_to_transcribed_tooltip: Guardar una página completada
+      please_wait: Espere por favor...
       preview: Avance
       preview_tooltip: Vista previa de esta página
       save_changes: Guardar Cambios

--- a/config/locales/transcribe/transcribe-fr.yml
+++ b/config/locales/transcribe/transcribe-fr.yml
@@ -50,6 +50,7 @@ fr:
       edit_tooltip: Modifier cette page
       finish_to_needs_review_tooltip: Enregistrer une page terminée
       finish_to_transcribed_tooltip: Enregistrer une page terminée
+      please_wait: S'il vous plaît, attendez...
       preview: Aperçu
       preview_tooltip: Aperçu de cette page
       save_changes: Sauvegarder

--- a/config/locales/transcribe/transcribe-pt.yml
+++ b/config/locales/transcribe/transcribe-pt.yml
@@ -50,6 +50,7 @@ pt:
       edit_tooltip: Edite essa página
       finish_to_needs_review_tooltip: Salvar uma página completa
       finish_to_transcribed_tooltip: Salvar uma página completa
+      please_wait: Por favor, espere...
       preview: Visualizar
       preview_tooltip: Visualizar esta página
       save_changes: Salvar


### PR DESCRIPTION
_Resolves #3365_

Previously, people could double-click the page save buttons and this could cause duplicate subjects to be created. To fix this, this PR disables the "save" or "done" or "approve" buttons after the form has been submitted. It does this via the `data-disable-with` attribute.

Here's a video of how it looks:

https://user-images.githubusercontent.com/35716893/207950887-3f06cd15-dbe6-4109-a397-7765e06a7be9.mp4

Are there any other save buttons we want to add this to?