### PR TITLE
Use image helpers for image tags in landing pages for #3427

### DIFF
--- a/app/assets/javascripts/landing.js
+++ b/app/assets/javascripts/landing.js
@@ -1,0 +1,15 @@
+// This is a manifest file that'll be compiled into application.js, which will include all the files
+// listed below.
+//
+// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
+// or vendor/assets/javascripts of plugins, if any, can be referenced here using a relative path.
+//
+// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
+// the compiled file.
+//
+// WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
+// GO AFTER THE REQUIRES BELOW.
+//
+//= require jquery
+//= require jquery.ui.all
+//= require jquery_ujs

--- a/app/views/shared/_landingheader.html.erb
+++ b/app/views/shared/_landingheader.html.erb
@@ -20,6 +20,9 @@
     <%= stylesheet_link_tag "https://fonts.googleapis.com/css2?family=Crete+Round&family=Lora:wght@400;500;600;700&display=swap" %>
     <%= stylesheet_link_tag 'optimize' %>
     <%= stylesheet_link_tag 'main' %>
+
+
+    <%= javascript_include_tag 'landing.js' %>
     <%= javascript_include_tag 'landing/lightbox.min.js' %>
     <%= javascript_include_tag 'landing/main.js' %>
     <%= javascript_include_tag 'landing/slick.min.js' %>

--- a/app/views/shared/_landingheader.html.erb
+++ b/app/views/shared/_landingheader.html.erb
@@ -47,5 +47,3 @@
     </style>
     <!-- Links End -->
 </head>
-
-<body>

--- a/app/views/static/digital_scholarship.html.erb
+++ b/app/views/static/digital_scholarship.html.erb
@@ -675,7 +675,7 @@
     <section class="crowd-schedule">
         <div class="container">
             <div class="title">
-                <h4>1,274,218</h4>
+                <h4><%= number_with_delimiter Page.where.not(:status=>nil).count %></h4>
                 <p>Pages — and counting!</p>
             </div>
 

--- a/app/views/static/digital_scholarship.html.erb
+++ b/app/views/static/digital_scholarship.html.erb
@@ -4,7 +4,7 @@
 
     <!-- Home Main -->
     <section class="home-main">
-        <!-- <img src="assets/materials/main-bg.png" alt=""> -->
+        <!-- <%= image_tag("materials/main-bg.png") %> -->
 
         <div class="text">
             <h2 data-aos="zoom-in" data-aos-duration="800">Transcription for Digital Scholarship</h2>
@@ -13,7 +13,7 @@
             <div class="container">
                 <div class="row justify-content-center">
                     <div class="col-lg-9">
-                        <img src="assets/materials/transcription-digital-main.png" alt="" class="main-img">
+                        <%= image_tag("materials/transcription-digital-main.png", class: 'main-img')%>
                     </div>
                 </div>
             </div>
@@ -66,7 +66,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">Like many archives at the university level, we are eager for students to use archival collections in an intellectually rigorous way. Students and alumni find that crowdsourcing transcription is fun and interesting, as well as academically substantive. Having the documents transcribed enables us to ask different questions and to automate larger-scale data exploration of the primary sources. FromThePage is such a feature-rich, easy-to-use platform that using it for archival records about early Chinese students has been a worthwhile, key phase of our larger project. We have been so fortunate to have FromThePage to keep people engaged with the archives remotely during the pandemic. It is a very intuitive platform for archives and volunteers.<img src="assets/icons/quote02.svg" alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>Like many archives at the university level, we are eager for students to use archival collections in an intellectually rigorous way. Students and alumni find that crowdsourcing transcription is fun and interesting, as well as academically substantive. Having the documents transcribed enables us to ask different questions and to automate larger-scale data exploration of the primary sources. FromThePage is such a feature-rich, easy-to-use platform that using it for archival records about early Chinese students has been a worthwhile, key phase of our larger project. We have been so fortunate to have FromThePage to keep people engaged with the archives remotely during the pandemic. It is a very intuitive platform for archives and volunteers.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -90,7 +90,7 @@
         <div class="container">
             <h2 class="title">Our software has been trusted by faculty and librarians at these institutions:</h2>
 
-            <img src="assets/materials/transcription-digital-logos.png" alt="">
+            <%= image_tag("materials/transcription-digital-logos.png") %>
         </div>
     </section>
     <!-- Crowd Logos End -->
@@ -144,7 +144,7 @@
                     <div class="loop">
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">With all of its features, FromThePage has proven to be incredibly useful for us in cultivating community engagement, developing research initiatives, and enhancing collection accessibility. This is primarily due to the customization the platform enables. On the one hand, project contributors have the ability to reconfigure with relative ease their workspace and workflows, such as using dictation to transcribe. On the project management side, the import and export features being designed and deployed as part of the NEH-funded work with UT Libraries will greatly facilitate the movement of collections between our institutional repositories and the platform to expedite access and preserve citizen scholarship.<img src="assets/icons/quote02.svg" alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>With all of its features, FromThePage has proven to be incredibly useful for us in cultivating community engagement, developing research initiatives, and enhancing collection accessibility. This is primarily due to the customization the platform enables. On the one hand, project contributors have the ability to reconfigure with relative ease their workspace and workflows, such as using dictation to transcribe. On the project management side, the import and export features being designed and deployed as part of the NEH-funded work with UT Libraries will greatly facilitate the movement of collections between our institutional repositories and the platform to expedite access and preserve citizen scholarship.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -158,8 +158,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">My experience has been resoundingly positive. Since the very first day we uploaded our documents to the website, we’ve had volunteers from around the globe dive into the project. Additionally, using FromThePage provides a centralized place where I can send volunteers who are interested in transcribing, where I can answer questions quickly and easily, and where I can track progress on the project. Previously, I had been emailing chunks of records to people who were interested in transcribing, which was an extremely inefficient, difficult to track, and overly stressful method. Using FromThePage has streamlined my entire operation and greatly improved the quality and speed of our transcriptions.<img src="assets/icons/quote02.svg"
-                                        alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>My experience has been resoundingly positive. Since the very first day we uploaded our documents to the website, we’ve had volunteers from around the globe dive into the project. Additionally, using FromThePage provides a centralized place where I can send volunteers who are interested in transcribing, where I can answer questions quickly and easily, and where I can track progress on the project. Previously, I had been emailing chunks of records to people who were interested in transcribing, which was an extremely inefficient, difficult to track, and overly stressful method. Using FromThePage has streamlined my entire operation and greatly improved the quality and speed of our transcriptions.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -173,8 +172,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">We wanted to enrich our digitized collections, improving both the searchability and the accessibility of our records; a notoriously difficult thing for most archives to do, but here we have a way forward to address accessibility issues, and have full text available for screen readers. From an administrator's perspective, this had to be one of the easiest platforms to start up. It took all of 10-20 minutes to get our account and project started, and our transcriber managed to transcribe 20 pages before the end of the first day! Honestly, the barrier-to-entry is almost non-existent, volunteers significantly improve the accessibility of our holdings, and the rewards can be seen almost immediately.<img src="assets/icons/quote02.svg"
-                                        alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>We wanted to enrich our digitized collections, improving both the searchability and the accessibility of our records; a notoriously difficult thing for most archives to do, but here we have a way forward to address accessibility issues, and have full text available for screen readers. From an administrator's perspective, this had to be one of the easiest platforms to start up. It took all of 10-20 minutes to get our account and project started, and our transcriber managed to transcribe 20 pages before the end of the first day! Honestly, the barrier-to-entry is almost non-existent, volunteers significantly improve the accessibility of our holdings, and the rewards can be seen almost immediately.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -507,7 +505,7 @@
                     <div class="loop-case">
                         <div class="box">
                             <div class="item">
-                                <img src="assets/materials/digital-case01.png" alt="">
+                                <%= image_tag("materials/digital-case01.png") %>
                                 <p>Rebecca Nesvet, an English Literature Professor at University of Wisconsin Green Bay uses FromThePage to teach documentary editing, critical editing, and how to create a Text Encoding Initiative (TEI) edition of The String of Pearls or The Barber of Fleet Street, the second oldest story of Sweeny Todd. FromThePage allows students to correct a poor OCR version, making a real contribution to the reading community. Explore Rebecca’s use of transcription for pedagogy <a href="#">here</a>.</p>
                             </div>
                         </div>
@@ -518,7 +516,7 @@
                             <div class="item">
                                 <div class="row">
                                     <div class="col-lg-6">
-                                        <img src="assets/materials/digital-case02.png" alt="" class="second-img">
+                                        <%= image_tag("materials/digital-case02.png", class: 'second-img') %>
                                     </div>
     
                                     <div class="col-lg-6">
@@ -532,7 +530,7 @@
                     
                         <div class="box">
                             <div class="item">
-                                <img src="assets/materials/digital-case03.png" alt="">
+                                <%= image_tag("materials/digital-case03.png") %>
                                 <p>Adam Rabinowitz, a Classics Professor at the University of Texas at Austin, uses FromThePage as a teaching tool in an undergraduate course. Each student is assigned to find the primary source materials in the archive and transcribe a letter in the collection using FromThePage. Then a larger collection of transcribed letters are provided to write a paper. Read more on Adam’s use of transcription for pedagogy <a href="#">here</a>.</p>
                             </div>
                         </div>
@@ -541,7 +539,7 @@
                      
                         <div class="box">
                             <div class="item">
-                                <img src="assets/materials/digital-case04.png" alt="">
+                                <%= image_tag("materials/digital-case04.png") %>
                                 <p>University of Southern Mississippi is transcribing, and annotating 20,000 digitized documents from the governor’s papers from the Civil War through the Reconstruction era. Transcription of letters to the governor provides a view of people experiencing this contentious time regardless of class, gender, race, religion, nativity, and age; traditional sources cannot provide access to that diversity. The collection includes lesson plans to help secondary educators incorporate these diverse nineteenth-century collections into classrooms. Discover more <a href="#">here</a>.</p>
                             </div>
                         </div>
@@ -549,7 +547,7 @@
                       
                         <div class="box">
                             <div class="item">
-                                <img src="assets/materials/digital-case05.png" alt="">
+                                <%= image_tag("materials/digital-case05.png") %>
                                 <p>The University of Texas has a project focused on documenting underrepresented communities in Latin America through the digitization, digital preservation, and long-term digital access of fragile and endangered local archives. FromThePage partnered on internationalizing the platform, breaking down barriers to accessing Spanish and Portuguese-language digital collections, enabling collaboration with Latin American partners. Find out more about how FromThePage can support democratizing knowledge production <a href="#">here</a>.</p>
                             </div>
                         </div>
@@ -560,7 +558,7 @@
                             <div class="item">
                                 <div class="row">
                                     <div class="col-lg-6">
-                                        <img src="assets/materials/digital-case06.png" alt="" class="second-img">
+                                        <%= image_tag("materials/digital-case06.png", class: 'second-img') %>
                                     </div>
     
                                     <div class="col-lg-6">
@@ -575,7 +573,7 @@
                      
                         <div class="box">
                             <div class="item">
-                                <img src="assets/materials/digital-case07.png" alt="">
+                                <%= image_tag("materials/digital-case07.png") %>
                                 <p>Dr. Julie deGraffenried & Benna Vaughan of Baylor University presented archival documents in a classroom setting to give students research experience in primary sources. Students used FromThePage to transcribe the 1916 minutes of the Evangelia Settlement House, the first daycare program for underprivileged children in Waco, Texas. Students experienced first-hand how transcription is a public service history enthusiasts can perform for the public. See how impactful the experience was for students <a href="#">here</a>.</p>
                             </div>
                         </div>
@@ -586,7 +584,7 @@
                             <div class="item">
                                 <div class="row">
                                     <div class="col-lg-6">
-                                        <img src="assets/materials/digital-case08.png" alt="" class="second-img">
+                                        <%= image_tag("materials/digital-case08.png", class: 'second-img') %>
                                     </div>
     
                                     <div class="col-lg-6">
@@ -620,7 +618,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">I have used FromThePage as both a research and a pedagogical tool; not having to wrestle with the tool is so helpful in keeping up the momentum of the work. I can confidently ask my colleagues to collaborate without asking them to spend hours learning a new tool or interface. A four year remote collaboration project has endured to a great extent because we could bring project members in seamlessly. In the classroom, my students have found transcribing exciting and gratifying, and a wonderful addition to the secondary material we are learning. Students really like learning this way because it is an unmediated experience; this is a real experience of meeting a scribe through his or her writings.<img src="assets/icons/quote02.svg" alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>I have used FromThePage as both a research and a pedagogical tool; not having to wrestle with the tool is so helpful in keeping up the momentum of the work. I can confidently ask my colleagues to collaborate without asking them to spend hours learning a new tool or interface. A four year remote collaboration project has endured to a great extent because we could bring project members in seamlessly. In the classroom, my students have found transcribing exciting and gratifying, and a wonderful addition to the secondary material we are learning. Students really like learning this way because it is an unmediated experience; this is a real experience of meeting a scribe through his or her writings.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -634,10 +632,10 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">We have an enormous amount of understudied documentation that could yield meaningful findings, if people could just get to the stuff — FromThePage helps make access possible.
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>We have an enormous amount of understudied documentation that could yield meaningful findings, if people could just get to the stuff — FromThePage helps make access possible.
                                     <br>
                                         The platform is straightforward; not having to learn a bunch of code or a complicated platform is such a relief. I had one student say it was “soothing” to work on transcribing on FromThePage, and that made me so happy. I don’t want it to be tedious and boring work, because the subject is so interesting! FromThePage lets the subject be the focus, and makes it easy to work. I lose track of time a lot when I work on the project and don’t want to stop.
-                                    <img src="assets/icons/quote02.svg" alt="" class="bottom">
+                                    <%= image_tag("icons/quote02.svg", class: 'bottom') %>
                                 </p>
 
                                 <div class="info">
@@ -652,8 +650,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">As part of a land grant institution, the library wholeheartedly supports the mission of sharing knowledge beyond the campus borders. Adhering to this mission requires a further commitment to digital accessibility and the inclusive practice of removing barriers that prevent interaction with, or access to, digital content by people with disabilities. By providing accurate transcriptions, translations, and correcting OCR, we expand access to this content for all online users in accordance with WCAG 2.1 AA accessibility guidelines. Ben and Sara are easy to work with, understand our profession well, and are committed to making the systems we all use easier and better integrated. <img src="assets/icons/quote02.svg" alt="" class="bottom">
-                                </p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>As part of a land grant institution, the library wholeheartedly supports the mission of sharing knowledge beyond the campus borders. Adhering to this mission requires a further commitment to digital accessibility and the inclusive practice of removing barriers that prevent interaction with, or access to, digital content by people with disabilities. By providing accurate transcriptions, translations, and correcting OCR, we expand access to this content for all online users in accordance with WCAG 2.1 AA accessibility guidelines. Ben and Sara are easy to work with, understand our profession well, and are committed to making the systems we all use easier and better integrated. <%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -708,7 +705,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">With FromThePage everyone from secondary and college students to retiree volunteers can hop online and transcribe a document. Template instructions appear with every item — basic transcription protocols and best practices that project directors can tweak to their standards. FromThePage lets us annotate documents from the start, radically improving users ability to navigate and learn from the collection as soon as it is available online.<img src="assets/icons/quote02.svg" alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>With FromThePage everyone from secondary and college students to retiree volunteers can hop online and transcribe a document. Template instructions appear with every item — basic transcription protocols and best practices that project directors can tweak to their standards. FromThePage lets us annotate documents from the start, radically improving users ability to navigate and learn from the collection as soon as it is available online.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 

--- a/app/views/static/public_libraries.html.erb
+++ b/app/views/static/public_libraries.html.erb
@@ -4,7 +4,7 @@
 
     <!-- Home Main -->
     <section class="home-main">
-        <!-- <img src="assets/materials/main-bg.png" alt=""> -->
+        <!-- <%= image_tag("materials/main-bg.png") %>-->
 
         <div class="text">
             <h2 data-aos="zoom-in" data-aos-duration="800">Crowdsourcing for Public Libraries</h2>
@@ -14,7 +14,7 @@
             <div class="container">
                 <div class="row justify-content-center">
                     <div class="col-lg-9">
-                        <img src="assets/materials/crowd-main01.png" alt="" class="main-img">
+                        <%= image_tag("materials/crowd-main01.png" class: 'main-img') %>
                     </div>
                 </div>
             </div>
@@ -71,7 +71,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">Most of our volunteers were
+                                <p><%= image_tag("icons/quote01.svg" class: 'top') %>Most of our volunteers were
                                     unfamiliar with the library’s digital collections before learning about the
                                     opportunity to volunteer with us, so there is value beyond just the transcripts they
                                     produce. FromThePage works for libraries at different levels; institutions like
@@ -82,8 +82,7 @@
                                     to transcription who previously had no experience with it whatsoever. We can expand
                                     the library’s volunteer base while also promoting the collections and seeing
                                     transcribers' joy at puzzling out a difficult word or finding something funny in an
-                                    old letter has been a real blast!<img src="assets/icons/quote02.svg" alt=""
-                                        class="bottom"></p>
+                                    old letter has been a real blast!<%= image_tag("icons/quote02.svg" class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -107,7 +106,7 @@
         <div class="container">
             <h2 class="title">Our software has been trusted by librarians and archivists at these institutions:</h2>
 
-            <img src="assets/materials/crowd-logos.png" alt="">
+            <%= image_tag("materials/crowd-logos.png") %>
         </div>
     </section>
     <!-- Crowd Logos End -->
@@ -164,7 +163,7 @@
                     <div class="loop">
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">Having transcriptions for some
+                                <p><%= image_tag("icons/quote01.svg" class: 'top') %>Having transcriptions for some
                                     of our most significant manuscript collections has been extremely valuable for
                                     researchers and Library staff, allowing the interrogation of large archival
                                     collections in an efficient way. Crowdsourcing has allowed us to harness the
@@ -172,8 +171,7 @@
                                     be mutually beneficial to both parties in achieving objectives of deeper public
                                     engagement with the collections and for the Library to build ongoing relationships
                                     with volunteers and establish a greater understanding of their interests, habits,
-                                    and motivations for supporting the Library.<img src="assets/icons/quote02.svg"
-                                        alt="" class="bottom"></p>
+                                    and motivations for supporting the Library.<%= image_tag("icons/quote02.svg" class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -187,8 +185,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">Most people are unaware of the lengthy process required to make digital images of textual documents discoverable. This issue is compounded by handwritten and typed documents. Documents created on typewriters in the late 19th and early 20th centuries have irregular margins, lines, and typed-over script. These characteristics make optical text recognition (OCR) nearly impossible, and the results are unreliable. Crowdsourced transcription easily solves this problem. FromThePage has reduced the amount of time spent preparing documents for publishing in our digital archives. Using crowdsourced transcription to speed up the process of indexing and publishing keyword searchable records to digital archives helps institutions make their collections discoverable from anywhere. My experience with FromThePage has by far exceeded my expectations.<img src="assets/icons/quote02.svg"
-                                        alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg" class: 'top') %>Most people are unaware of the lengthy process required to make digital images of textual documents discoverable. This issue is compounded by handwritten and typed documents. Documents created on typewriters in the late 19th and early 20th centuries have irregular margins, lines, and typed-over script. These characteristics make optical text recognition (OCR) nearly impossible, and the results are unreliable. Crowdsourced transcription easily solves this problem. FromThePage has reduced the amount of time spent preparing documents for publishing in our digital archives. Using crowdsourced transcription to speed up the process of indexing and publishing keyword searchable records to digital archives helps institutions make their collections discoverable from anywhere. My experience with FromThePage has by far exceeded my expectations.<%= image_tag("icons/quote02.svg" class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -202,8 +199,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">Our experience using FromThePage has been very positive. Our goal was to capture all the data from the WWI Questionnaires, as well as other field-based documents, in order to increase access and searchability. We chose an absolute beast of a form to attempt as our first structured data transcription set: 118 lines, some with 3 or 4 fields per line, with a total of over 200 fields. Ben and Sara worked with our team at the Library to upload all the images, make the form properly, and even incorporate new features we needed. Crowdsourcing has been immensely popular with our users, and we want to continue to build on this type of interaction with ongoing projects. We look forward to continuing to work with users and FromThePage to improve our collections and generate new interactions.<img src="assets/icons/quote02.svg"
-                                        alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg" class: 'top') %>Our experience using FromThePage has been very positive. Our goal was to capture all the data from the WWI Questionnaires, as well as other field-based documents, in order to increase access and searchability. We chose an absolute beast of a form to attempt as our first structured data transcription set: 118 lines, some with 3 or 4 fields per line, with a total of over 200 fields. Ben and Sara worked with our team at the Library to upload all the images, make the form properly, and even incorporate new features we needed. Crowdsourcing has been immensely popular with our users, and we want to continue to build on this type of interaction with ongoing projects. We look forward to continuing to work with users and FromThePage to improve our collections and generate new interactions.<%= image_tag("icons/quote02.svg" class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -219,8 +215,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">We have a community who wants to engage with records, and this gives us a way to let them interact with our materials that is supportive without requiring special knowledge. It's been very easy, very hands off. Instead of dealing with dozens of questions about transcriptions and formatting I just send our patrons to our site. Also, any time we try to implement something new and cool, Sara and Ben are super responsive and supportive. I wish even a fraction of our other services were as supportive as FromThePage has been.<img src="assets/icons/quote02.svg"
-                                        alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg" class: 'top') %>We have a community who wants to engage with records, and this gives us a way to let them interact with our materials that is supportive without requiring special knowledge. It's been very easy, very hands off. Instead of dealing with dozens of questions about transcriptions and formatting I just send our patrons to our site. Also, any time we try to implement something new and cool, Sara and Ben are super responsive and supportive. I wish even a fraction of our other services were as supportive as FromThePage has been.<%= image_tag("icons/quote02.svg" class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -609,7 +604,7 @@
                     <div class="loop-case">
                         <div class="box">
                             <div class="item">
-                                <img src="assets/materials/crowd-case01.png" alt="">
+                                <%= image_tag("materials/crowd-case01.png") %>
                                 <p>FromThePage allows the public to have meaningful interaction with the Genealogy, Local History & Archives Unit of the Fort Worth Public Library. Over 8,000 pages have been transcribed in a little over a year. Volunteers enjoy making a contribution to the historical record by transcribing hand-written or type-written documents, helping make digitized records more useful to researchers by speeding up the indexing process. Learn more about this crowdsourcing success <a href="#">here</a>.</p>
                             </div>
                         </div>
@@ -622,7 +617,7 @@
                             <div class="item">
                                 <div class="row">
                                     <div class="col-lg-6">
-                                        <img src="assets/materials/crowd-case02.png" alt="" class="second-img">
+                                        <%= image_tag("materials/crowd-case02.png", class: 'second-img') %>
                                     </div>
     
                                     <div class="col-lg-6">
@@ -638,7 +633,7 @@
                      
                         <div class="box">
                             <div class="item">
-                                <img src="assets/materials/crowd-case03.png" alt="">
+                                <%= image_tag("materials/crowd-case03.png") %>
                                 <p>Los Angeles County Library’s Office of Indian Affairs has 5,300 handwritten letters about interactions with California Indians from federal and state government officials and private citizens sent to the federal Office of Indian Affairs between 1849 and 1880. Using FromThePage to create full-text transcripts of the letters opens them up to students, researchers, and others who want to learn about people from that time. Crowdsourcing this work also provides users new ways to interact with and explore the collection; find out more <a href="#">here</a>.</p>
                             </div>
                         </div>
@@ -648,7 +643,7 @@
                     
                         <div class="box">
                             <div class="item">
-                                <img src="assets/materials/crowd-case04.png" alt="">
+                                <%= image_tag("materials/crowd-case04.png") %>
                                 <p>The Alabama Department of Archives and History has transcribed 61 volumes of voter registration oaths taken by white and black men in Alabama in 1875. Each entry records the voter's name, race, and occupation–details invaluable to genealogists and scholars. These are among the state's earliest government records documenting the names of formerly enslaved African American men. Discover how transcription allows exploration of these rich but complicated sources of information <a href="#">here</a>.</p>
                             </div>
                         </div>
@@ -660,7 +655,7 @@
                             <div class="item">
                                 <div class="row">
                                     <div class="col-lg-6">
-                                        <img src="assets/materials/crowd-case05.png" alt="" class="second-img">
+                                        <%= image_tag("materials/crowd-case05.png") %>
                                     </div>
     
                                     <div class="col-lg-6">
@@ -676,7 +671,7 @@
                      
                         <div class="box">
                             <div class="item">
-                                <img src="assets/materials/crowd-case06.png" alt="">
+                                <%= image_tag("materials/crowd-case06.png") %>
                                 <p>East Hampton Public Library is using FromThePage for historical church records to help identify formerly enslaved people and for 63 volumes of whaling logs covering 70 voyages. Cursive handwriting of records has been a barrier for genealogical research and for people to understand some amazing stories, like the first American voyage to Antarctica by Captain Mercator Cooper. Transcripts of materials make them more searchable and accessible, helping people discover historical records without requiring special knowledge on how to decipher difficult handwriting. Find out more <a href="#">here</a>.</p>
                             </div>
                         </div>
@@ -687,7 +682,7 @@
                      
                         <div class="box">
                             <div class="item">
-                                <img src="assets/materials/crowd-case07.png" alt="">
+                                <%= image_tag("materials/crowd-case07.png") %>
                                 <p>The Seattle Municipal Archives has been transcribing records documenting City of Seattle activities from the 1870s to the early 1900s; including letters and petitions to claims, reports, bids, and contracts illustrating the growth of a booming city in the words of everyday people who may not be documented elsewhere. These transcripts are full of gold nuggets for genealogists, and valuable primary sources for students and anyone interested in early Seattle history. Check out how FromThePage provides a hands-on approach to history <a href="#">here</a>.</p>
                             </div>
                         </div>
@@ -715,8 +710,8 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">
-                                    One of our goals is to increase the visibility of our materials and engage new audiences and volunteers in a way that is as “hands-on” as possible in a virtual environment. We like that FromThePage is a web-based platform that can be easily accessed from anywhere and is an uncomplicated platform, easy to set up and also easy for people of any technical ability to use. FromThePage is scalable with different options depending on your number of records and/or institutional capacity, so we’re able to work within a level that best fits our needs. It’s been exciting to hear from our community of volunteer transcribers who say they enjoy this unique way of learning about the history of their city! <img src="assets/icons/quote02.svg" alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg" class: 'top') %>
+                                    One of our goals is to increase the visibility of our materials and engage new audiences and volunteers in a way that is as “hands-on” as possible in a virtual environment. We like that FromThePage is a web-based platform that can be easily accessed from anywhere and is an uncomplicated platform, easy to set up and also easy for people of any technical ability to use. FromThePage is scalable with different options depending on your number of records and/or institutional capacity, so we’re able to work within a level that best fits our needs. It’s been exciting to hear from our community of volunteer transcribers who say they enjoy this unique way of learning about the history of their city! <%= image_tag("icons/quote02.svg" class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -730,7 +725,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">Even as computer-generated character recognition continues to improve, the best mechanism for transcription is still the human eye. Historical institutions such as Kentucky Historical Society rely on the hard work of volunteers and staff to create readable and searchable versions of their collections, especially handwritten documents. In many cases, the usefulness of historical resources increases exponentially after transcription. FromThePage provides a platform on which this work can take place quickly and easily. FromThePage is also remarkably easy to use, both from the back end and as a transcriber, and the projects themselves provide an opportunity for users to interact with primary sources virtually even if they can’t visit the institution in person. <img src="assets/icons/quote02.svg" alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg" class: 'top') %>Even as computer-generated character recognition continues to improve, the best mechanism for transcription is still the human eye. Historical institutions such as Kentucky Historical Society rely on the hard work of volunteers and staff to create readable and searchable versions of their collections, especially handwritten documents. In many cases, the usefulness of historical resources increases exponentially after transcription. FromThePage provides a platform on which this work can take place quickly and easily. FromThePage is also remarkably easy to use, both from the back end and as a transcriber, and the projects themselves provide an opportunity for users to interact with primary sources virtually even if they can’t visit the institution in person. <%= image_tag("icons/quote02.svg" class: 'bottom') %></p>
 
                                 <div class="info">
                                     <div class="text">
@@ -743,7 +738,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">FromThePage was exactly what we were looking for—a crowdsourced transcription platform that offered hosting services. The archives used it to create a meaningful World War I centennial commemorative program involving the public. We accomplished a massive indexing project of over 111,000 WWI service records cards more quickly than we ever could have in-house. Working with Ben and Sara we produced the field function feature needed for this project and now it can be adapted for other crowdsourcing projects. Through this work we established a base of “virtual volunteers” and formed relationships in a new community of users. <img src="assets/icons/quote02.svg" alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg" class: 'top') %>FromThePage was exactly what we were looking for—a crowdsourced transcription platform that offered hosting services. The archives used it to create a meaningful World War I centennial commemorative program involving the public. We accomplished a massive indexing project of over 111,000 WWI service records cards more quickly than we ever could have in-house. Working with Ben and Sara we produced the field function feature needed for this project and now it can be adapted for other crowdsourcing projects. Through this work we established a base of “virtual volunteers” and formed relationships in a new community of users. <%= image_tag("icons/quote02.svg" class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -799,7 +794,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">We'd been looking for a program to facilitate this project for some time, and FromThePage ticked all the boxes for us: ability to import, host, and export documents and content, mechanisms to track progress, and ways to learn about how our collaborators were working on the project were all important to us. Our main goal is to make this large amount of content more accessible. Full-text transcription of the letters will really open them up to use for students, researchers, and others who want to find, read, and analyze their contents to learn more about people and events of the time. We're also interested in providing our users with new ways to interact with and explore our collections. We're so glad we found FromThePage!<img src="assets/icons/quote02.svg" alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg" class: 'top') %>We'd been looking for a program to facilitate this project for some time, and FromThePage ticked all the boxes for us: ability to import, host, and export documents and content, mechanisms to track progress, and ways to learn about how our collaborators were working on the project were all important to us. Our main goal is to make this large amount of content more accessible. Full-text transcription of the letters will really open them up to use for students, researchers, and others who want to find, read, and analyze their contents to learn more about people and events of the time. We're also interested in providing our users with new ways to interact with and explore our collections. We're so glad we found FromThePage!<%= image_tag("icons/quote02.svg" class: 'bottom') %></p>
 
                                 <div class="info">
 

--- a/app/views/static/public_libraries.html.erb
+++ b/app/views/static/public_libraries.html.erb
@@ -1,6 +1,6 @@
 <%= render "shared/landingheader" %>
 <body>
-<%= render "shared/landingbodyheader" %>
+    <%= render "shared/landingbodyheader" %>
 
     <!-- Home Main -->
     <section class="home-main">
@@ -14,7 +14,7 @@
             <div class="container">
                 <div class="row justify-content-center">
                     <div class="col-lg-9">
-                        <%= image_tag("materials/crowd-main01.png" class: 'main-img') %>
+                        <%= image_tag("materials/crowd-main01.png", class: 'main-img') %>
                     </div>
                 </div>
             </div>
@@ -71,7 +71,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><%= image_tag("icons/quote01.svg" class: 'top') %>Most of our volunteers were
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>Most of our volunteers were
                                     unfamiliar with the library’s digital collections before learning about the
                                     opportunity to volunteer with us, so there is value beyond just the transcripts they
                                     produce. FromThePage works for libraries at different levels; institutions like
@@ -82,7 +82,7 @@
                                     to transcription who previously had no experience with it whatsoever. We can expand
                                     the library’s volunteer base while also promoting the collections and seeing
                                     transcribers' joy at puzzling out a difficult word or finding something funny in an
-                                    old letter has been a real blast!<%= image_tag("icons/quote02.svg" class: 'bottom') %></p>
+                                    old letter has been a real blast!<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -163,7 +163,7 @@
                     <div class="loop">
                         <div class="box">
                             <div class="item">
-                                <p><%= image_tag("icons/quote01.svg" class: 'top') %>Having transcriptions for some
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>Having transcriptions for some
                                     of our most significant manuscript collections has been extremely valuable for
                                     researchers and Library staff, allowing the interrogation of large archival
                                     collections in an efficient way. Crowdsourcing has allowed us to harness the
@@ -171,7 +171,7 @@
                                     be mutually beneficial to both parties in achieving objectives of deeper public
                                     engagement with the collections and for the Library to build ongoing relationships
                                     with volunteers and establish a greater understanding of their interests, habits,
-                                    and motivations for supporting the Library.<%= image_tag("icons/quote02.svg" class: 'bottom') %></p>
+                                    and motivations for supporting the Library.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -185,7 +185,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><%= image_tag("icons/quote01.svg" class: 'top') %>Most people are unaware of the lengthy process required to make digital images of textual documents discoverable. This issue is compounded by handwritten and typed documents. Documents created on typewriters in the late 19th and early 20th centuries have irregular margins, lines, and typed-over script. These characteristics make optical text recognition (OCR) nearly impossible, and the results are unreliable. Crowdsourced transcription easily solves this problem. FromThePage has reduced the amount of time spent preparing documents for publishing in our digital archives. Using crowdsourced transcription to speed up the process of indexing and publishing keyword searchable records to digital archives helps institutions make their collections discoverable from anywhere. My experience with FromThePage has by far exceeded my expectations.<%= image_tag("icons/quote02.svg" class: 'bottom') %></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>Most people are unaware of the lengthy process required to make digital images of textual documents discoverable. This issue is compounded by handwritten and typed documents. Documents created on typewriters in the late 19th and early 20th centuries have irregular margins, lines, and typed-over script. These characteristics make optical text recognition (OCR) nearly impossible, and the results are unreliable. Crowdsourced transcription easily solves this problem. FromThePage has reduced the amount of time spent preparing documents for publishing in our digital archives. Using crowdsourced transcription to speed up the process of indexing and publishing keyword searchable records to digital archives helps institutions make their collections discoverable from anywhere. My experience with FromThePage has by far exceeded my expectations.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -199,7 +199,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><%= image_tag("icons/quote01.svg" class: 'top') %>Our experience using FromThePage has been very positive. Our goal was to capture all the data from the WWI Questionnaires, as well as other field-based documents, in order to increase access and searchability. We chose an absolute beast of a form to attempt as our first structured data transcription set: 118 lines, some with 3 or 4 fields per line, with a total of over 200 fields. Ben and Sara worked with our team at the Library to upload all the images, make the form properly, and even incorporate new features we needed. Crowdsourcing has been immensely popular with our users, and we want to continue to build on this type of interaction with ongoing projects. We look forward to continuing to work with users and FromThePage to improve our collections and generate new interactions.<%= image_tag("icons/quote02.svg" class: 'bottom') %></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>Our experience using FromThePage has been very positive. Our goal was to capture all the data from the WWI Questionnaires, as well as other field-based documents, in order to increase access and searchability. We chose an absolute beast of a form to attempt as our first structured data transcription set: 118 lines, some with 3 or 4 fields per line, with a total of over 200 fields. Ben and Sara worked with our team at the Library to upload all the images, make the form properly, and even incorporate new features we needed. Crowdsourcing has been immensely popular with our users, and we want to continue to build on this type of interaction with ongoing projects. We look forward to continuing to work with users and FromThePage to improve our collections and generate new interactions.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -215,7 +215,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><%= image_tag("icons/quote01.svg" class: 'top') %>We have a community who wants to engage with records, and this gives us a way to let them interact with our materials that is supportive without requiring special knowledge. It's been very easy, very hands off. Instead of dealing with dozens of questions about transcriptions and formatting I just send our patrons to our site. Also, any time we try to implement something new and cool, Sara and Ben are super responsive and supportive. I wish even a fraction of our other services were as supportive as FromThePage has been.<%= image_tag("icons/quote02.svg" class: 'bottom') %></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>We have a community who wants to engage with records, and this gives us a way to let them interact with our materials that is supportive without requiring special knowledge. It's been very easy, very hands off. Instead of dealing with dozens of questions about transcriptions and formatting I just send our patrons to our site. Also, any time we try to implement something new and cool, Sara and Ben are super responsive and supportive. I wish even a fraction of our other services were as supportive as FromThePage has been.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -710,8 +710,8 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><%= image_tag("icons/quote01.svg" class: 'top') %>
-                                    One of our goals is to increase the visibility of our materials and engage new audiences and volunteers in a way that is as “hands-on” as possible in a virtual environment. We like that FromThePage is a web-based platform that can be easily accessed from anywhere and is an uncomplicated platform, easy to set up and also easy for people of any technical ability to use. FromThePage is scalable with different options depending on your number of records and/or institutional capacity, so we’re able to work within a level that best fits our needs. It’s been exciting to hear from our community of volunteer transcribers who say they enjoy this unique way of learning about the history of their city! <%= image_tag("icons/quote02.svg" class: 'bottom') %></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>
+                                    One of our goals is to increase the visibility of our materials and engage new audiences and volunteers in a way that is as “hands-on” as possible in a virtual environment. We like that FromThePage is a web-based platform that can be easily accessed from anywhere and is an uncomplicated platform, easy to set up and also easy for people of any technical ability to use. FromThePage is scalable with different options depending on your number of records and/or institutional capacity, so we’re able to work within a level that best fits our needs. It’s been exciting to hear from our community of volunteer transcribers who say they enjoy this unique way of learning about the history of their city! <%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -725,7 +725,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><%= image_tag("icons/quote01.svg" class: 'top') %>Even as computer-generated character recognition continues to improve, the best mechanism for transcription is still the human eye. Historical institutions such as Kentucky Historical Society rely on the hard work of volunteers and staff to create readable and searchable versions of their collections, especially handwritten documents. In many cases, the usefulness of historical resources increases exponentially after transcription. FromThePage provides a platform on which this work can take place quickly and easily. FromThePage is also remarkably easy to use, both from the back end and as a transcriber, and the projects themselves provide an opportunity for users to interact with primary sources virtually even if they can’t visit the institution in person. <%= image_tag("icons/quote02.svg" class: 'bottom') %></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>Even as computer-generated character recognition continues to improve, the best mechanism for transcription is still the human eye. Historical institutions such as Kentucky Historical Society rely on the hard work of volunteers and staff to create readable and searchable versions of their collections, especially handwritten documents. In many cases, the usefulness of historical resources increases exponentially after transcription. FromThePage provides a platform on which this work can take place quickly and easily. FromThePage is also remarkably easy to use, both from the back end and as a transcriber, and the projects themselves provide an opportunity for users to interact with primary sources virtually even if they can’t visit the institution in person. <%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
                                     <div class="text">
@@ -738,7 +738,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><%= image_tag("icons/quote01.svg" class: 'top') %>FromThePage was exactly what we were looking for—a crowdsourced transcription platform that offered hosting services. The archives used it to create a meaningful World War I centennial commemorative program involving the public. We accomplished a massive indexing project of over 111,000 WWI service records cards more quickly than we ever could have in-house. Working with Ben and Sara we produced the field function feature needed for this project and now it can be adapted for other crowdsourcing projects. Through this work we established a base of “virtual volunteers” and formed relationships in a new community of users. <%= image_tag("icons/quote02.svg" class: 'bottom') %></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>FromThePage was exactly what we were looking for—a crowdsourced transcription platform that offered hosting services. The archives used it to create a meaningful World War I centennial commemorative program involving the public. We accomplished a massive indexing project of over 111,000 WWI service records cards more quickly than we ever could have in-house. Working with Ben and Sara we produced the field function feature needed for this project and now it can be adapted for other crowdsourcing projects. Through this work we established a base of “virtual volunteers” and formed relationships in a new community of users. <%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -763,7 +763,7 @@
     <section class="crowd-schedule">
         <div class="container">
             <div class="title">
-                <h4>1,274,218</h4>
+                <h4><%= number_with_delimiter Page.where.not(:status=>nil).count %></h4>
                 <p>Pages — and counting!</p>
             </div>
 
@@ -794,7 +794,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><%= image_tag("icons/quote01.svg" class: 'top') %>We'd been looking for a program to facilitate this project for some time, and FromThePage ticked all the boxes for us: ability to import, host, and export documents and content, mechanisms to track progress, and ways to learn about how our collaborators were working on the project were all important to us. Our main goal is to make this large amount of content more accessible. Full-text transcription of the letters will really open them up to use for students, researchers, and others who want to find, read, and analyze their contents to learn more about people and events of the time. We're also interested in providing our users with new ways to interact with and explore our collections. We're so glad we found FromThePage!<%= image_tag("icons/quote02.svg" class: 'bottom') %></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>We'd been looking for a program to facilitate this project for some time, and FromThePage ticked all the boxes for us: ability to import, host, and export documents and content, mechanisms to track progress, and ways to learn about how our collaborators were working on the project were all important to us. Our main goal is to make this large amount of content more accessible. Full-text transcription of the letters will really open them up to use for students, researchers, and others who want to find, read, and analyze their contents to learn more about people and events of the time. We're also interested in providing our users with new ways to interact with and explore our collections. We're so glad we found FromThePage!<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -813,7 +813,7 @@
     </section>
     <!-- Crowd Testimonials End -->
 
-<%= render "shared/landingfooter" %>
+    <%= render "shared/landingfooter" %>
 
 </body>
 

--- a/app/views/static/state_archives.html.erb
+++ b/app/views/static/state_archives.html.erb
@@ -4,7 +4,7 @@
 
     <!-- Home Main -->
     <section class="home-main">
-        <!-- <img src="assets/materials/main-bg.png" alt=""> -->
+        <!-- <%= image_tag("materials/main-bg.png") %> -->
 
         <div class="text">
             <h2 data-aos="zoom-in" data-aos-duration="800">Transcription for State & Provincial Archives</h2>
@@ -13,7 +13,7 @@
             <div class="container">
                 <div class="row justify-content-center">
                     <div class="col-lg-9">
-                        <img src="assets/materials/transcription-state-main.png" alt="" class="main-img">
+                        <%= image_tag("materials/transcription-state-main.png", class: 'main-img') %>
                     </div>
                 </div>
             </div>
@@ -66,7 +66,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">Crowdsourcing is a great fit for state archives. It’s an efficient way of reaching out to people interested in the archives and offering them a specific project to work on. For our first project with FromThePage we transcribed 50,000 marriage certificates, which have no index, and have to be searched by hand otherwise. We don’t have the staff for a data-entry project of this magnitude; we need to utilize volunteers. The fielded-form of FromThePage, along with the desire of the volunteer transcribers to help create something useful for the benefit of many, has made this project successful.<img src="assets/icons/quote02.svg" alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>Crowdsourcing is a great fit for state archives. It’s an efficient way of reaching out to people interested in the archives and offering them a specific project to work on. For our first project with FromThePage we transcribed 50,000 marriage certificates, which have no index, and have to be searched by hand otherwise. We don’t have the staff for a data-entry project of this magnitude; we need to utilize volunteers. The fielded-form of FromThePage, along with the desire of the volunteer transcribers to help create something useful for the benefit of many, has made this project successful.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -90,7 +90,7 @@
         <div class="container">
             <h2 class="title">Our software has been trusted by archivists at these institutions:</h2>
 
-            <img src="assets/materials/transcription-state-logos.png" alt="">
+            <%= image_tag("materials/transcription-state-logos.png") %>
         </div>
     </section>
     <!-- Crowd Logos End -->
@@ -144,7 +144,7 @@
                     <div class="loop">
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">FromThePage was exactly what we were looking for—a crowdsourced transcription platform that offered hosting services. The archives used it to create a meaningful World War I centennial commemorative program involving the public. We accomplished a massive indexing project of over 111,000 WWI service records cards more quickly than we ever could have in-house. Working with Ben and Sara we produced the field function feature needed for this project and now it can be adapted for other crowdsourcing projects. Through this work we established a base of “virtual volunteers” and formed relationships in a new community of users.<img src="assets/icons/quote02.svg" alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>FromThePage was exactly what we were looking for—a crowdsourced transcription platform that offered hosting services. The archives used it to create a meaningful World War I centennial commemorative program involving the public. We accomplished a massive indexing project of over 111,000 WWI service records cards more quickly than we ever could have in-house. Working with Ben and Sara we produced the field function feature needed for this project and now it can be adapted for other crowdsourcing projects. Through this work we established a base of “virtual volunteers” and formed relationships in a new community of users.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -158,8 +158,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">As part of a land grant institution, the library wholeheartedly supports the mission of sharing knowledge beyond the campus borders. Adhering to this mission requires a further commitment to digital accessibility and the inclusive practice of removing barriers that prevent interaction with, or access to, digital content by people with disabilities. By providing accurate transcriptions, translations, and correcting OCR, we expand access to this content for all online users in accordance with WCAG 2.1 AA accessibility guidelines. Ben and Sara are easy to work with, understand our profession well, and are committed to making the systems we all use easier and better integrated.<img src="assets/icons/quote02.svg"
-                                        alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>As part of a land grant institution, the library wholeheartedly supports the mission of sharing knowledge beyond the campus borders. Adhering to this mission requires a further commitment to digital accessibility and the inclusive practice of removing barriers that prevent interaction with, or access to, digital content by people with disabilities. By providing accurate transcriptions, translations, and correcting OCR, we expand access to this content for all online users in accordance with WCAG 2.1 AA accessibility guidelines. Ben and Sara are easy to work with, understand our profession well, and are committed to making the systems we all use easier and better integrated.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -173,8 +172,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">This particular collection has always been available at the Archives, but now people know about it! They are able to search and even see the images from home. It’s been a very efficient way for us to get a large collection indexed. We have over 100 volunteers, and about 25 active any given week; they can all work at the same time, at any time of the day, from anywhere. The collection is now available online to researchers as it’s being indexed, which is something we haven’t been able to offer before. As more archives embark on digitization and transcription projects, our history becomes much more accessible. Also, this project has allowed us to interact with a group of people who have never visited the Indiana Archives before and may have never heard of it.<img src="assets/icons/quote02.svg"
-                                        alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>This particular collection has always been available at the Archives, but now people know about it! They are able to search and even see the images from home. It’s been a very efficient way for us to get a large collection indexed. We have over 100 volunteers, and about 25 active any given week; they can all work at the same time, at any time of the day, from anywhere. The collection is now available online to researchers as it’s being indexed, which is something we haven’t been able to offer before. As more archives embark on digitization and transcription projects, our history becomes much more accessible. Also, this project has allowed us to interact with a group of people who have never visited the Indiana Archives before and may have never heard of it.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -522,7 +520,7 @@
                     <div class="loop-case">
                         <div class="box">
                             <div class="item">
-                                <img src="assets/materials/state-case01.png" alt="">
+                                <%= image_tag("materials/state-case01.png") %>
                                 <p>The Alabama Department of Archives and History staff spent 18 months digitizing 111,000 WWI service record cards and in only 3.5 months volunteer transcribers finished them all. FromThePage made it easy to keep track of all the volunteers, many who were not even in Alabama. People were looking for worthwhile projects, and the geographic boundaries of the documents mattered way less than staff thought they would. When this project was done the virtual volunteers were clamoring for more and the archives went to work getting more digitized collections up on the platform. See the whole story <a href="#">here</a>.</p>
                             </div>
                         </div>
@@ -531,7 +529,7 @@
                      
                         <div class="box">
                             <div class="item">
-                                <img src="assets/materials/state-case02.png" alt="">
+                                <%= image_tag("materials/state-case02.png") %>
                                 <p>The Maryland State Archives had volunteer transcribers help create an index for over 50,000 marriage certificates. Archivists no longer need to search by hand for the record. This was made more difficult if the patron couldn’t remember the date of their marriage but desperately needed the certificate to apply for social security benefits, a passport, or a driver’s license renewal. Digitized, searchable indexes of records make an enormous difference in helping people who need them and those who use them for genealogical purposes. Check out this project <a href="#">here</a>.</p>
                             </div>  
                         </div>
@@ -540,7 +538,7 @@
                  
                         <div class="box">
                             <div class="item">
-                                <img src="assets/materials/state-case03.png" alt="">
+                                <%= image_tag("materials/state-case03.png") %>
                                 <p>The State Archives of North Carolina has active collections on varying topics on FromThePage, including Local Draft Board Records, Colonial Court Records, African American Education, World War I Diaries, WWI and WWII Letters, and Women’s History. Their grant-funded project North Carolina’s Early Court Records kicked-off their use of the platform. Beyond their goal to broaden accessibility to the collections, they also wanted to engage public volunteers with the work of the archives through transcription. Now patrons anywhere in the world can perform full-text searches on the transcribed documents; find out more <a href="#">here</a>.</p>
                             </div> 
                         </div>
@@ -549,7 +547,7 @@
                     
                         <div class="box">
                             <div class="item">
-                                <img src="assets/materials/state-case04.png" alt="">
+                                <%= image_tag("materials/state-case04.png") %>
                                 <p>The Indiana Archives and Records Administration used FromThePage to create an index of Indiana’s WWI service record cards with the goal of honoring veterans and making history more accessible. Interest in transcribing records made it a very efficient way to index a large collection and illustrate the value of the archives to more people. FromThePage is a valuable platform for helping to make that connection happen. Read what volunteers have to say about the transcription process <a href="#">here</a>.</p>
                             </div>
                         </div>
@@ -560,7 +558,7 @@
                             <div class="item">
                                 <div class="row">
                                     <div class="col-lg-6">
-                                        <img src="assets/materials/state-case05.png" alt="" class="second-img">
+                                        <%= image_tag("materials/state-case05.png", class: 'second-img') %>
                                     </div>
     
                                     <div class="col-lg-6">
@@ -592,7 +590,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">Our experience using FromThePage has been very positive. Our goal was to capture all the data from the WWI Questionnaires, as well as other field-based documents, in order to increase access and searchability. We chose an absolute beast of a form to attempt as our first structured data transcription set: 118 lines, some with 3 or 4 fields per line, with a total of over 200 fields. Ben and Sara worked with our team at the Library to upload all the images, make the form properly, and even incorporate new features we needed. Crowdsourcing has been immensely popular with our users, and we want to continue to build on this type of interaction with ongoing projects. We look forward to continuing to work with users and FromThePage to improve our collections and generate new interactions.<img src="assets/icons/quote02.svg" alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>Our experience using FromThePage has been very positive. Our goal was to capture all the data from the WWI Questionnaires, as well as other field-based documents, in order to increase access and searchability. We chose an absolute beast of a form to attempt as our first structured data transcription set: 118 lines, some with 3 or 4 fields per line, with a total of over 200 fields. Ben and Sara worked with our team at the Library to upload all the images, make the form properly, and even incorporate new features we needed. Crowdsourcing has been immensely popular with our users, and we want to continue to build on this type of interaction with ongoing projects. We look forward to continuing to work with users and FromThePage to improve our collections and generate new interactions.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -606,7 +604,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">We utilize FromThePage to broaden accessibility to our collections and also to engage public volunteers. Our goals are to increase access through expanded arrangement, description, and digitization, providing greater keyword searching and increased accessibility when cursive or archaic spelling may present a barrier to reading archival materials. Now on transcribed materials we can perform full text searches! Also, the platform is very simple and straightforward to use. One of the best features is its compatibility with CONTENTdm, the digital management software we utilize. Exporting the completed transcriptions is a two-step process requiring very little effort. <img src="assets/icons/quote02.svg" alt="" class="bottom">
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>We utilize FromThePage to broaden accessibility to our collections and also to engage public volunteers. Our goals are to increase access through expanded arrangement, description, and digitization, providing greater keyword searching and increased accessibility when cursive or archaic spelling may present a barrier to reading archival materials. Now on transcribed materials we can perform full text searches! Also, the platform is very simple and straightforward to use. One of the best features is its compatibility with CONTENTdm, the digital management software we utilize. Exporting the completed transcriptions is a two-step process requiring very little effort. <%= image_tag("icons/quote02.svg", class: 'bottom') %>
                                 </p>
 
                                 <div class="info">
@@ -663,7 +661,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">Records are absolutely a frontline necessity for so many aspects of our lives–authorization for medical care, government and employee benefits, passports, even final burial. If you can't find the record you're sunk. I got a call from a woman who needed her marriage certificate so she could authorize treatment for her husband who was hospitalized with covid. I used an index created by FromThePage volunteer transcribers to find the certificate, and was able to email a copy to her in less than thirty minutes. It was a wonderful feeling to be able to help her in a dire time.<img src="assets/icons/quote02.svg" alt="" class="bottom"></p>
+                                <p><<%= image_tag("icons/quote01.svg", class: 'top') %>Records are absolutely a frontline necessity for so many aspects of our lives–authorization for medical care, government and employee benefits, passports, even final burial. If you can't find the record you're sunk. I got a call from a woman who needed her marriage certificate so she could authorize treatment for her husband who was hospitalized with covid. I used an index created by FromThePage volunteer transcribers to find the certificate, and was able to email a copy to her in less than thirty minutes. It was a wonderful feeling to be able to help her in a dire time.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 

--- a/app/views/static/state_archives.html.erb
+++ b/app/views/static/state_archives.html.erb
@@ -631,7 +631,7 @@
     <section class="crowd-schedule">
         <div class="container">
             <div class="title">
-                <h4>1,317,240</h4>
+                <h4><%= number_with_delimiter Page.where.not(:status=>nil).count %></h4>
                 <p>Pages — and counting!</p>
             </div>
 

--- a/app/views/static/transcription_archives.html.erb
+++ b/app/views/static/transcription_archives.html.erb
@@ -4,7 +4,7 @@
 
     <!-- Home Main -->
     <section class="home-main">
-        <!-- <img src="assets/materials/main-bg.png" alt=""> -->
+        <!-- <%= image_tag("materials/main-bg.png") %> -->
 
         <div class="text">
             <h2 data-aos="zoom-in" data-aos-duration="800">Transcription for Archives and Special Collections</h2>
@@ -14,7 +14,7 @@
             <div class="container">
                 <div class="row justify-content-center">
                     <div class="col-lg-9">
-                        <img src="assets/materials/transcription-archive-main.png" alt="" class="main-img">
+                        <%= image_tag("materials/transcription-archive-main.png", class: 'main-img') %>
                     </div>
                 </div>
             </div>
@@ -71,13 +71,13 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">Our goals are to make primary
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>Our goals are to make primary
                                     sources unique to Queen’s University more accessible to all, and to enhance remote
                                     research, teaching, and coursework opportunities for our faculty and students, this
                                     year in particular, while almost all course work is being delivered remotely. Sara
                                     and Ben have been the most wonderful team to work with as we started up. They have
                                     been responsive to our questions and incredibly helpful in getting us up and
-                                    running.<img src="assets/icons/quote02.svg" alt="" class="bottom"></p>
+                                    running.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -102,7 +102,7 @@
         <div class="container">
             <h2 class="title">Our software has been trusted by librarians and archivists at these institutions:</h2>
 
-            <img src="assets/materials/transcription-archive-logos.png" alt="">
+            <%= image_tag("materials/transcription-archive-logos.png") %>
         </div>
     </section>
     <!-- Crowd Logos End -->
@@ -158,7 +158,7 @@
                     <div class="loop">
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">As part of a land grant
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>As part of a land grant
                                     institution, the library wholeheartedly supports the mission of sharing knowledge
                                     beyond the campus borders. Adhering to this mission requires a further commitment to
                                     digital accessibility and the inclusive practice of removing barriers that prevent
@@ -167,7 +167,7 @@
                                     access to this content for all online users in accordance with WCAG 2.1 AA
                                     accessibility guidelines. Ben and Sara are easy to work with, understand our
                                     profession well, and are committed to making the systems we all use easier and
-                                    better integrated.<img src="assets/icons/quote02.svg" alt="" class="bottom"></p>
+                                    better integrated.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -183,8 +183,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">We wanted to enrich our digitized collections, improving both the searchability and the accessibility of our records; a notoriously difficult thing for most archives to do, but here we have a way forward to address accessibility issues, and have full text available for screen readers. From an administrator's perspective, this had to be one of the easiest platforms to start up. It took all of 10-20 minutes to get our account and project started, and our transcriber managed to transcribe 20 pages before the end of the first day! Honestly, the barrier-to-entry is almost non-existent, and the rewards can be seen almost immediately. The dashboard and summary give us some great stats, and let us know who our most active volunteers are. Now, we can leverage the power of a whole world of volunteers to spend a few minutes here and there in a week to significantly improve the accessibility of our holdings.<img src="assets/icons/quote02.svg"
-                                        alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>We wanted to enrich our digitized collections, improving both the searchability and the accessibility of our records; a notoriously difficult thing for most archives to do, but here we have a way forward to address accessibility issues, and have full text available for screen readers. From an administrator's perspective, this had to be one of the easiest platforms to start up. It took all of 10-20 minutes to get our account and project started, and our transcriber managed to transcribe 20 pages before the end of the first day! Honestly, the barrier-to-entry is almost non-existent, and the rewards can be seen almost immediately. The dashboard and summary give us some great stats, and let us know who our most active volunteers are. Now, we can leverage the power of a whole world of volunteers to spend a few minutes here and there in a week to significantly improve the accessibility of our holdings.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -198,8 +197,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">Like many archives at the university level, we are eager for students to use archival collections in an intellectually rigorous way. Students and alumni find that crowdsourcing transcription is fun and interesting, as well as academically substantive. Having the documents transcribed enables us to ask different questions and to automate larger-scale data exploration of the primary sources. FromThePage is such a feature-rich, easy-to-use platform that using it for archival records about early Chinese students has been a worthwhile, key phase of our larger project. We have been so fortunate to have FromThePage to keep people engaged with the archives remotely during the pandemic. It is a very intuitive platform for archives and volunteers.<img src="assets/icons/quote02.svg"
-                                        alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>Like many archives at the university level, we are eager for students to use archival collections in an intellectually rigorous way. Students and alumni find that crowdsourcing transcription is fun and interesting, as well as academically substantive. Having the documents transcribed enables us to ask different questions and to automate larger-scale data exploration of the primary sources. FromThePage is such a feature-rich, easy-to-use platform that using it for archival records about early Chinese students has been a worthwhile, key phase of our larger project. We have been so fortunate to have FromThePage to keep people engaged with the archives remotely during the pandemic. It is a very intuitive platform for archives and volunteers.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -617,7 +615,7 @@
                             <div class="item">
                                 <div class="row">
                                     <div class="col-lg-6">
-                                        <img src="assets/materials/transcription-archive01.png" alt="">
+                                        <%= image_tag("materials/transcription-archive01.png") %>
                                     </div>
     
                                     <div class="col-lg-6">
@@ -631,7 +629,7 @@
                     
                         <div class="box">
                             <div class="item">
-                                <img src="assets/materials/crowd-case01.png" alt="">
+                                <%= image_tag("materials/crowd-case01.png") %>
                                  
                                 <p>FromThePage allows the public to have meaningful interaction with the Genealogy, Local History &
                                     Archives Unit of the Fort Worth Public Library. Over 8,000 pages have been transcribed in a
@@ -646,7 +644,7 @@
                     
                         <div class="box">
                             <div class="item">
-                                <img src="assets/materials/transcription-archive02.png" alt="">
+                                <%= image_tag("materials/transcription-archive02.png") %>
                                 <p><a href="#">Ohio University Libraries</a> uses FromThePage to generate transcriptions and descriptive metadata for dance posters in their collection. This project is a hybrid project, transcriptions are generated along with text from the posters captured through standardized metadata fields. This allows more accessibility and findability by users, also allowing discovery of related posters based on the standardized fields. See examples of how to capture metadata for your collection <a href="#">here</a>.</p>
                             </div>
                         </div>
@@ -655,7 +653,7 @@
                   
                         <div class="box">
                             <div class="item">
-                                <img src="assets/materials/transcription-archive03.png" alt="">
+                                <%= image_tag("materials/transcription-archive03.png") %>
                                 <p>Adam Rabinowitz, a Classics Professor at the University of Texas at Austin, uses FromThePage as a teaching tool in an undergraduate course. Each student is assigned to find the primary source materials in the archive and transcribe any letter in the collection using FromThePage. Then a larger collection of transcribed letters are provided to write a paper. Read more on Adam’s use of transcription for pedagogy <a href="#">here</a>.</p>
                             </div>
                         </div>
@@ -664,7 +662,7 @@
                      
                         <div class="box">
                             <div class="item">
-                                <img src="assets/materials/transcription-archive04.png" alt="">
+                                <%= image_tag("materials/transcription-archive04.png") %>
                                 <p>Heather Home and Jeremy Heil of Queen's University Archives use FromThePage to make primary source material more accessible, searchable, and usable. Transcription helps foster research, reveal information, and highlight materials that are often thought to be “hidden” due to the fact that their contents are not easily searchable how people have become accustomed. As they increase their digitization projects find out more about how FromThePage is providing ways to improve the discoverability of their immense holdings <a href="#">here</a>.</p>
                             </div>
                         </div>
@@ -692,7 +690,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">FromThePage has proven to be a very versatile tool. It’s a great platform for collaborative work, making it easy for all users to simultaneously edit, review, and track progress within a collection. The management features also allow a lot of flexibility. Using the field-based transcription option, for example, we’ve created projects to tag works and collect metadata so our collaborators can assist with content description, in addition to transcribing. The software lends itself to creative uses by allowing administrators to configure projects and access the data in a variety of ways.<img src="assets/icons/quote02.svg" alt="" class="bottom"></p>
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>FromThePage has proven to be a very versatile tool. It’s a great platform for collaborative work, making it easy for all users to simultaneously edit, review, and track progress within a collection. The management features also allow a lot of flexibility. Using the field-based transcription option, for example, we’ve created projects to tag works and collect metadata so our collaborators can assist with content description, in addition to transcribing. The software lends itself to creative uses by allowing administrators to configure projects and access the data in a variety of ways.<%= image_tag("icons/quote02.svg", class: 'bottom') %></p>
 
                                 <div class="info">
 
@@ -706,7 +704,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">The killer feature that takes FromThePage well beyond other transcription interfaces I have seen [...] is the powerful yet simple wiki-like annotation and indexing feature. Using simple double brackets, or an optional automatic suggested markup feature, simple transcriptions immediately become “tagged” (though only for items explicit in a text, rather than arbitrary tags) in a truly powerful way, allowing visitors to find documents through a index of subjects, places, or people – or jump immediately from linked subjects within a text to others like it in what becomes a rich hypertext environment. <img src="assets/icons/quote02.svg" alt="" class="bottom">
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>The killer feature that takes FromThePage well beyond other transcription interfaces I have seen [...] is the powerful yet simple wiki-like annotation and indexing feature. Using simple double brackets, or an optional automatic suggested markup feature, simple transcriptions immediately become “tagged” (though only for items explicit in a text, rather than arbitrary tags) in a truly powerful way, allowing visitors to find documents through a index of subjects, places, or people – or jump immediately from linked subjects within a text to others like it in what becomes a rich hypertext environment. <%= image_tag("icons/quote02.svg", class: 'bottom') %>
                                 </p>
 
                                 <div class="info">
@@ -721,7 +719,7 @@
 
                         <div class="box">
                             <div class="item">
-                                <p><img src="assets/icons/quote01.svg" alt="" class="top">With all of its features, FromThePage has proven to be incredibly useful for us in cultivating community engagement, developing research initiatives, and enhancing collection accessibility. This is primarily due to the customization the platform enables. On the one hand, project contributors have the ability to reconfigure with relative ease their workspace and workflows, such as using dictation to transcribe. On the project management side, the import and export features being designed and deployed as part of the NEH-funded work with UT Libraries will greatly facilitate the movement of collections between our institutional repositories and the platform to expedite access and preserve citizen scholarship. <img src="assets/icons/quote02.svg" alt="" class="bottom">
+                                <p><%= image_tag("icons/quote01.svg", class: 'top') %>With all of its features, FromThePage has proven to be incredibly useful for us in cultivating community engagement, developing research initiatives, and enhancing collection accessibility. This is primarily due to the customization the platform enables. On the one hand, project contributors have the ability to reconfigure with relative ease their workspace and workflows, such as using dictation to transcribe. On the project management side, the import and export features being designed and deployed as part of the NEH-funded work with UT Libraries will greatly facilitate the movement of collections between our institutional repositories and the platform to expedite access and preserve citizen scholarship. <%= image_tag("icons/quote02.svg", class: 'bottom') %>
                                 </p>
 
                                 <div class="info">

--- a/app/views/static/transcription_archives.html.erb
+++ b/app/views/static/transcription_archives.html.erb
@@ -746,7 +746,7 @@
     <section class="crowd-schedule">
         <div class="container">
             <div class="title">
-                <h4>1,274,218</h4>
+                <h4><%= number_with_delimiter Page.where.not(:status=>nil).count %></h4>
                 <p>Pages — and counting!</p>
             </div>
 


### PR DESCRIPTION
_Resolves #3427_

This changes all of the `<img src="/assets/...">` tags into `<%= image_tag("...") %>`s so that these landing pages will work in production.