### PR TITLE
Handle unusual data for #3442 and #3443

### DIFF
--- a/app/helpers/export_helper.rb
+++ b/app/helpers/export_helper.rb
@@ -328,7 +328,7 @@ module ExportHelper
     tei << "            <catDesc>\n"
     tei << "              <term>#{ERB::Util.html_escape(subject.title)}</term>\n"
     unless subject.uri.blank?
-      tei << "              <idno>#{subject.uri}</idno>\n"
+      tei << "              <idno>#{subject.uri.encode(xml: :text)}</idno>\n"
     end
     tei << '              <note type="categorization">Categories:'
     subject.categories.each do |category|

--- a/app/views/export/tei.html.erb
+++ b/app/views/export/tei.html.erb
@@ -31,7 +31,13 @@ xml:id="export">
 
       <% @user_contributions.each do |user| %>
         <respStmt xml:id="U<%= user[:user_id]%>">
-          <persName><%= user[:real_name] || user.display_name %></persName>
+          <persName
+            <% if user[:real_name].blank? %>
+              type="pseudonym"
+            <% end %>
+            >
+            <%= user.real_name.blank? ? user.display_name : user.real_name %>
+            </persName>
           <% if user[:edit_count] == 1 %>
             <resp>
               <%= t('export.tei.made_one_edit_on') %>


### PR DESCRIPTION
This resolves #3442 by escaping strings used in the XML export.

It resolves #3443 by handling empty strings in users's `real_name` fields.

It also adds a `type="psedonym"` attribute to the exported `persName` of a user if they have a blank `real_name`.