### PR TITLE
Cache recent deeds in collaborator dashboard / watchlist for #3439

### DIFF
--- a/app/models/deed.rb
+++ b/app/models/deed.rb
@@ -17,6 +17,7 @@ class Deed < ApplicationRecord
   visitable class_name: "Visit" # ahoy integration
 
   before_save :calculate_prerender, :calculate_prerender_mailer, :calculate_public
+  after_save :update_collections_most_recent_deed
 
   def deed_type_name
     DeedType.name(self.deed_type)
@@ -51,5 +52,9 @@ class Deed < ApplicationRecord
         renderer.render(:partial => 'deed/deed.html', :locals => { :deed => self, :long_view => true, :prerender => true, :mailer => true, locale: locale })
       ]
     }.to_json
+  end
+
+  def update_collections_most_recent_deed
+    self.collection.update(most_recent_deed_created_at: self.created_at)
   end
 end

--- a/app/models/document_set.rb
+++ b/app/models/document_set.rb
@@ -299,4 +299,8 @@ class DocumentSet < ApplicationRecord
   def api_access # API access is only controlled by public/private for document sets
     false
   end
+
+  def most_recent_deed_created_at
+    self.collection.most_recent_deed_created_at
+  end
 end

--- a/app/views/collection/_recent_deeds.html.slim
+++ b/app/views/collection/_recent_deeds.html.slim
@@ -1,0 +1,9 @@
+-collection.deeds.includes(:page, :user, :work).limit(5).each do |d|
+  -d.collection = nil
+  .user-bubble
+    =link_to(user_profile_path(d.user))
+      =profile_picture(d.user)
+    .user-bubble_content
+      =time_tag d.created_at
+        =t('time_ago_in_words', time: time_ago_in_words(d.created_at))
+      p =render(:partial => 'deed/deed.html', :locals => { :deed => d, :long_view => true })

--- a/app/views/dashboard/watchlist.html.slim
+++ b/app/views/dashboard/watchlist.html.slim
@@ -14,16 +14,8 @@ h1 =t('dashboard.collaborator')
       -@collections.each do |c|
         -if c.show_to?(current_user)
           h4 =link_to c.title, collection_path(c.owner, c), class: 'nodecor'
-          -c.deeds.includes(:page, :user, :work).limit(5).each do |d|
-            //- Hide collection link
-            -d.collection = nil
-            .user-bubble
-              =link_to(user_profile_path(d.user))
-                =profile_picture(d.user)
-              .user-bubble_content
-                =time_tag d.created_at
-                  =t('.time_ago_in_words', time: time_ago_in_words(d.created_at))
-                p =render(:partial => 'deed/deed.html', :locals => { :deed => d, :long_view => true })
+          -cache c.most_recent_deed_created_at do
+            =render(:partial => 'collection/recent_deeds', locals: {:collection => c})
     -else
       =t('.try_transcribing_a_page')
       =link_to t('.collections'), dashboard_path

--- a/config/locales/dashboard/dashboard-en.yml
+++ b/config/locales/dashboard/dashboard-en.yml
@@ -153,6 +153,5 @@ en:
       collections: collections
       private_collections_you_belong_to: Private projects
       projects_you_have_contributed_to: Projects you have contributed to -- by transcribing, editing, or commenting on -- will be listed here with their most recent activity so you can stay up to date with what's going on.
-      time_ago_in_words: "%{time} ago"
       try_transcribing_a_page: 'You haven''t participated in any projects yet.  Try transcribing a page from one of these '
       your_activity: Your Activity

--- a/config/locales/dashboard/dashboard-es.yml
+++ b/config/locales/dashboard/dashboard-es.yml
@@ -153,6 +153,5 @@ es:
       collections: colecciones
       private_collections_you_belong_to: Colecciones Privadas a las que Perteneces
       projects_you_have_contributed_to: Los proyectos a los que has contribuido -- transcribiendo, editando o comentando -- se enumerarán aquí con su actividad más reciente para que puedas mantenerte al día con lo que está sucediendo.
-      time_ago_in_words: Hace %{time}
       try_transcribing_a_page: 'Aún no has participado en ningún proyecto.  Intenta transcribir una página de uno de estos '
       your_activity: Tu Actividad

--- a/config/locales/dashboard/dashboard-fr.yml
+++ b/config/locales/dashboard/dashboard-fr.yml
@@ -153,6 +153,5 @@ fr:
       collections: collections
       private_collections_you_belong_to: Projets privés
       projects_you_have_contributed_to: Les projets auxquels vous avez contribué - en les transcrivant, en les modifiant ou en les commentant - seront répertoriés ici avec leur activité la plus récente afin que vous puissiez rester au courant de ce qui se passe.
-      time_ago_in_words: Il y a %{time}
       try_transcribing_a_page: 'Vous n''avez encore participé à aucun projet. Essayez de transcrire une page de l''une de ces '
       your_activity: Votre activité

--- a/config/locales/dashboard/dashboard-pt.yml
+++ b/config/locales/dashboard/dashboard-pt.yml
@@ -153,6 +153,5 @@ pt:
       collections: coleções
       private_collections_you_belong_to: Coleções Privadas às quais você pertence
       projects_you_have_contributed_to: Os projetos para os quais você contribui -- transcrevendo, editando ou comentando -- serão listados aqui com sua atividade mais recente para que você possa se manter atualizado/a com o que está acontecendo.
-      time_ago_in_words: Há %{time}
       try_transcribing_a_page: 'Ainda não participou em nenhum projeto. Tente transcrever uma página de um destes '
       your_activity: Sua Atividade

--- a/db/migrate/20230102175848_add_most_recent_deed_created_at_to_collections.rb
+++ b/db/migrate/20230102175848_add_most_recent_deed_created_at_to_collections.rb
@@ -1,0 +1,13 @@
+class AddMostRecentDeedCreatedAtToCollections < ActiveRecord::Migration[6.0]
+  def change
+    add_column :collections, :most_recent_deed_created_at, :datetime
+
+    Collection.includes(:deeds).each do |collection|
+      unless collection.deeds.empty?
+        collection.update_column(:most_recent_deed_created_at, collection.deeds.first.created_at)
+      else
+        collection.update_column(:most_recent_deed_created_at, collection.created_on)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_29_213613) do
+ActiveRecord::Schema.define(version: 2023_01_02_175848) do
 
-  create_table "ahoy_activity_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "ahoy_activity_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "date"
     t.integer "user_id"
     t.integer "collection_id"
@@ -23,7 +23,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["date", "collection_id", "user_id", "activity"], name: "ahoy_activity_day_user_collection", unique: true
   end
 
-  create_table "ahoy_events", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "ahoy_events", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "visit_id"
     t.integer "user_id"
     t.string "name"
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["visit_id", "name"], name: "index_ahoy_events_on_visit_id_and_name"
   end
 
-  create_table "article_article_links", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "article_article_links", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "source_article_id"
     t.integer "target_article_id"
     t.string "display_text"
@@ -43,7 +43,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["target_article_id"], name: "index_article_article_links_on_target_article_id"
   end
 
-  create_table "article_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "article_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.text "source_text", size: :medium
     t.text "xml_text", size: :medium
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["user_id"], name: "index_article_versions_on_user_id"
   end
 
-  create_table "articles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "articles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.text "source_text", size: :medium
     t.datetime "created_on"
@@ -70,13 +70,13 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["collection_id"], name: "index_articles_on_collection_id"
   end
 
-  create_table "articles_categories", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "articles_categories", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "article_id"
     t.integer "category_id"
     t.index ["article_id", "category_id"], name: "index_articles_categories_on_article_id_and_category_id"
   end
 
-  create_table "bulk_exports", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "bulk_exports", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "collection_id", null: false
     t.string "status"
@@ -111,7 +111,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["work_id"], name: "index_bulk_exports_on_work_id"
   end
 
-  create_table "categories", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "categories", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.integer "parent_id"
     t.integer "collection_id"
@@ -121,7 +121,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["parent_id"], name: "index_categories_on_parent_id"
   end
 
-  create_table "cdm_bulk_imports", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "cdm_bulk_imports", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false
     t.boolean "ocr_correction", default: false
     t.string "collection_param", null: false
@@ -131,7 +131,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["user_id"], name: "index_cdm_bulk_imports_on_user_id"
   end
 
-  create_table "clientperf_results", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "clientperf_results", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "clientperf_uri_id"
     t.integer "milliseconds"
     t.datetime "created_at"
@@ -139,26 +139,26 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["clientperf_uri_id"], name: "index_clientperf_results_on_clientperf_uri_id"
   end
 
-  create_table "clientperf_uris", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "clientperf_uris", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "uri"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["uri"], name: "index_clientperf_uris_on_uri"
   end
 
-  create_table "collection_collaborators", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "collection_collaborators", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.integer "collection_id"
   end
 
-  create_table "collection_owners", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "collection_owners", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.integer "collection_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "collection_reviewers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "collection_reviewers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.integer "collection_id"
     t.datetime "created_at", null: false
@@ -167,7 +167,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["user_id"], name: "index_collection_reviewers_on_user_id"
   end
 
-  create_table "collections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "collections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.integer "owner_user_id"
     t.datetime "created_on"
@@ -202,13 +202,14 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.string "messageboard_slug"
     t.bigint "thredded_messageboard_group_id"
     t.boolean "messageboards_enabled"
+    t.datetime "most_recent_deed_created_at"
     t.index ["owner_user_id"], name: "index_collections_on_owner_user_id"
     t.index ["restricted"], name: "index_collections_on_restricted"
     t.index ["slug"], name: "index_collections_on_slug", unique: true
     t.index ["thredded_messageboard_group_id"], name: "index_collections_on_thredded_messageboard_group_id"
   end
 
-  create_table "comments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "comments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "parent_id"
     t.integer "user_id"
     t.datetime "created_at", null: false
@@ -221,7 +222,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.string "comment_status", limit: 10
   end
 
-  create_table "deeds", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "deeds", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "deed_type", limit: 10
     t.integer "page_id"
     t.integer "work_id"
@@ -247,12 +248,12 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["work_id"], name: "index_deeds_on_work_id"
   end
 
-  create_table "document_set_collaborators", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "document_set_collaborators", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.integer "document_set_id"
   end
 
-  create_table "document_sets", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "document_sets", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.boolean "is_public"
     t.integer "owner_user_id"
     t.integer "collection_id"
@@ -271,13 +272,13 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["slug"], name: "index_document_sets_on_slug", unique: true
   end
 
-  create_table "document_sets_works", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "document_sets_works", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "document_set_id", null: false
     t.integer "work_id", null: false
     t.index ["work_id", "document_set_id"], name: "index_document_sets_works_on_work_id_and_document_set_id", unique: true
   end
 
-  create_table "document_uploads", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "document_uploads", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.integer "collection_id"
     t.string "file"
@@ -290,7 +291,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["user_id"], name: "index_document_uploads_on_user_id"
   end
 
-  create_table "editor_buttons", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "editor_buttons", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "key"
     t.integer "collection_id", null: false
     t.boolean "prefer_html"
@@ -299,7 +300,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["collection_id"], name: "index_editor_buttons_on_collection_id"
   end
 
-  create_table "facet_configs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "facet_configs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "label"
     t.string "input_type"
     t.integer "order"
@@ -309,7 +310,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["metadata_coverage_id"], name: "index_facet_configs_on_metadata_coverage_id"
   end
 
-  create_table "flags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "flags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "author_user_id"
     t.integer "page_version_id"
     t.integer "article_version_id"
@@ -331,7 +332,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["reporter_user_id"], name: "index_flags_on_reporter_user_id"
   end
 
-  create_table "friendly_id_slugs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "friendly_id_slugs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "slug", null: false
     t.integer "sluggable_id", null: false
     t.string "sluggable_type", limit: 50
@@ -343,7 +344,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
   end
 
-  create_table "ia_leaves", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "ia_leaves", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "ia_work_id"
     t.integer "page_id"
     t.integer "page_w"
@@ -357,7 +358,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["page_id"], name: "index_ia_leaves_on_page_id"
   end
 
-  create_table "ia_works", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "ia_works", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "detail_url"
     t.integer "user_id"
     t.integer "work_id"
@@ -384,7 +385,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.boolean "use_ocr", default: false
   end
 
-  create_table "metadata_coverages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "metadata_coverages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "key"
     t.integer "count", default: 0
     t.integer "collection_id"
@@ -392,7 +393,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "metadata_description_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "metadata_description_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "metadata_description"
     t.integer "user_id", null: false
     t.integer "work_id", null: false
@@ -403,7 +404,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["work_id"], name: "index_metadata_description_versions_on_work_id"
   end
 
-  create_table "notes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "notes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.text "body", size: :medium
     t.integer "user_id"
@@ -417,7 +418,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["page_id"], name: "index_notes_on_page_id"
   end
 
-  create_table "notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.boolean "add_as_owner", default: true
     t.boolean "add_as_collaborator", default: true
     t.boolean "note_added", default: true
@@ -429,13 +430,13 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.boolean "add_as_reviewer", default: true
   end
 
-  create_table "oai_repositories", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "oai_repositories", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "url"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "oai_sets", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "oai_sets", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "set_spec"
     t.string "repository_url"
     t.integer "user_id"
@@ -443,7 +444,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.datetime "updated_at"
   end
 
-  create_table "omeka_collections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "omeka_collections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "omeka_id"
     t.integer "collection_id"
     t.string "title"
@@ -453,7 +454,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.datetime "updated_at"
   end
 
-  create_table "omeka_files", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "omeka_files", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "omeka_id"
     t.integer "omeka_item_id"
     t.string "mime_type"
@@ -467,7 +468,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["omeka_id"], name: "index_omeka_files_on_omeka_id"
   end
 
-  create_table "omeka_items", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "omeka_items", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.string "subject"
     t.string "description"
@@ -485,7 +486,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.integer "work_id"
   end
 
-  create_table "omeka_sites", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "omeka_sites", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.string "api_url"
     t.string "api_key"
@@ -494,7 +495,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.datetime "updated_at"
   end
 
-  create_table "page_article_links", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "page_article_links", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "page_id"
     t.integer "article_id"
     t.string "display_text"
@@ -504,7 +505,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["page_id"], name: "index_page_article_links_on_page_id"
   end
 
-  create_table "page_blocks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "page_blocks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "controller"
     t.string "view"
     t.string "tag"
@@ -515,7 +516,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["controller", "view"], name: "index_page_blocks_on_controller_and_view"
   end
 
-  create_table "page_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "page_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.text "transcription", size: :medium
     t.text "xml_transcription", size: :medium
@@ -530,7 +531,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["user_id"], name: "index_page_versions_on_user_id"
   end
 
-  create_table "pages", id: :integer, options: "ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "pages", id: :integer, options: "ENGINE=MyISAM DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.text "source_text", size: :medium
     t.string "base_image"
@@ -561,19 +562,19 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["work_id"], name: "index_pages_on_work_id"
   end
 
-  create_table "pages_sections", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "pages_sections", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "page_id", null: false
     t.integer "section_id", null: false
     t.index ["page_id", "section_id"], name: "index_pages_sections_on_page_id_and_section_id"
     t.index ["section_id", "page_id"], name: "index_pages_sections_on_section_id_and_page_id"
   end
 
-  create_table "plugin_schema_info", id: false, options: "ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "plugin_schema_info", id: false, options: "ENGINE=MyISAM DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "plugin_name"
     t.integer "version"
   end
 
-  create_table "quality_samplings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "quality_samplings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "collection_id", null: false
     t.text "sample_set", size: :medium
@@ -583,7 +584,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["user_id"], name: "index_quality_samplings_on_user_id"
   end
 
-  create_table "sc_canvases", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "sc_canvases", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "sc_id"
     t.integer "sc_manifest_id"
     t.integer "page_id"
@@ -601,7 +602,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["sc_manifest_id"], name: "index_sc_canvases_on_sc_manifest_id"
   end
 
-  create_table "sc_collections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "sc_collections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "collection_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -612,7 +613,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["collection_id"], name: "index_sc_collections_on_collection_id"
   end
 
-  create_table "sc_manifests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "sc_manifests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "work_id"
     t.integer "sc_collection_id"
     t.string "sc_id"
@@ -629,7 +630,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["work_id"], name: "index_sc_manifests_on_work_id"
   end
 
-  create_table "sections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "sections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.integer "depth"
     t.integer "position"
@@ -639,7 +640,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["work_id"], name: "index_sections_on_work_id"
   end
 
-  create_table "sessions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "sessions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "session_id", default: "", null: false
     t.text "data", size: :medium
     t.datetime "created_at"
@@ -648,7 +649,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
-  create_table "spreadsheet_columns", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "spreadsheet_columns", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "transcription_field_id", null: false
     t.integer "position"
     t.string "label"
@@ -659,7 +660,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["transcription_field_id"], name: "index_spreadsheet_columns_on_transcription_field_id"
   end
 
-  create_table "table_cells", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "table_cells", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "work_id"
     t.integer "page_id"
     t.integer "section_id"
@@ -675,7 +676,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["work_id"], name: "index_table_cells_on_work_id"
   end
 
-  create_table "tex_figures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "tex_figures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "page_id"
     t.integer "position"
     t.text "source"
@@ -684,7 +685,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["page_id"], name: "index_tex_figures_on_page_id"
   end
 
-  create_table "thredded_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "messageboard_id", null: false
     t.text "name", null: false
     t.text "description"
@@ -696,14 +697,14 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["name"], name: "thredded_categories_name_ci", length: 191
   end
 
-  create_table "thredded_messageboard_groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_messageboard_groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
     t.integer "position", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "thredded_messageboard_notifications_for_followed_topics", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_messageboard_notifications_for_followed_topics", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false
     t.bigint "messageboard_id", null: false
     t.string "notifier_key", limit: 90, null: false
@@ -711,7 +712,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["user_id", "messageboard_id", "notifier_key"], name: "thredded_messageboard_notifications_for_followed_topics_unique", unique: true
   end
 
-  create_table "thredded_messageboard_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_messageboard_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "thredded_user_detail_id", null: false
     t.bigint "thredded_messageboard_id", null: false
     t.datetime "last_seen_at", null: false
@@ -720,7 +721,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["thredded_user_detail_id"], name: "fk_rails_06e42c62f5"
   end
 
-  create_table "thredded_messageboards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_messageboards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "name", null: false
     t.text "slug"
     t.text "description"
@@ -736,21 +737,21 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["slug"], name: "index_thredded_messageboards_on_slug", unique: true, length: 191
   end
 
-  create_table "thredded_notifications_for_followed_topics", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_notifications_for_followed_topics", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "notifier_key", limit: 90, null: false
     t.boolean "enabled", default: true, null: false
     t.index ["user_id", "notifier_key"], name: "thredded_notifications_for_followed_topics_unique", unique: true
   end
 
-  create_table "thredded_notifications_for_private_topics", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_notifications_for_private_topics", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "notifier_key", limit: 90, null: false
     t.boolean "enabled", default: true, null: false
     t.index ["user_id", "notifier_key"], name: "thredded_notifications_for_private_topics_unique", unique: true
   end
 
-  create_table "thredded_post_moderation_records", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_post_moderation_records", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "post_id"
     t.bigint "messageboard_id"
     t.text "post_content"
@@ -763,7 +764,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["messageboard_id", "created_at"], name: "index_thredded_moderation_records_for_display"
   end
 
-  create_table "thredded_posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.text "content"
     t.string "source", limit: 191, default: "web"
@@ -780,7 +781,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["user_id"], name: "index_thredded_posts_on_user_id"
   end
 
-  create_table "thredded_private_posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_private_posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.text "content"
     t.bigint "postable_id", null: false
@@ -789,7 +790,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["postable_id", "created_at"], name: "index_thredded_private_posts_on_postable_id_and_created_at"
   end
 
-  create_table "thredded_private_topics", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_private_topics", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.integer "last_user_id"
     t.text "title", null: false
@@ -804,7 +805,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["slug"], name: "index_thredded_private_topics_on_slug", unique: true, length: 191
   end
 
-  create_table "thredded_private_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_private_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "private_topic_id"
     t.integer "user_id"
     t.datetime "created_at", null: false
@@ -813,14 +814,14 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["user_id"], name: "index_thredded_private_users_on_user_id"
   end
 
-  create_table "thredded_topic_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_topic_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "topic_id", null: false
     t.bigint "category_id", null: false
     t.index ["category_id"], name: "index_thredded_topic_categories_on_category_id"
     t.index ["topic_id"], name: "index_thredded_topic_categories_on_topic_id"
   end
 
-  create_table "thredded_topics", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_topics", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.integer "last_user_id"
     t.text "title", null: false
@@ -843,7 +844,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["user_id"], name: "index_thredded_topics_on_user_id"
   end
 
-  create_table "thredded_user_details", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_user_details", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "latest_activity_at"
     t.integer "posts_count", default: 0
@@ -858,7 +859,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["user_id"], name: "index_thredded_user_details_on_user_id", unique: true
   end
 
-  create_table "thredded_user_messageboard_preferences", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_user_messageboard_preferences", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false
     t.bigint "messageboard_id", null: false
     t.boolean "follow_topics_on_mention", default: true, null: false
@@ -868,7 +869,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["user_id", "messageboard_id"], name: "thredded_user_messageboard_preferences_user_id_messageboard_id", unique: true
   end
 
-  create_table "thredded_user_post_notifications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_user_post_notifications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false
     t.bigint "post_id", null: false
     t.datetime "notified_at", null: false
@@ -876,7 +877,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["user_id", "post_id"], name: "index_thredded_user_post_notifications_on_user_id_and_post_id", unique: true
   end
 
-  create_table "thredded_user_preferences", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_user_preferences", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false
     t.boolean "follow_topics_on_mention", default: true, null: false
     t.boolean "auto_follow_topics", default: false, null: false
@@ -885,7 +886,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["user_id"], name: "index_thredded_user_preferences_on_user_id", unique: true
   end
 
-  create_table "thredded_user_private_topic_read_states", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_user_private_topic_read_states", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false
     t.bigint "postable_id", null: false
     t.integer "unread_posts_count", default: 0, null: false
@@ -895,7 +896,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["user_id", "postable_id"], name: "thredded_user_private_topic_read_states_user_postable", unique: true
   end
 
-  create_table "thredded_user_topic_follows", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_user_topic_follows", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false
     t.bigint "topic_id", null: false
     t.datetime "created_at", null: false
@@ -903,7 +904,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["user_id", "topic_id"], name: "thredded_user_topic_follows_user_topic", unique: true
   end
 
-  create_table "thredded_user_topic_read_states", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_user_topic_read_states", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "messageboard_id", null: false
     t.integer "user_id", null: false
     t.bigint "postable_id", null: false
@@ -916,12 +917,12 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["user_id", "postable_id"], name: "thredded_user_topic_read_states_user_postable", unique: true
   end
 
-  create_table "transcribe_authorizations", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "transcribe_authorizations", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.integer "work_id"
   end
 
-  create_table "transcription_fields", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "transcription_fields", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "label"
     t.integer "collection_id"
     t.string "input_type"
@@ -937,7 +938,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.string "field_type", default: "transcription"
   end
 
-  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "login"
     t.string "display_name"
     t.string "real_name"
@@ -983,7 +984,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["slug"], name: "index_users_on_slug", unique: true
   end
 
-  create_table "visits", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "visits", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "visit_token"
     t.string "visitor_token"
     t.string "ip"
@@ -1014,7 +1015,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["visit_token"], name: "index_visits_on_visit_token", unique: true
   end
 
-  create_table "work_facets", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "work_facets", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "s0", limit: 512
     t.string "s1", limit: 512
     t.string "s2", limit: 512
@@ -1034,7 +1035,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.index ["work_id"], name: "index_work_facets_on_work_id"
   end
 
-  create_table "work_statistics", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "work_statistics", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "work_id"
     t.integer "transcribed_pages"
     t.integer "annotated_pages"
@@ -1054,7 +1055,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.integer "line_count"
   end
 
-  create_table "works", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci", force: :cascade do |t|
+  create_table "works", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.text "description", size: :medium
     t.datetime "created_on"
@@ -1079,6 +1080,7 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.string "identifier"
     t.integer "next_untranscribed_page_id"
     t.text "original_metadata"
+    t.string "uploaded_filename"
     t.string "genre"
     t.string "source_location"
     t.string "source_collection_name"
@@ -1086,7 +1088,6 @@ ActiveRecord::Schema.define(version: 2022_11_29_213613) do
     t.boolean "in_scope", default: true
     t.text "editorial_notes"
     t.string "document_date"
-    t.string "uploaded_filename"
     t.text "metadata_description"
     t.integer "metadata_description_version_id"
     t.string "description_status", default: "undescribed"


### PR DESCRIPTION
_Resolves #3439_

This should help performance issues with the watchlist page by caching the recent deeds listed for each collection. 

### Changes made

* Moved the recent deeds shown for each collection on the watchlist to a partial, `collection/_recent_deeds` to make it simpler to cache.
* Added a `most_recent_deed_created_at` column to the `collections` table to invalidate a collection's cache when a deed is added.
  * The migration updates this field in all pre-existing collections to when their most recent deed was created.
* Added a `most_recent_deed_created_at` method for document sets, which references its collection. 
  * Although a docsest might have a different most recent deed than its collection, the `most_recent_deed_created_at` field is updated by the new deed and a `Deed` doesn't know what document set it's in; it only knows which collection (`deed.collection` is always a `Collection`, never a `DocumentSet`). 
* Cached the `_recent_deeds` partial based on (invalidated by an update in) each collection's `most_recent_deed_created_at` column.
