### PR TITLE
Added filename in upload finished email for #2981

### DIFF
--- a/app/views/user_mailer/upload_finished.html.erb
+++ b/app/views/user_mailer/upload_finished.html.erb
@@ -1,6 +1,6 @@
 <h2 style="color:#453939; margin:0; font-weight:normal;"><%= t('.your_upload_is_ready') %></h2>
 <p>
-  <%= t('.html.message') %>
+  <%= t('.html.message', file: @document_upload.name) %>
   <%= link_to @document_upload.collection.title, {
       controller: 'collection',
       action: 'show',

--- a/app/views/user_mailer/upload_finished.text.erb
+++ b/app/views/user_mailer/upload_finished.text.erb
@@ -1,6 +1,6 @@
 <%= t('.your_upload_is_ready') %>
 
-<%= t('.text.message') %>
+<%= t('.text.message', file: @document_upload.name) %>
 <%= url_for({
     controller: 'collection',
     action: 'show',

--- a/config/locales/user_mailer/user_mailer-en.yml
+++ b/config/locales/user_mailer/user_mailer-en.yml
@@ -55,9 +55,9 @@ en:
       turn_off_notification: 'Turn off this notification at the URL: %{url}'
     upload_finished:
       html:
-        message: Your upload has been processed and is ready at
+        message: Your upload of "%{file}" has been processed and is ready at
       text:
-        message: 'Your upload has been processed and is ready at this URL:'
+        message: 'Your upload of "%{file}" has been processed and is ready at this URL:'
       your_upload_is_ready: Your upload is ready!
     work_collaborator:
       html:

--- a/config/locales/user_mailer/user_mailer-es.yml
+++ b/config/locales/user_mailer/user_mailer-es.yml
@@ -53,9 +53,9 @@ es:
       turn_off_notification: 'Desactive esta notificación en la URL: %{url}'
     upload_finished:
       html:
-        message: Su carga ha sido procesada y está lista en
+        message: Su carga de "%{file}" ha sido procesada y está lista en
       text:
-        message: 'Su carga ha sido procesada y está lista en esta URL:'
+        message: 'Su carga de "%{file}" ha sido procesada y está lista en esta URL:'
       your_upload_is_ready: "¡Tu carga está lista!"
     work_collaborator:
       html:

--- a/config/locales/user_mailer/user_mailer-fr.yml
+++ b/config/locales/user_mailer/user_mailer-fr.yml
@@ -55,9 +55,9 @@ fr:
       turn_off_notification: 'Désactivez cette notification à l''URL : %{url}'
     upload_finished:
       html:
-        message: Votre téléchargement a été traité et est prêt à
+        message: Votre téléchargement de "%{file}" a été traité et est prêt à
       text:
-        message: 'Votre importation a été traitée et est prête à cette URL :'
+        message: 'Votre téléchargement de "%{file}" a été traité et est prêt à cette URL :'
       your_upload_is_ready: Votre téléchargement est prêt !
     work_collaborator:
       html:

--- a/config/locales/user_mailer/user_mailer-pt.yml
+++ b/config/locales/user_mailer/user_mailer-pt.yml
@@ -53,9 +53,9 @@ pt:
       turn_off_notification: 'Desative esta notificação no URL: %{url}'
     upload_finished:
       html:
-        message: Seu upload foi processado e está pronto em
+        message: Seu upload de "%{file}" foi processado e está pronto em
       text:
-        message: 'Seu upload foi processado e está pronto neste URL:'
+        message: 'Seu upload de "%{file}" foi processado e está pronto neste URL:'
       your_upload_is_ready: Seu carregamento está pronto!
     work_collaborator:
       html:


### PR DESCRIPTION
_Resolves #2981_

This adds the name of the file uploaded to the upload notification email. If a .zip file was uploaded, the name of the zip file will be shown, not the included filenames.

<img alt="email" src="https://user-images.githubusercontent.com/35716893/210403902-b052e6c5-109d-4fb9-91b9-26eae9dbe8bf.jpg" width="70%">

Susan Gray at LVA wanted a list of files uploaded in the upload notification email, but it doesn't seem like the files in the .zip file are recorded in the `DocumentUpload` object. If we think the list is important, I can investigate further how to find it.