### PR TITLE
Resolves #3496 for collections and fixes new collaborators

### DIFF
--- a/app/controllers/collection_controller.rb
+++ b/app/controllers/collection_controller.rb
@@ -498,7 +498,6 @@ class CollectionController < ApplicationController
       :name, 
       :user_real_name,
       :email,
-      :user_total_minutes,
       :user_proportional_minutes,
       :pages_transcribed, 
       :page_edits, 
@@ -508,20 +507,13 @@ class CollectionController < ApplicationController
       :notes, 
     ]
 
+    user_time_proportional = AhoyActivitySummary.where(collection_id: @collection.id, date: [start_date..end_date]).group(:user_id).sum(:minutes)
+
     stats = @active_transcribers.map do |user|
-      time_total = 0
-      time_proportional = 0
-
-      if @user_time[user.id]
-        time_total = (@user_time[user.id] / 60 + 1).floor
-      end
-
-      if @user_time_proportional[user.id]
-        time_proportional = (@user_time_proportional[user.id] / 60 + 1).floor
-      end
+      time_proportional = user_time_proportional[user.id]
 
       id_data = [user.display_name, user.real_name, user.email]
-      time_data = [time_total, time_proportional]
+      time_data = [time_proportional]
 
       user_deeds = @collection_deeds.select { |d| d.user_id == user.id }
 

--- a/app/helpers/contributor_helper.rb
+++ b/app/helpers/contributor_helper.rb
@@ -13,7 +13,7 @@ module ContributorHelper
     #check to see if there are any deeds in the collection
     @collection_deeds = @collection.deeds.where(condition, start_date, end_date).includes(:page, :work, :user)
 
-    transcription_deeds = @collection.deeds.where(deed_type: DeedType.transcriptions)
+    transcription_deeds = @collection.deeds.where(deed_type: DeedType.transcriptions_or_corrections)
 
     @recent_notes = @collection_deeds.where(deed_type: DeedType::NOTE_ADDED)
     @recent_transcriptions = @collection_deeds.where(deed_type: DeedType.transcriptions)
@@ -30,43 +30,19 @@ module ContributorHelper
     user_deeds = @collection.deeds.where(condition, start_date, end_date).distinct.pluck(:user_id)
     @active_transcribers = User.where(id: user_deeds)
 
-    # All deeds by active transcribers in range
-    user_deeds_by_date = Deed.where(user_id: @active_transcribers).where(condition, start_date, end_date)
+    # use ahoy activity summary to calculate ranges
+    @user_time_proportional = AhoyActivitySummary.where(collection_id: @collection.id, date: [start_date..end_date]).group(:user_id).sum(:minutes)
 
-    # Deed counts in date range by User
-    user_deeds_total = user_deeds_by_date.group('user_id').count
-    user_deeds_collection = @collection.deeds.where(condition, start_date, end_date).group('user_id').count
-
-    # All distinct visits by users who logged deeds in date range affecting @collection 
-    deed_visits = Visit.where("user_id in (?) and started_at between ? and ?", user_deeds, start_date, end_date)
-
-    # Sum the time between the beginning of the visit and the last ahoy event for the session per user
-    @user_time = {}
-    deed_visits.each do |visit|
-      if visit.ahoy_events.last
-        @user_time[visit.user_id] = 0 unless @user_time[visit.user_id]
-        @user_time[visit.user_id] += visit.ahoy_events.last.time - visit.started_at
-      end
-    end
-
-    @user_time_proportional = {}
-    @user_time.each do |user_id, total_time|
-        if user_deeds_collection.has_key?(user_id) && user_deeds_total.has_key?(user_id)
-          collection_weight = user_deeds_collection[user_id].to_f / user_deeds_total[user_id]
-          @user_time_proportional[user_id] = (@user_time[user_id] * collection_weight)
-        else
-          @user_time_proportional[user_id] = "No user #{user_id}"
-        end
-    end
 
     #find recent transcription deeds by user, then older deeds by user
-    recent_trans_deeds = transcription_deeds.where("created_at >= ?", start_date).distinct.pluck(:user_id)
+    recent_trans_deeds = transcription_deeds.where(created_at: [start_date..end_date]).distinct.pluck(:user_id)
     recent_users = User.where(id: recent_trans_deeds)
-    older_trans_deeds = transcription_deeds.where("created_at < ?", start_date).distinct.pluck(:user_id)
+    older_trans_deeds = transcription_deeds.where(created_at: [..start_date]).distinct.pluck(:user_id)
     older_users = User.where(id: older_trans_deeds)
 
     #compare older to recent list to get new transcribers
     @new_transcribers = recent_users - older_users
+
     all_transcribers = User.includes(:deeds).where(deeds: {collection_id: @collection.id}).distinct
     @all_collaborators = all_transcribers.map { |user| "#{user.display_name} <#{user.email}>"}.join(', ')
   end

--- a/app/views/collection/_contributors_body.html.slim
+++ b/app/views/collection/_contributors_body.html.slim
@@ -31,18 +31,16 @@
           tr
             th= t('.user') 
             th= t('.time_on_this')
-            th= t('.time_on_ftp')
         tbody 
-        -@active_transcribers.each do |user|
-          tr 
-            td= link_to user.display_name, user_profile_path(:user_id => user.id, only_path: false)
-            -if @user_time[user.id]
-              td= (@user_time_proportional[user.id] / 60 + 1).floor
-              td= (@user_time[user.id] / 60 + 1).floor
-            -else
-              <td><td>
+          -@active_transcribers.each do |user|
+            tr
+              td= link_to user.display_name, user_profile_path(:user_id => user.id, only_path: false)
+              -if @user_time_proportional[user.id]
+                td= @user_time_proportional[user.id]
+              -else
+                <td><td>
       p
-        -total_minutes = (@user_time.values.sum / 60).floor + 1
+        -total_minutes = @user_time_proportional.values.sum
         =t('.total_time', hours: (total_minutes / 60), minutes: (total_minutes % 60))
       p
         =link_to(collection_contributors_download_path(:collection_id => @collection.id, :start_date => @start_deed, :end_date => @end_deed), :class => 'button btnExport')

--- a/config/locales/collection/collection-en.yml
+++ b/config/locales/collection/collection-en.yml
@@ -38,7 +38,6 @@ en:
       new_collaborators: New Collaborators
       no_activity_this_time_frame: No activity in this time frame
       no_collaborators: No Collaborators
-      time_on_ftp: Time on FromThePage
       time_on_this: Time on this collection
       total_time: 'Total time: %{hours} hours, %{minutes} minutes.'
       user: User

--- a/config/locales/collection/collection-es.yml
+++ b/config/locales/collection/collection-es.yml
@@ -38,7 +38,6 @@ es:
       new_collaborators: Nuevos Colaboradores
       no_activity_this_time_frame: No hubo actividad en este lapso de tiempo
       no_collaborators: No hay colaboradores
-      time_on_ftp: Tiempo en FromThePage
       time_on_this: Tiempo en esta colección
       total_time: 'Tiempo total: %{hours} horas, %{minutes} minutos.'
       user: Usuario

--- a/config/locales/collection/collection-fr.yml
+++ b/config/locales/collection/collection-fr.yml
@@ -38,7 +38,6 @@ fr:
       new_collaborators: Nouveaux collaborateurs
       no_activity_this_time_frame: Aucune activité pendant cette période
       no_collaborators: Aucun collaborateur
-      time_on_ftp: Heure sur FromThePage
       time_on_this: Temps sur cette collection
       total_time: 'Durée totale : %{hours} heures, %{minutes} minutes.'
       user: Utilisateur

--- a/config/locales/collection/collection-pt.yml
+++ b/config/locales/collection/collection-pt.yml
@@ -38,7 +38,6 @@ pt:
       new_collaborators: Novos Colaboradores
       no_activity_this_time_frame: Nenhuma atividade neste período de tempo
       no_collaborators: Sem Colaboradores
-      time_on_ftp: Tempo em FromThePage
       time_on_this: Tempo nesta coleção
       total_time: 'Tempo Total: %{hours} horas, %{minutes} minutos.'
       user: Do utilizador


### PR DESCRIPTION
This implements the use of AhoyActivitySummary for the collection-level collaborators tab.

It also fixes a bug I noticed in which viewing the contributors for a single week 2 years ago shows as "New Transcribers" every single person who was new since the beginning of the span, not just the transcribers during the single week.

It also fixes a bug I noticed in which we were only showing new transcribers for "transcription" deeds, ignoring edits and OCR corrections.