### PR TITLE
Added italics tag for #3461

### DIFF
--- a/app/helpers/abstract_xml_helper.rb
+++ b/app/helpers/abstract_xml_helper.rb
@@ -175,6 +175,14 @@ module AbstractXmlHelper
       end
     end
 
+    doc.elements.each("//emph") do |e|
+      rend = e.attributes["rend"]
+      span = e
+      if rend == 'italics'
+        span.name='i'
+      end
+    end
+
     doc.elements.each("//add") do |e|
       e.name='span'
       e.add_attribute('class', "addition")

--- a/app/helpers/abstract_xml_helper.rb
+++ b/app/helpers/abstract_xml_helper.rb
@@ -164,22 +164,15 @@ module AbstractXmlHelper
         span.name='sup'
       when 'underline'
         span.name='u'
-      when 'italic'
+      when 'italics'
         span.name='i'
+        span.attributes.delete 'rend'
       when 'bold'
         span.name='i'
       when 'sub'
         span.name='sub'
       when 'str'
         span.name='strike'
-      end
-    end
-
-    doc.elements.each("//emph") do |e|
-      rend = e.attributes["rend"]
-      span = e
-      if rend == 'italics'
-        span.name='i'
       end
     end
 

--- a/app/models/editor_button.rb
+++ b/app/models/editor_button.rb
@@ -19,6 +19,7 @@ class EditorButton < ApplicationRecord
     SUP = 'sup'
     UNCLEAR = 'unclear'
     UNDERLINE = 'u'
+    ITALIC = 'i'
   end
 
   BUTTON_MAP = {
@@ -38,7 +39,8 @@ class EditorButton < ApplicationRecord
     Keys::SUB => ['<hi rend="sub">', '<sub>'],
     Keys::SUP => ['<hi rend="sup">', '<sup>'],
     Keys::UNCLEAR => ['<unclear>'],
-    Keys::UNDERLINE => ['<hi rend="underline">', '<u>']
+    Keys::UNDERLINE => ['<hi rend="underline">', '<u>'],
+    Keys::ITALIC => ['<emph rend="italics">', '<i>']
   }
 
 

--- a/app/models/editor_button.rb
+++ b/app/models/editor_button.rb
@@ -32,6 +32,7 @@ class EditorButton < ApplicationRecord
     Keys::FOOTNOTE => ['<footnote marker="*">'],
     Keys::GAP => ['<gap>'],
     Keys::HEAD => ['<head>'],
+    Keys::ITALIC => ['<hi rend="italics">', '<i>'],
     Keys::SOFT_BREAK => ['<lb break="no">'],
     Keys::MARGINALIA => ['<marginalia>'],
     Keys::REG => ['<reg orig="">'],
@@ -39,8 +40,7 @@ class EditorButton < ApplicationRecord
     Keys::SUB => ['<hi rend="sub">', '<sub>'],
     Keys::SUP => ['<hi rend="sup">', '<sup>'],
     Keys::UNCLEAR => ['<unclear>'],
-    Keys::UNDERLINE => ['<hi rend="underline">', '<u>'],
-    Keys::ITALIC => ['<emph rend="italics">', '<i>']
+    Keys::UNDERLINE => ['<hi rend="underline">', '<u>']
   }
 
 

--- a/app/views/shared/_codemirror.html.erb
+++ b/app/views/shared/_codemirror.html.erb
@@ -33,7 +33,7 @@
   ];
 
   var fromthepage_tags = {
-    "!top": ["abbr", "add", "catchword", "cb", "date", "del", "expan", "figure", "footnote", "gap", "hi", "ins", "lb", "marginalia", "milestone", "reg", "stamp", "sub", "sup", "supplied", "table", "unclear", "u", "strike", "span", "a"],
+    "!top": ["abbr", "add", "catchword", "cb", "date", "del", "expan", "figure", "footnote", "gap", "hi", "ins", "lb", "marginalia", "milestone", "reg", "stamp", "sub", "sup", "supplied", "table", "unclear", "u", "strike", "span", "a", "i"],
     abbr: { attrs: { expan: null}},
     add: { children: ["u", "s", "hi"] },
     cb: { attrs: { "n": null } },

--- a/config/locales/collection/collection-de.yml
+++ b/config/locales/collection/collection-de.yml
@@ -185,6 +185,8 @@ de:
       head_label: Überschrift
       heading: Konfiguration des Transkriptionseditors
       html: "(HTML)"
+      i_description: Markiert kursiven Text.
+      i_label: Kursiv
       lb_description: Markiert Zeilenumbrüche
       lb_label: Zeilenumbruch
       markup_preference_description: Einige Tags haben Entsprechungen in HTML und TEI-XML. Wählen Sie eine Einstellung aus, um festzulegen, welche Tag-Form eingefügt wird, wenn ein:e Mitarbeitende:r den Button nutzt.

--- a/config/locales/collection/collection-en.yml
+++ b/config/locales/collection/collection-en.yml
@@ -185,6 +185,8 @@ en:
       head_label: Heading
       heading: Transcription Editor Configuration
       html: " (HTML)"
+      i_description: Marks italicized text.
+      i_label: Italic
       lb_description: Marks line breaks
       lb_label: Line Break
       markup_preference_description: Some tags have equivalents forms in HTML and TEI-XML.  Choose a preference to determine which form of tag is inserted when a user presses the button.

--- a/config/locales/collection/collection-es.yml
+++ b/config/locales/collection/collection-es.yml
@@ -185,6 +185,8 @@ es:
       head_label: Bóveda
       heading: Configuración del editor de transcripciones
       html: "(HTML)"
+      i_description: Marca el texto en cursiva.
+      i_label: Itálico
       lb_description: Marca saltos de línea
       lb_label: Salto de línea
       markup_preference_description: Algunas etiquetas tienen formas equivalentes en HTML y TEI-XML. Elija una preferencia para determinar qué forma de etiqueta se inserta cuando un usuario presiona el botón.

--- a/config/locales/collection/collection-fr.yml
+++ b/config/locales/collection/collection-fr.yml
@@ -185,6 +185,8 @@ fr:
       head_label: Titre
       heading: Configuration de l'éditeur de transcription
       html: "(HTML)"
+      i_description: Marquez le texte en italique.
+      i_label: Italique
       lb_description: Marque les sauts de ligne
       lb_label: Saut de ligne
       markup_preference_description: Certaines balises ont des formes équivalentes en HTML et TEI-XML. Choisissez une préférence pour déterminer quelle forme de balise est insérée lorsqu'un utilisateur appuie sur le bouton.

--- a/config/locales/collection/collection-pt.yml
+++ b/config/locales/collection/collection-pt.yml
@@ -185,6 +185,8 @@ pt:
       head_label: Cabeçalho
       heading: Configuração do Editor de Transcrição
       html: "(HTML)"
+      i_description: Marque o texto em itálico.
+      i_label: Itálico
       lb_description: Marca quebras de linha
       lb_label: Quebra de linha
       markup_preference_description: Algumas tags possuem formas equivalentes em HTML e TEI-XML. Escolha uma preferência para determinar qual forma de tag é inserida quando um usuário pressiona o botão.


### PR DESCRIPTION
_Resolves #3461_

This adds an italics tag to the advanced editor.

Here is how it looks in the editor buttons settings:
![settings](https://user-images.githubusercontent.com/35716893/236584264-78356385-599c-4e0f-a80c-df17c49b0db8.png)

Here is how it looks in the editor:
![editor](https://user-images.githubusercontent.com/35716893/236584971-2bd84743-9b95-4854-b339-01f2ed432484.png)
And the result:
![result](https://user-images.githubusercontent.com/35716893/236584979-5d7c5760-436b-4384-b382-8ab7fd5fe620.png)
