### PR TITLE
Simplified owner dashboard and added collection progress bars for #3619

### DIFF
--- a/app/assets/stylesheets/sections/dashboard.scss
+++ b/app/assets/stylesheets/sections/dashboard.scss
@@ -181,6 +181,32 @@
   font-style: italic;
 }
 
+.owner-collection {
+  clear: both;
+  padding: $gapSize;
+  border-radius: 4px;
+  margin-bottom: $gapSize / 2;
+  background-clip: padding-box;
+  border: 1px solid rgba(#000, 0.06);
+  background-color: mix(#FFF, $bodyBg, 35%);
+  overflow: hidden;
+  &.stats-visible { border-color: transparent; }
+  &.stats-visible &_stats-bubble { opacity: 1; }
+  &_title {
+    margin: 0;
+    a {
+      text-decoration: none;
+      color: darken($fgLink, 10%);
+      &:hover { color: $fgLink; }
+    }
+  }
+}
+
+.visibility {
+  font-style: italic;
+  color: $bgSelected;
+}
+
 //--------------------------------
 // LANDING PAGE
 //--------------------------------

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -74,6 +74,11 @@ class DashboardController < ApplicationController
 
   # Owner Dashboard - list of works
   def owner
+    collections = current_user.all_owner_collections
+    @active_collections = @collections.select { |c| c.active? }
+    @inactive_collections = @collections.select { |c| !c.active? }
+    # Needs to be active collections first, then inactive collections
+    @collections = @active_collections + @inactive_collections
   end
 
   # Owner Summary Statistics - statistics for all owned collections

--- a/app/helpers/collection_helper.rb
+++ b/app/helpers/collection_helper.rb
@@ -37,15 +37,23 @@ module CollectionHelper
   def collection_stats(collection)
     works = WorkStatistic.where(work_id: collection.works.pluck(:id))
     total_pages = works.sum(:total_pages)
-    total_blank_pages = works.sum(:blank_pages)
-    total_annotated_pages = works.sum('annotated_pages + translated_annotated')
-    total_review_pages = works.sum('needs_review + translated_review')
-    total_completed_pages = works.sum('transcribed_pages + translated_pages')
     
-    @progress_blank = ((total_blank_pages.to_f/total_pages)*100).round
-    @progress_annotated = ((total_annotated_pages.to_f/total_pages)*100).round
-    @progress_review = ((total_review_pages.to_f/total_pages)*100).round
-    @progress_completed = ((total_completed_pages.to_f/total_pages)*100).round
+    unless total_pages == 0
+      total_blank_pages = works.sum(:blank_pages)
+      total_annotated_pages = works.sum('annotated_pages + translated_annotated')
+      total_review_pages = works.sum('needs_review + translated_review')
+      total_completed_pages = works.sum('transcribed_pages + translated_pages')
+      
+      @progress_blank = ((total_blank_pages.to_f/total_pages)*100).round
+      @progress_annotated = ((total_annotated_pages.to_f/total_pages)*100).round
+      @progress_review = ((total_review_pages.to_f/total_pages)*100).round
+      @progress_completed = ((total_completed_pages.to_f/total_pages)*100).round
+    else
+      @progress_blank = 0
+      @progress_annotated = 0
+      @progress_review = 0
+      @progress_completed = 0
+    end
 
     if collection.subjects_disabled
       unless @progress_review == 0

--- a/app/helpers/collection_helper.rb
+++ b/app/helpers/collection_helper.rb
@@ -34,6 +34,32 @@ module CollectionHelper
     end
   end
 
+  def collection_stats(collection)
+    works = WorkStatistic.where(work_id: collection.works.pluck(:id))
+    total_pages = works.sum(:total_pages)
+    total_blank_pages = works.sum(:blank_pages)
+    total_annotated_pages = works.sum('annotated_pages + translated_annotated')
+    total_review_pages = works.sum('needs_review + translated_review')
+    total_completed_pages = works.sum('transcribed_pages + translated_pages')
+    
+    @progress_blank = ((total_blank_pages.to_f/total_pages)*100).round
+    @progress_annotated = ((total_annotated_pages.to_f/total_pages)*100).round
+    @progress_review = ((total_review_pages.to_f/total_pages)*100).round
+    @progress_completed = ((total_completed_pages.to_f/total_pages)*100).round
+
+    if collection.subjects_disabled
+      unless @progress_review == 0
+        @wording = "#{collection.pct_completed}% #{t('collection.complete')} (#{@progress_completed+@progress_review+@progress_blank}% #{t('collection.transcribed')}, #{@progress_review}% #{t('collection.needs_review')})"
+      else
+        @wording = "#{collection.pct_completed}% #{t('collection.complete')} (#{@progress_completed+@progress_review+@progress_blank}% #{t('collection.transcribed')})"
+      end
+    elsif @progress_review == 0
+      @wording = "#{collection.pct_completed}% #{t('collection.complete')} (#{@progress_annotated}% #{t('collection.indexed')}, #{@progress_completed+@progress_blank}% #{t('collection.transcribed')})"
+    else
+      @wording = "#{collection.pct_completed}% #{t('collection.complete')} (#{@progress_annotated}% #{t('collection.indexed')}, #{@progress_completed+@progress_review+@progress_blank}% #{t('collection.transcribed')}, #{@progress_review}% #{t('collection.needs_review')})"
+    end
+  end
+
   def work_stats(work)
     @wording=''
     @progress_blank = work.work_statistic.pct_blank.round
@@ -55,14 +81,14 @@ module CollectionHelper
 
     if @collection.subjects_disabled
       unless @progress_review == 0
-        @wording = "#{work.work_statistic.complete}% complete (#{@progress_completed+@progress_review}% #{@type}, #{@progress_review}% #{t('collection.needs_review')})"
+        @wording = "#{work.work_statistic.complete}% #{t('collection.complete')} (#{@progress_completed+@progress_review}% #{@type}, #{@progress_review}% #{t('collection.needs_review')})"
       else
-        @wording = "#{work.work_statistic.complete}% complete (#{@progress_completed+@progress_review}% #{@type})"
+        @wording = "#{work.work_statistic.complete}% #{t('collection.complete')} (#{@progress_completed+@progress_review}% #{@type})"
       end
     elsif @progress_review == 0
-      @wording = "#{work.work_statistic.complete}% complete (#{@progress_annotated}% #{t('collection.indexed')}, #{@progress_completed}% #{@type})"
+      @wording = "#{work.work_statistic.complete}% #{t('collection.complete')} (#{@progress_annotated}% #{t('collection.indexed')}, #{@progress_completed}% #{@type})"
     else
-      @wording = "#{work.work_statistic.complete}% complete (#{@progress_annotated}% #{t('collection.indexed')}, #{@progress_completed+@progress_review}% #{@type}, #{@progress_review}% #{t('collection.needs_review')})"
+      @wording = "#{work.work_statistic.complete}% #{t('collection.complete')} (#{@progress_annotated}% #{t('collection.indexed')}, #{@progress_completed+@progress_review}% #{@type}, #{@progress_review}% #{t('collection.needs_review')})"
     end
 
     if @collection.metadata_entry?

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -1,9 +1,4 @@
 module DashboardHelper
-  def collection_list(collection)
-    @count = collection.works.count
-    @works = collection.works.order(:title).limit(15)
-  end
-
   def dashboard_set_title
     case
     when is_active_link?(dashboard_startproject_path)

--- a/app/models/collection_statistic.rb
+++ b/app/models/collection_statistic.rb
@@ -88,8 +88,9 @@ module CollectionStatistic
 
   def calculate_complete
     #note: need to compact mapped array so it doesn't fail on a nil value
-    unless work_count == 0
-      pct = (self.works.includes(:work_statistic).map(&:completed).compact.sum)/work_count
+    unless page_count == 0
+      # Weighted by page count
+      pct = (self.works.includes(:work_statistic).map{|w| w.work_statistic.pct_completed * w.work_statistic.total_pages}.compact.sum)/page_count
     else
       pct = 0
     end

--- a/app/views/collection/show.html.slim
+++ b/app/views/collection/show.html.slim
@@ -60,12 +60,7 @@
                 = t('.n_pages', count: work.work_statistic.total_pages)
                 = @wording
               span
-                span.progress
-                  -unless @collection.subjects_disabled
-                    span(style="width:#{@progress_annotated}%")
-                  span(style="width:#{@progress_completed - @progress_annotated + @progress_blank}%")
-                  -unless @progress_review == 0
-                    span(style="width:#{@progress_review}%")
+                =render(:partial => 'shared/progress', :locals => { :collection => @collection })
           -else
             .collection-work_stats
               span =t("work.#{work.description_status}")

--- a/app/views/dashboard/owner.html.slim
+++ b/app/views/dashboard/owner.html.slim
@@ -2,40 +2,39 @@
 
 .columns
   article.maincol
-    -unless current_user.all_owner_collections.empty?
+    -unless @collections.empty?
+      -unless @active_collections.empty? || @inactive_collections.empty?
+        h4 =t('.active_collections')
       .collections
-        -current_user.all_owner_collections.includes(:works).each do |c|
-          .collection
+        -@collections.each do |c|
+          -if c == @inactive_collections.first
+            h4 =t('.inactive_collections')
+          .owner-collection
             h4.collection_title
               =link_to c.title, collection_path(c.owner, c) unless c.owner.nil?
-              -collection_list(c)
-            ol.collection_works
-            ==c.intro_block
-            -unless @works.empty?
-              -@works.each do |w|
-                li =link_to w.title, collection_read_work_path(c.owner, c, w)
-              -more_works = link_to t('.see_all_works'), collection_works_list_path(c.owner, c)
-              -start_project = link_to t('.start_a_project'), dashboard_startproject_path(:collection_id => c.id)
-              p.nodata_text = t('.total_work_count', count: @count)
-                  -if @count > 15
-                    i &nbsp; #{more_works}
-                    br
-              p.nodata_text = t('.you_can_add_another_work', start_project: start_project).html_safe
+              span.visibility
+                -if c.is_public
+                  =t('.public')
+                -else
+                  =t('.private')
+            -unless c.works.empty?
+              -collection_stats(c)
+              .collection-work_stats
+                span 
+                  =t('.n_works', count: c.works.count)
+                  =@wording
+                span
+                  =render({ :partial => 'shared/progress', :locals => { :collection => c } })
             -else
               -start_project = link_to t('.start_a_project'), dashboard_startproject_path(:collection_id => c.id)
               .nodata
                 h5.nodata_title =t('.there_are_no_works')
                 p.nodata_text =t('.you_can_upload_documents', start_project: start_project).html_safe
-      -unless current_user.document_sets.empty?
-        h3 =t('.document_sets')
-        -current_user.document_sets.each do |s|
-          .collection
-            h4.collection_title
-              =link_to s.title, collection_path(s.owner, s)
-            ol.collection_works
-            -unless s.works.empty?
-              -(s.works.sort_by { |work| work.title }).each do |w|
-                li =link_to w.title, collection_read_work_path(s.owner, s, w)
+            -unless c.document_sets.empty?
+              h3 =t('.document_sets')
+              -c.document_sets.each do |s|
+                h5.collection_title
+                  =link_to s.title, collection_path(s.owner, s)
 
     -else
       -new_collection = link_to t('.create_a_collection'), collection_new_path

--- a/app/views/shared/_progress.html.slim
+++ b/app/views/shared/_progress.html.slim
@@ -1,0 +1,6 @@
+span.progress
+  -unless collection.subjects_disabled
+    span(style="width:#{@progress_annotated}%")
+  span(style="width:#{@progress_completed - @progress_annotated + @progress_blank}%")
+  -unless @progress_review == 0
+    span(style="width:#{@progress_review}%")

--- a/config/locales/collection/collection-de.yml
+++ b/config/locales/collection/collection-de.yml
@@ -9,6 +9,7 @@ de:
         other: "%{count} Seiten;"
       progress: Fortschritt
       work_title: Werktitel
+    complete: vollständig
     contributor_activity:
       recent_notes: Neue Anmerkungen
       recent_ocr_correction: Kürzlich hinzugefügte OCR-Korrekturen

--- a/config/locales/collection/collection-en.yml
+++ b/config/locales/collection/collection-en.yml
@@ -9,6 +9,7 @@ en:
         other: "%{count} pages; "
       progress: Progress
       work_title: Work title
+    complete: complete
     contributor_activity:
       recent_notes: Recent Notes
       recent_ocr_correction: Recent OCR correction

--- a/config/locales/collection/collection-es.yml
+++ b/config/locales/collection/collection-es.yml
@@ -9,6 +9,7 @@ es:
         other: "%{count} páginas:"
       progress: Progreso
       work_title: Título de la obra
+    complete: completo
     contributor_activity:
       recent_notes: Notas Recientes
       recent_ocr_correction: Correcciones de OCR recientes

--- a/config/locales/collection/collection-fr.yml
+++ b/config/locales/collection/collection-fr.yml
@@ -9,6 +9,7 @@ fr:
         other: "%{count} pages :"
       progress: Progrès
       work_title: Titre de œuvre
+    complete: complet
     contributor_activity:
       recent_notes: Notes récentes
       recent_ocr_correction: Correction d'OCR récente

--- a/config/locales/collection/collection-pt.yml
+++ b/config/locales/collection/collection-pt.yml
@@ -9,6 +9,7 @@ pt:
         other: "%{count} páginas:"
       progress: Progresso
       work_title: Título da obra
+    complete: completo
     contributor_activity:
       recent_notes: Notas Recentes
       recent_ocr_correction: Correção de OCR recente

--- a/config/locales/dashboard/dashboard-de.yml
+++ b/config/locales/dashboard/dashboard-de.yml
@@ -96,14 +96,10 @@ de:
       n_works:
         one: '1 Werk:'
         other: "%{count} funktioniert:"
-      pct_complete: "%{pct} % abgeschlossen"
       private: " (Privatgelände)"
       public: " (Öffentlich)"
-      see_all_works: Alle Werke ansehen...
       start_a_project: Ein Projekt starten
       there_are_no_works: Es gibt noch keine Werke in dieser Sammlung
-      total_work_count: 'Gesamtanzahl an Werken: %{count}'
-      you_can_add_another_work: Sie können ein weiteres Werk unter %{start_project} hinzufügen
       you_can_new_collection: Sie können %{new_collection}
       you_can_upload_documents: Unter %{start_project} können Sie Dokumente hochladen
       you_dont_have_any_collections: Sie haben noch keine Sammlungen

--- a/config/locales/dashboard/dashboard-de.yml
+++ b/config/locales/dashboard/dashboard-de.yml
@@ -89,8 +89,16 @@ de:
       page_image_guidelines: Richtlinien für Faksimiles
       paste_in_the_url: Fügen Sie die URL eines mehrteiligen Objekts oder einer Sammlung auf Ihrer CONTENTdm-Site ein.
     owner:
+      active_collections: Aktive Sammlungen
       create_a_collection: eine Sammlung erstellen
       document_sets: Dokumentensets
+      inactive_collections: Inaktive Sammlungen
+      n_works:
+        one: '1 Werk:'
+        other: "%{count} funktioniert:"
+      pct_complete: "%{pct} % abgeschlossen"
+      private: " (Privatgelände)"
+      public: " (Öffentlich)"
       see_all_works: Alle Werke ansehen...
       start_a_project: Ein Projekt starten
       there_are_no_works: Es gibt noch keine Werke in dieser Sammlung

--- a/config/locales/dashboard/dashboard-en.yml
+++ b/config/locales/dashboard/dashboard-en.yml
@@ -96,14 +96,10 @@ en:
       n_works:
         one: '1 work: '
         other: "%{count} works: "
-      pct_complete: "%{pct}% complete"
       private: " (Private)"
       public: " (Public)"
-      see_all_works: See All Works...
       start_a_project: Start A Project
       there_are_no_works: There are no works in this collection yet
-      total_work_count: 'Total work count: %{count}'
-      you_can_add_another_work: You can add another work under %{start_project}
       you_can_new_collection: You can %{new_collection}
       you_can_upload_documents: You can upload documents under %{start_project}
       you_dont_have_any_collections: You don't have any collections yet

--- a/config/locales/dashboard/dashboard-en.yml
+++ b/config/locales/dashboard/dashboard-en.yml
@@ -89,8 +89,16 @@ en:
       page_image_guidelines: Page Image Guidelines
       paste_in_the_url: Paste in the URL of a compound object or a collection on your CONTENTdm site.
     owner:
+      active_collections: Active Collections
       create_a_collection: create a collection
       document_sets: Document Sets
+      inactive_collections: Inactive Collections
+      n_works:
+        one: '1 work: '
+        other: "%{count} works: "
+      pct_complete: "%{pct}% complete"
+      private: " (Private)"
+      public: " (Public)"
       see_all_works: See All Works...
       start_a_project: Start A Project
       there_are_no_works: There are no works in this collection yet

--- a/config/locales/dashboard/dashboard-es.yml
+++ b/config/locales/dashboard/dashboard-es.yml
@@ -96,14 +96,10 @@ es:
       n_works:
         one: '1 trabajo:'
         other: "%{count} funciona:"
-      pct_complete: "%{pct}% completado"
       private: " (Privado)"
       public: " (Público)"
-      see_all_works: Consulte Todas las Obras...
       start_a_project: Iniciar Un Proyecto
       there_are_no_works: Todavía no hay obras en esta colección
-      total_work_count: 'Recuento total de obras: %{count}'
-      you_can_add_another_work: Puedes añadir otra obra bajo %{start_project}
       you_can_new_collection: Puedes %{new_collection}
       you_can_upload_documents: Puedes subir documentos en %{start_project}
       you_dont_have_any_collections: No hay colecciones todavía

--- a/config/locales/dashboard/dashboard-es.yml
+++ b/config/locales/dashboard/dashboard-es.yml
@@ -89,8 +89,16 @@ es:
       page_image_guidelines: Guías para Imagen de Página
       paste_in_the_url: Pega el URL del objeto compuesto de tu sitio CONTENTdm.
     owner:
+      active_collections: Colecciones activas
       create_a_collection: crear una colección
       document_sets: Conjuntos de Documentos
+      inactive_collections: Colecciones inactivas
+      n_works:
+        one: '1 trabajo:'
+        other: "%{count} funciona:"
+      pct_complete: "%{pct}% completado"
+      private: " (Privado)"
+      public: " (Público)"
       see_all_works: Consulte Todas las Obras...
       start_a_project: Iniciar Un Proyecto
       there_are_no_works: Todavía no hay obras en esta colección

--- a/config/locales/dashboard/dashboard-fr.yml
+++ b/config/locales/dashboard/dashboard-fr.yml
@@ -96,14 +96,10 @@ fr:
       n_works:
         one: '1 œuvre :'
         other: "%{count} fonctionne :"
-      pct_complete: "%{pct} % terminé"
       private: " (Privé)"
       public: " (Public)"
-      see_all_works: Voir toutes les oeuvres...
       start_a_project: Démarrer un projet
       there_are_no_works: Il n'y a pas encore d'œuvres dans cette collection
-      total_work_count: 'Nombre total de œuvres : %{count}'
-      you_can_add_another_work: Vous pouvez ajouter une autre œuvre sous %{start_project}
       you_can_new_collection: Vous pouvez %{new_collection}
       you_can_upload_documents: Vous pouvez téléverser des documents sous %{start_project}
       you_dont_have_any_collections: Vous n'avez pas encore de collections

--- a/config/locales/dashboard/dashboard-fr.yml
+++ b/config/locales/dashboard/dashboard-fr.yml
@@ -89,8 +89,16 @@ fr:
       page_image_guidelines: Directives relatives aux images de page
       paste_in_the_url: Coller l'URL d'un objet composé ou d'une collection sur votre site CONTENTdm.
     owner:
+      active_collections: Collections actives
       create_a_collection: créer une collection
       document_sets: Jeux de documents
+      inactive_collections: Collections inactives
+      n_works:
+        one: '1 œuvre :'
+        other: "%{count} fonctionne :"
+      pct_complete: "%{pct} % terminé"
+      private: " (Privé)"
+      public: " (Public)"
       see_all_works: Voir toutes les oeuvres...
       start_a_project: Démarrer un projet
       there_are_no_works: Il n'y a pas encore d'œuvres dans cette collection

--- a/config/locales/dashboard/dashboard-pt.yml
+++ b/config/locales/dashboard/dashboard-pt.yml
@@ -96,14 +96,10 @@ pt:
       n_works:
         one: '1 trabalho:'
         other: "%{count} funciona:"
-      pct_complete: "%{pct}% concluído"
       private: " (Privado)"
       public: " (Público)"
-      see_all_works: Ver Todas as Obras...
       start_a_project: Iniciar um Projeto
       there_are_no_works: Ainda não há obras nesta coleção
-      total_work_count: 'Número total de obras: %{count}'
-      you_can_add_another_work: Você pode adicionar uma nova obra em %{start_project}
       you_can_new_collection: Você pode %{new_collection}
       you_can_upload_documents: Você pode subir um documento em %{start_project}
       you_dont_have_any_collections: Você ainda não tem nenhuma coleção.

--- a/config/locales/dashboard/dashboard-pt.yml
+++ b/config/locales/dashboard/dashboard-pt.yml
@@ -89,8 +89,16 @@ pt:
       page_image_guidelines: Regras Gerais das Imagens da Página
       paste_in_the_url: Cole o URL de um objeto composto na sua página web de CONTENTdm.
     owner:
+      active_collections: Coleções ativas
       create_a_collection: criar uma coleção
       document_sets: Conjuntos de Documentos
+      inactive_collections: Coleções inativas
+      n_works:
+        one: '1 trabalho:'
+        other: "%{count} funciona:"
+      pct_complete: "%{pct}% concluído"
+      private: " (Privado)"
+      public: " (Público)"
       see_all_works: Ver Todas as Obras...
       start_a_project: Iniciar um Projeto
       there_are_no_works: Ainda não há obras nesta coleção

--- a/spec/features/add_data_spec.rb
+++ b/spec/features/add_data_spec.rb
@@ -107,6 +107,7 @@ describe "uploads data for collections", :order => :defined do
 
   it "adds pages to an empty work" do
     visit dashboard_owner_path
+    page.find('.maincol').find('a', text: @collection.title).click
     page.find('.maincol').find('a', text: @title).click
     page.find('.tabs').click_link("Pages")
     page.find('a', text: "Add New Page").click

--- a/spec/features/admin_view_spec.rb
+++ b/spec/features/admin_view_spec.rb
@@ -77,9 +77,7 @@ describe "admin actions" do
     collections = Collection.where(owner_user_id: @owner.id)
     collections.each do |c|
       expect(page).to have_content(c.title)
-      c.works.each do |w|
-        expect(page).to have_content(w.title)
-      end
+      expect(page).to have_content("#{c.works.count} works")
     end
     #make the masqueraded user doesn't have access to the admin dashboard
     expect(page).to have_selector('a', text: 'Owner Dashboard')

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -284,7 +284,8 @@ describe "collection spec (isolated)" do
 
       visit dashboard_owner_path
 
-      page.find('.collections').click_link('Stats Test Work')
+      page.find('.collections').click_link('Stats Test Collection')
+      page.find('.collection-works .collection-work_title').click_link('Stats Test Work')
       page.find('.maincol h4').click_link('Page 1')
       fill_in_editor_field('Transcription')
       page.find('#finish_button_top').click

--- a/spec/features/owner_actions_spec.rb
+++ b/spec/features/owner_actions_spec.rb
@@ -165,8 +165,10 @@ describe "owner actions", :order => :defined do
   end
 
   it "moves a work to another collection" do
+    work = Work.find_by(title: @title)
+
     visit dashboard_owner_path
-    page.find('.maincol').find('a', text: @rtl_collection.title).click
+    page.find('.maincol').find('a', text: work.collection).click
     page.find('.collection-works').find('a', text: @title).click
     page.find('.tabs').click_link('Settings')
     expect(page).to have_content(@title)
@@ -176,7 +178,6 @@ describe "owner actions", :order => :defined do
     select(@collection.title, :from => 'work_collection_id')
     click_button('Save Changes')
     expect(page).to have_content("Work updated successfully")
-    work = Work.find_by(title: @title)
     expect(Deed.last.work_id).to eq(work.id)
     expect(work.deeds.where.not(:collection_id => work.collection_id).count).to eq(0)
     expect(page.find('.breadcrumbs')).to have_selector('a', text: @collection.title)
@@ -230,14 +231,17 @@ describe "owner actions", :order => :defined do
   end
 
   it "deletes a work" do
+    collection = Work.find_by(title: @title).collection
+
     visit dashboard_owner_path
-    page.find('.maincol').find('a', text: @rtl_collection.title).click
+    page.find('.maincol').find('a', text: collection.title).click
     page.find('.collection-works').find('a', text: @title).click
     page.find('.tabs').click_link('Settings')
     expect(page).to have_content(@title)
     expect(page).to have_content("Work title")
     click_link("Delete Work")
     expect(page.current_path).to eq dashboard_owner_path
+    page.find('.maincol').find('a', text: collection.title).click
     expect(page).not_to have_content(@title)
   end
 

--- a/spec/features/owner_actions_spec.rb
+++ b/spec/features/owner_actions_spec.rb
@@ -167,7 +167,7 @@ describe "owner actions", :order => :defined do
   it "moves a work to another collection" do
     visit dashboard_owner_path
     page.find('.maincol').find('a', text: @rtl_collection.title).click
-    page.find('.collection-works .collection-work_title').find('a', text: @title).click
+    page.find('.collection-works').find('a', text: @title).click
     page.find('.tabs').click_link('Settings')
     expect(page).to have_content(@title)
     expect(page).to have_content("Work title")
@@ -232,7 +232,7 @@ describe "owner actions", :order => :defined do
   it "deletes a work" do
     visit dashboard_owner_path
     page.find('.maincol').find('a', text: @rtl_collection.title).click
-    page.find('.collection-works .collection-work_title').find('a', text: @title).click
+    page.find('.collection-works').find('a', text: @title).click
     page.find('.tabs').click_link('Settings')
     expect(page).to have_content(@title)
     expect(page).to have_content("Work title")

--- a/spec/features/owner_actions_spec.rb
+++ b/spec/features/owner_actions_spec.rb
@@ -166,7 +166,8 @@ describe "owner actions", :order => :defined do
 
   it "moves a work to another collection" do
     visit dashboard_owner_path
-    page.find('.maincol').find('a', text: @title).click
+    page.find('.maincol').find('a', text: @rtl_collection.title).click
+    page.find('.collection-works').find('a', text: @title).click
     page.find('.tabs').click_link('Settings')
     expect(page).to have_content(@title)
     expect(page).to have_content("Work title")
@@ -230,7 +231,8 @@ describe "owner actions", :order => :defined do
 
   it "deletes a work" do
     visit dashboard_owner_path
-    page.find('.maincol').find('a', text: @title).click
+    page.find('.maincol').find('a', text: @rtl_collection.title).click
+    page.find('.collection-works').find('a', text: @title).click
     page.find('.tabs').click_link('Settings')
     expect(page).to have_content(@title)
     expect(page).to have_content("Work title")

--- a/spec/features/owner_actions_spec.rb
+++ b/spec/features/owner_actions_spec.rb
@@ -178,6 +178,7 @@ describe "owner actions", :order => :defined do
     select(@collection.title, :from => 'work_collection_id')
     click_button('Save Changes')
     expect(page).to have_content("Work updated successfully")
+    work = Work.find_by(title: @title)
     expect(Deed.last.work_id).to eq(work.id)
     expect(work.deeds.where.not(:collection_id => work.collection_id).count).to eq(0)
     expect(page.find('.breadcrumbs')).to have_selector('a', text: @collection.title)

--- a/spec/features/owner_actions_spec.rb
+++ b/spec/features/owner_actions_spec.rb
@@ -168,7 +168,7 @@ describe "owner actions", :order => :defined do
     work = Work.find_by(title: @title)
 
     visit dashboard_owner_path
-    page.find('.maincol').find('a', text: work.collection).click
+    page.find('.maincol').find('a', text: work.collection.title).click
     page.find('.collection-works').find('a', text: @title).click
     page.find('.tabs').click_link('Settings')
     expect(page).to have_content(@title)
@@ -234,7 +234,7 @@ describe "owner actions", :order => :defined do
     collection = Work.find_by(title: @title).collection
 
     visit dashboard_owner_path
-    page.find('.maincol').find('a', text: collection.title).click
+    page.find('.maincol').find('a', text: @collection.title).click
     page.find('.collection-works').find('a', text: @title).click
     page.find('.tabs').click_link('Settings')
     expect(page).to have_content(@title)

--- a/spec/features/owner_actions_spec.rb
+++ b/spec/features/owner_actions_spec.rb
@@ -167,7 +167,7 @@ describe "owner actions", :order => :defined do
   it "moves a work to another collection" do
     visit dashboard_owner_path
     page.find('.maincol').find('a', text: @rtl_collection.title).click
-    page.find('.collection-works').find('a', text: @title).click
+    page.find('.collection-works .collection-work_title').find('a', text: @title).click
     page.find('.tabs').click_link('Settings')
     expect(page).to have_content(@title)
     expect(page).to have_content("Work title")
@@ -232,7 +232,7 @@ describe "owner actions", :order => :defined do
   it "deletes a work" do
     visit dashboard_owner_path
     page.find('.maincol').find('a', text: @rtl_collection.title).click
-    page.find('.collection-works').find('a', text: @title).click
+    page.find('.collection-works .collection-work_title').find('a', text: @title).click
     page.find('.tabs').click_link('Settings')
     expect(page).to have_content(@title)
     expect(page).to have_content("Work title")

--- a/spec/features/role_view_spec.rb
+++ b/spec/features/role_view_spec.rb
@@ -92,9 +92,7 @@ describe "different user role logins" do
     expect(page).to have_content("Owner Dashboard")
     @collections.each do |c|
       expect(page).to have_content(c.title)
-      c.works.each do |w|
-        expect(page).to have_content(w.title)
-      end
+      expect(page).to have_content("#{c.works.count} works")
     end
     @sets.each do |s|
       expect(page).to have_content(s.title)

--- a/spec/features/zz_deletion_spec.rb
+++ b/spec/features/zz_deletion_spec.rb
@@ -54,7 +54,7 @@ describe "testing deletions" do
     test_page = work.pages.first
     visit dashboard_owner_path
     page.find('.maincol').click_link(@collection.title)
-    page.find('.collection-works .collection-work_title').find_all('a', text: work.title).first.click
+    page.find('.collection-works').find('a', text: work.title).click
     expect(page).to have_content(work.title)
     expect(page).to have_content(test_page.title)
     page.find('.work-page_title', text: test_page.title).click_link(test_page.title)

--- a/spec/features/zz_deletion_spec.rb
+++ b/spec/features/zz_deletion_spec.rb
@@ -54,7 +54,7 @@ describe "testing deletions" do
     test_page = work.pages.first
     visit dashboard_owner_path
     page.find('.maincol').click_link(@collection.title)
-    page.find('.maincol').find_all('a', text: work.title).first.click
+    page.find('.collection-works .collection-work_title').find_all('a', text: work.title).first.click
     expect(page).to have_content(work.title)
     expect(page).to have_content(test_page.title)
     page.find('.work-page_title', text: test_page.title).click_link(test_page.title)

--- a/spec/features/zz_deletion_spec.rb
+++ b/spec/features/zz_deletion_spec.rb
@@ -53,6 +53,7 @@ describe "testing deletions" do
     count = work.pages.count
     test_page = work.pages.first
     visit dashboard_owner_path
+    page.find('.maincol').click_link(@collection.title)
     page.find('.maincol').find_all('a', text: work.title).first.click
     expect(page).to have_content(work.title)
     expect(page).to have_content(test_page.title)
@@ -76,7 +77,8 @@ describe "testing deletions" do
     path = File.join(Rails.root, "public", "images", "uploaded", id.to_s)
     expect(Dir.exist?(path)).to be true
     visit dashboard_owner_path
-    page.find('.maincol').find('a', text: work.title).click
+    page.find('.maincol').click_link(work.collection.title)
+    page.find('.collection-works').find('a', text: work.title).click
     page.find('.tabs').click_link('Settings')
     expect(page).to have_content(work.title)
     expect(page).to have_selector('a', text: 'Delete Work')

--- a/spec/features/zz_deletion_spec.rb
+++ b/spec/features/zz_deletion_spec.rb
@@ -54,7 +54,8 @@ describe "testing deletions" do
     test_page = work.pages.first
     visit dashboard_owner_path
     page.find('.maincol').click_link(@collection.title)
-    page.find('.collection-works').find('a', text: work.title).click
+    page.find('.tabs').click_link("Works List")
+    page.find('.collection-work-stats').find('a', text: work.title).click
     expect(page).to have_content(work.title)
     expect(page).to have_content(test_page.title)
     page.find('.work-page_title', text: test_page.title).click_link(test_page.title)


### PR DESCRIPTION
_Resolves #3619 (and #3590, #3205)_

This improves and simplifies the owner dashboard.

![image](https://github.com/benwbrum/fromthepage/assets/35716893/d612a1cf-bcce-416f-8606-ec1aeced3107)

### Changes
* UI updated so that collections are more easily distinguished with a border, like how works are shown on the collection show page.
* Collection description removed.
* Works list removed.
* "You can add another work under Start A Project" was previously written under work list, now removed.
* Collection privacy added next to the collection title.
* Document sets nested under the collection they belong to instead of listed at the bottom of the dashboard.
* Inactive collections listed separate from active collections, at the bottom of the dashboard.
* Collection progress % completed statistics added (% completed, transcribed, reviewed, indexed).
* Collection progress bars added.

The logic for these last two statistics are based on the corresponding logic for the work progress bars on the collection show page.
