### PR TITLE
Fixes #3699 by balancing empty HR elements

### DIFF
--- a/app/helpers/abstract_xml_helper.rb
+++ b/app/helpers/abstract_xml_helper.rb
@@ -286,7 +286,7 @@ module AbstractXmlHelper
     my_display_html.gsub!('<p/>','')
     my_display_html.gsub!(/<\/?page>/,'')
 
-    return ActionController::Base.helpers.sanitize(my_display_html.strip, :tags => SANITIZE_ALLOWED_TAGS).gsub('<br>','<br/>')
+    return ActionController::Base.helpers.sanitize(my_display_html.strip, :tags => SANITIZE_ALLOWED_TAGS).gsub('<br>','<br/>').gsub('<hr>','<hr/>')
   end
 
 end


### PR DESCRIPTION
Closes #3699 

To test, add an HR element to a page transcript, then try to export it.