### PR TITLE
Track collection and work searches with search attempts for #3730

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -279,16 +279,29 @@ class AdminController < ApplicationController
   end
 
   def searches
-    if params[:filter]
-      @searches = SearchAttempt.where(owner: false).order('id DESC').paginate :page => params[:page], :per_page => PAGES_PER_SCREEN
+    if params[:filter] == 'nonowner' # Only transcriber searches
+      searches = SearchAttempt.where(owner: false)
+    elsif params[:filter] == 'findaproject'
+      searches = SearchAttempt.where(search_type: 'findaproject')
+    elsif params[:filter] == 'collectionwork'
+      searches = SearchAttempt.where.not(search_type: 'findaproject')
+    elsif params[:filter] == 'collection'
+      searches = SearchAttempt.where(search_type: 'collection')
+    elsif params[:filter] == 'collection-title'
+      searches = SearchAttempt.where(search_type: 'collection-title')
+    elsif params[:filter] == 'work'
+      searches = SearchAttempt.where(search_type: 'work')
     else
-      @searches = SearchAttempt.order('id DESC').paginate :page => params[:page], :per_page => PAGES_PER_SCREEN
+      searches = SearchAttempt.all
     end
+    @searches = searches.order('id DESC').paginate :page => params[:page], :per_page => PAGES_PER_SCREEN
 
     this_week = SearchAttempt.where('created_at > ?', 1.week.ago)
     by_visit = this_week.joins(:visit).group('visits.id')
-    @searches_per_day = (this_week.count / 7.0).round(2)
-    @average_hits = this_week.average(:hits).round(2)
+    @find_a_project_searches_per_day = (this_week.where(search_type: 'findaproject').count / 7.0).round(2)
+    @collection_work_searches_per_day = (this_week.where.not(search_type: 'findaproject').count / 7.0).round(2)
+    @find_a_project_average_hits = this_week.where(search_type: 'findaproject').average(:hits).round(2)
+    @collection_work_average_hits = this_week.where.not(search_type: 'findaproject').average(:hits).round(2)
     @clickthrough_rate = ((this_week.where('clicks > 0').count.to_f / this_week.count) * 100).round(1)
     @clickthrough_rate_visit = ((by_visit.sum(:clicks).values.count{|c|c>0}.to_f / by_visit.length) * 100).round(1)
     @contribution_rate = ((this_week.where('contributions > 0').count.to_f / this_week.count) * 100).round(1) 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -317,12 +317,7 @@ class ApplicationController < ActionController::Base
     # Otherwise owners should go to their dashboards
     # And everyone else should go to user dashboard/watchlist
   def after_sign_in_path_for(resource)
-    # Update search attempt with user
-    if session[:search_attempt_id]
-      search_attempt = SearchAttempt.find(session[:search_attempt_id])
-      search_attempt.user = current_user
-      search_attempt.save
-    end
+    update_search_attempt_user(current_user)
 
     if current_user.admin
       admin_path
@@ -410,6 +405,15 @@ end
     if session[:search_attempt_id]
       search_attempt = SearchAttempt.find(session[:search_attempt_id])
       search_attempt.increment!(:contributions)
+    end
+  end
+
+  def update_search_attempt_user(user)
+    if session[:search_attempt_id]
+      search_attempt = SearchAttempt.find(session[:search_attempt_id])
+      search_attempt.user = user
+      search_attempt.owner = user.owner
+      search_attempt.save
     end
   end
 

--- a/app/controllers/concerns/owner_exporter.rb
+++ b/app/controllers/concerns/owner_exporter.rb
@@ -88,7 +88,7 @@ module OwnerExporter
 
   def admin_searches_csv(start_date, end_date)
     rows = []
-    header = ['Query', 'Date', 'Hits', 'Clicks', 'Contributions', 'Visit ID', 'User ID', 'Owner']
+    header = ['Query', 'Date', 'Search Type', 'Collection Title', 'Collection ID', 'Work Title', 'Work ID', 'Hits', 'Clicks', 'Contributions', 'Visit ID', 'User ID', 'Owner']
 
     start_date = start_date&.beginning_of_day || 1.week.ago.beginning_of_day
     end_date = end_date&.end_of_day || 1.day.ago.end_of_day
@@ -97,6 +97,11 @@ module OwnerExporter
       row = []
       row << search.query
       row << search.created_at
+      row << search.search_type
+      row << search.collection&.title || ""
+      row << search.collection_id || ""
+      row << search.work&.title || ""
+      row << search.work&.id || ""
       row << search.hits
       row << search.clicks
       row << search.contributions

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -68,12 +68,7 @@ class RegistrationsController < Devise::RegistrationsController
         alert_intercom
       end
 
-      # Update search attempt with new user
-      if session[:search_attempt_id]
-        search_attempt = SearchAttempt.find(session[:search_attempt_id])
-        search_attempt.user = @user
-        search_attempt.save
-      end
+      update_search_attempt_user(@user)
     else
       clean_up_passwords resource
       @validatable = devise_mapping.validatable?

--- a/app/controllers/search_attempt_controller.rb
+++ b/app/controllers/search_attempt_controller.rb
@@ -1,23 +1,68 @@
 class SearchAttemptController < ApplicationController
     def create
-        if current_user.nil?
-            @search_attempt = SearchAttempt.new(query: params[:search])
-        else
+        user_id = current_user.nil? ? nil : current_user.id
+        owner = current_user.nil? ? false : current_user.owner
+        
+        if params[:work_id].present?
+            work =  Work.find(params[:work_id])
+            @search_attempt = SearchAttempt.new(
+                query: params[:search],
+                search_type: "work",
+                work_id: work.id,
+                collection_id: work.collection_id,
+                user_id: user_id,
+                owner: owner
+            )
+            @search_attempt.save
+            session[:search_attempt_id] = @search_attempt.id
+            ajax_redirect_to(paged_search_path(@search_attempt))
+
+        elsif params[:collection_id].present? && params[:search_by_title].present?
+            collection = Collection.find(params[:collection_id])
+            @search_attempt = SearchAttempt.new(
+                query: params[:search_by_title],
+                search_type: "collection-title",
+                collection_id: collection.id,
+                user_id: user_id,
+                owner: owner
+            )
+            @search_attempt.save
+            session[:search_attempt_id] = @search_attempt.id
+            ajax_redirect_to(collection_path(collection.owner, collection.slug, search_attempt_id: @search_attempt.id))
+
+        elsif params[:collection_id].present?
+            collection_id = Collection.find(params[:collection_id]).id
+            @search_attempt = SearchAttempt.new(
+                query: params[:search],
+                search_type: "collection",
+                collection_id: collection_id,
+                user_id: user_id,
+                owner: owner
+            )
+            @search_attempt.save
+            session[:search_attempt_id] = @search_attempt.id
+            ajax_redirect_to(paged_search_path(@search_attempt))
+
+        else # Find a Project search
             @search_attempt = SearchAttempt.new(
                 query: params[:search], 
+                search_type: "findaproject",
                 user_id: current_user.id, 
-                owner: current_user.owner)
+                owner: current_user.owner
+            )
+            @search_attempt.save
+            session[:search_attempt_id] = @search_attempt.id
+            ajax_redirect_to(search_attempt_show_path(@search_attempt))
         end
-        @search_attempt.save
-        
-        ajax_redirect_to(search_attempt_show_path(@search_attempt))
     end
 
     def show
         @search_attempt = SearchAttempt.find_by(slug: params[:id])
         
         unless @search_attempt.nil?
-            session[:search_attempt_id] = @search_attempt.id
+            if session[:search_attempt_id] != @search_attempt.id
+                session[:search_attempt_id] = @search_attempt.id
+            end
 
             # Get matching Collections and Docsets
             @search_results = Collection.search(@search_attempt.query).unrestricted + DocumentSet.search(@search_attempt.query).unrestricted
@@ -31,5 +76,18 @@ class SearchAttemptController < ApplicationController
             flash[:error] = "Search attempt not found"
             redirect_to landing_page_path
         end
+    end
+
+    # Called from any search result link by ajax
+    def click
+        # binding.pry
+        puts "CLICK"
+        # puts session.inspect
+        if session[:search_attempt_id].present?
+            search_attempt = SearchAttempt.find(session[:search_attempt_id])
+            search_attempt.increment!(:clicks)
+        end
+        
+        return head :ok
     end
 end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -125,12 +125,6 @@ class UserController < ApplicationController
   end
 
   def profile
-    # Check if the user is coming from a search result
-    if session[:search_attempt_id]
-      @search_attempt = SearchAttempt.find(session[:search_attempt_id])
-      @search_attempt.increment!(:clicks)
-    end
-
     #find the user if it isn't already set
     unless @user
       @user = User.friendly.find(params[:id])

--- a/app/models/search_attempt.rb
+++ b/app/models/search_attempt.rb
@@ -1,5 +1,7 @@
 class SearchAttempt < ApplicationRecord
     belongs_to :user, optional: true
+    belongs_to :collection, optional: true
+    belongs_to :work, optional: true
     visitable class_name: "Visit" # ahoy integration
 
     after_create :update_slug

--- a/app/views/admin/searches.html.slim
+++ b/app/views/admin/searches.html.slim
@@ -1,10 +1,10 @@
 =render(:partial => 'header', :locals => { :selected => 7 })
 
 section.admin-counters
-  .counter
-  .counter(data-prefix="#{number_with_delimiter(@searches_per_day)}") Searches per day
-  .counter(data-prefix="#{number_with_delimiter(@average_hits)}") Average hits
-  .counter
+  .counter(data-prefix="#{number_with_delimiter(@find_a_project_searches_per_day)}") Find a project<br> searches per day
+  .counter(data-prefix="#{number_with_delimiter(@collection_work_searches_per_day)}") Collection/work<br> searches per day
+  .counter(data-prefix="#{number_with_delimiter(@find_a_project_average_hits)}") Find a project<br> average hits
+  .counter(data-prefix="#{number_with_delimiter(@collection_work_average_hits)}") Collection/work<br> average hits
   .counter(data-prefix="#{number_with_delimiter(@clickthrough_rate)}%") Searches get clicks
   .counter(data-prefix="#{number_with_delimiter(@clickthrough_rate_visit)}%") Visits get search clicks
   .counter(data-prefix="#{number_with_delimiter(@contribution_rate)}%") Searches get contributions
@@ -14,21 +14,47 @@ table.admin-grid.datagrid.striped
   thead
     tr
       th =t('.query')
+      th 
+        =t('.type')
+        br
+        =form_tag admin_searches_path, method: :get do
+          =select_tag :filter, options_for_select([['All', 'all'], ['Find a Project', 'findaproject'], ['Collection & Work', 'collectionwork'], ['Collection', 'collection'], ['Collection title/metadata', 'collection-title'], ['Work', 'work']], params[:filter]), onchange: 'this.form.submit();'
+
+      th =t('.collection')
+      th =t('.work')
       th =t('.hits')
       th =t('.clicks')
       th =t('.contributions')
       th =t('.date')
       th(colspan="2") =t('.user')
-      th =link_to t('.owner'), admin_searches_path(:filter => 'owner'), class: 'acenter', title: t('.owner_filter')
+      th =link_to t('.owner'), admin_searches_path(:filter => 'nonowner'), class: 'acenter', title: t('.owner_filter')
 
   tbody 
     -@searches.each do |search|
       tr
         td.toleft
-          div =link_to search.query, search_attempt_show_path(search)
-        td =search.hits
-        td =search.clicks
-        td =search.contributions
+          -if search.search_type == 'findaproject'
+            -link = search_attempt_show_path(search)
+          -elsif search.search_type == 'collection'
+            -link = paged_search_path(search)
+          -elsif search.search_type == 'collection-title'
+            -link = collection_path(search.collection.owner, search.collection.slug, search_attempt_id: search.id)
+          -else #Work
+            -link = paged_search_path(search)
+
+          div =link_to search.query, link
+        td.nowrap =t(".search_type.#{search.search_type}")
+        td
+          -if search.collection 
+            =link_to search.collection.title, collection_path(search.collection.owner, search.collection)
+          -elsif search.work
+            =link_to search.work.collection.title, collection_path(search.work.collection.owner, search.work.collection)
+        td 
+          -if search.work
+            =link_to search.work.title, collection_read_work_path(search.work.collection.owner, search.work.collection, search.work)
+        td.nowrap =search.hits
+        td.nowrap =search.clicks
+        td.nowrap =search.contributions
         td.nowrap =search.created_at.localtime.strftime("%m/%d/%Y at %I:%M %p")
         -if search.user
           td.nowrap.toleft
@@ -40,7 +66,7 @@ table.admin-grid.datagrid.striped
         -else
           td
           td Guest
-        td.acenter =svg_symbol '#icon-check-sign', class: 'icon a50' if search.user&.owner
+        td.acenter =svg_symbol '#icon-check-sign', class: 'icon a50' if search.owner
 
 =render(:partial => 'shared/pagination', :locals => { :model => @searches, :entries_info => true })
 

--- a/app/views/collection/show.html.slim
+++ b/app/views/collection/show.html.slim
@@ -34,15 +34,15 @@
         .collection-work
           .collection-work_image
             -unless work.thumbnail.nil?
-                =link_to image_tag(work.thumbnail, alt: work.title), default_path
-          h4.collection-work_title =link_to work.title, default_path
+                =link_to image_tag(work.thumbnail, alt: work.title), default_path, onclick: "resultClicked();"
+          h4.collection-work_title =link_to work.title, default_path, onclick: "resultClicked();"
           p.collection-work_snippet = to_snippet(work.description)
           -if @collection.text_entry? && work.next_untranscribed_page
             p.collection-work_action 
               -if (current_user && current_user.can_transcribe?(work))
                 =t('.this_work_has_pages_that_need_work')
                 span &nbsp;
-                =link_to(t('.help_transcribe_or_correct'), collection_transcribe_page_path(@collection.owner, @collection, work, work.next_untranscribed_page))
+                =link_to(t('.help_transcribe_or_correct'), collection_transcribe_page_path(@collection.owner, @collection, work, work.next_untranscribed_page), onclick: "resultClicked();")
               -else
                 =t('.restricted_collaboratoration')
           -if @collection.metadata_entry? && work.description_status != Work::DescriptionStatus::DESCRIBED && !work.has_untranscribed_pages?
@@ -50,7 +50,7 @@
               -if (current_user && current_user.can_transcribe?(work))
                 =t('.this_work_has_not_been_described')
                 span &nbsp;
-                =link_to(t('.help_create_metadata'), describe_collection_work_path(@collection.owner, @collection, work))
+                =link_to(t('.help_create_metadata'), describe_collection_work_path(@collection.owner, @collection, work), onclick: "resultClicked();")
               -else
                 =t('.restricted_collaboratoration')
           -if @collection.text_entry?
@@ -95,15 +95,15 @@
         small =t('.project_by')
         =link_to @collection.owner.display_name, user_profile_path(@collection.owner)
 
-    =form_tag(display_search_path, :method => :post, class: 'collection-search') do
+    =form_tag({:controller => 'search_attempt', :action => 'create'}, :method => :get, class: 'collection-search') do
       =hidden_field_tag('collection_id', @collection.slug)
-      =search_field_tag 'search_string', nil, :placeholder => t('.search_the_text'), "aria-label" => t('.search_the_text_1')
+      =search_field_tag :search, nil, placeholder: t('.search_the_text'), "aria-label" => t('.search_the_text_1')
       =button_tag t('.search')
       =label_tag 'search_string', t('.search_the_text_1'), class: 'hidden'
 
-    =form_tag({:controller => 'collection', :action => 'show'}, method: :get, enforce_utf8: false, class: 'collection-search') do
-      =hidden_field_tag('collection_id', @collection, {:id => "collection id for search work"})
-      =search_field_tag :work_search, params[:work_search], placeholder: t('.search_by_title'), "aria-label" => t('.search_by_title_1')
+    =form_tag({:controller => 'search_attempt', :action => 'create'}, method: :get, enforce_utf8: false, class: 'collection-search') do
+      =hidden_field_tag('collection_id', @collection.slug, {:id => "collection id for search work"})
+      =search_field_tag :search_by_title, @query, placeholder: t('.search_by_title'), "aria-label" => t('.search_by_title_1')
       =button_tag t('.search')
       =label_tag 'search', t('.search_by_title_1'), class: 'hidden'
 
@@ -146,3 +146,13 @@
       $(document).ready(function(){
         $('#new_mobile_user_link').trigger('click');
       });
+
+-if @search_attempt
+  -content_for :javascript
+    javascript:
+      function resultClicked() {
+        $.ajax({
+          url: '/search_attempt/click',
+          type: 'GET',
+        })
+      };

--- a/app/views/display/_multi_page.html.slim
+++ b/app/views/display/_multi_page.html.slim
@@ -14,19 +14,21 @@
     aside.sidecol
 
       -if @collection
-        =form_tag({:controller => 'display', :action => 'search'}, :method => :post, class: 'collection-search') do
-          =hidden_field_tag('collection_id', @collection.slug)
-          =search_field_tag 'search_string', @search_string, :placeholder => t('.search_in_collection'), "aria-label" => t('.search_in_collection_1')
+        -query = @query if @search_attempt&.search_type == 'collection'
+        =form_tag({:controller => 'search_attempt', :action => 'create'}, :method => :get, class: 'collection-search') do
+          =hidden_field_tag('collection_id', @collection.id)
+          =search_field_tag :search, query, :placeholder => t('.search_in_collection'), "aria-label" => t('.search_in_collection_1')
           =button_tag t('.search')
           =label_tag 'search_string', t('.search_in_collection'), class: 'hidden'
 
-        =form_tag({:controller => 'display', :action => 'search'}, :method => :post, class: 'collection-search') do
-          =hidden_field_tag('work_id', @work&.id)
-          =search_field_tag 'search_work_string', @search_work_string, :placeholder => t('.search_in_work'), "aria-label" => t('.search_in_collection_1')
+      -if @work
+        -query = @query if @search_attempt&.search_type == 'work'
+        =form_tag({:controller => 'search_attempt', :action => 'create'}, :method => :get, class: 'collection-search') do
+          =hidden_field_tag('work_id', @work.id)
+          =search_field_tag :search, query, :placeholder => t('.search_in_work'), "aria-label" => t('.search_in_collection_1')
           =button_tag t('.search')
           =label_tag 'search_work_string', t('.search_in_work'), class: 'hidden'
 
-      -if @work
         -if @total != @count
           =button_to t('.view_all_pages'), {action: "read_work", work_id: @work.slug, needs_review: 'none'}, class: 'review-button'
         -elsif @collection.active?

--- a/app/views/display/_pages_view.html.slim
+++ b/app/views/display/_pages_view.html.slim
@@ -18,16 +18,16 @@
   -if !@work && work_title != old_work_title
     h3 =work_title
     -if page.work.description_status == Work::DescriptionStatus::NEEDS_REVIEW && current_user.can_review?(@collection)
-      =link_to t('.review_metadata'), describe_collection_work_path(@collection.owner, @collection, page.work), class: 'button review-button'
+      =link_to t('.review_metadata'), describe_collection_work_path(@collection.owner, @collection, page.work), class: 'button review-button', onclick: "resultClicked();"
 
   .work-page 
     .work-page_thumbnail
       -if page.ia_leaf
-        =link_to(image_tag(page.ia_leaf.thumb_url, alt: page.title), page_params(page) )
+        =link_to(image_tag(page.ia_leaf.thumb_url, alt: page.title), page_params(page), onclick: "resultClicked();")
       -elsif page.sc_canvas
-        =link_to(image_tag(page.sc_canvas.thumbnail_url, alt: page.title), page_params(page))
+        =link_to(image_tag(page.sc_canvas.thumbnail_url, alt: page.title), page_params(page), onclick: "resultClicked();")
       -else
-        =link_to image_tag(file_to_url(page.thumbnail_image), alt: page.title), page_params(page)
+        =link_to(image_tag(file_to_url(page.thumbnail_image), alt: page.title), page_params(page), onclick: "resultClicked();")
       span
         span.progress
           -if page.status.nil?
@@ -47,7 +47,7 @@
 
     .work-page_content
       -if page.work.pages_are_meaningful
-        h4.work-page_title =link_to page.title, page_params(page)
+        h4.work-page_title =link_to page.title, page_params(page), onclick: "resultClicked();"
 
       .work-page_text[*language_attrs(@collection)]
         -transcription = xml_to_html(page.xml_text, false)
@@ -66,7 +66,7 @@
               ==transcription.force_encoding('utf-8')
             .incomplete_text
               b ==t('.this_page_is_incomplete')
-              =link_to(t('.help_complete'), action, class: 'button')
+              =link_to(t('.help_complete'), action, class: 'button', onclick: "resultClicked();")
           -else
             ==transcription.force_encoding('utf-8')
 
@@ -75,10 +75,10 @@
             -if @collection.active?
               -if page.work.ocr_correction
                 -status = t('.corrected')
-                -help = link_to(t('.help_correct'), action)
+                -help = link_to(t('.help_correct'), action, onclick: "resultClicked();")
               -else
                 -status = t('.transcribed')
-                -help = link_to(t('.help_transcribe'), action)
+                -help = link_to(t('.help_transcribe'), action, onclick: "resultClicked();")
               p.nodata_text == t('.this_page_is_not', status: status, help: help)
             -else
               p.nodata_text 
@@ -94,12 +94,21 @@
           -elsif translation.present?
             ==translation.force_encoding('utf-8')
           -else
-            -help_translate = link_to(t('.help_translate'), collection_translate_page_path(@collection.owner, @collection, page.work, page))
+            -help_translate = link_to(t('.help_translate'), collection_translate_page_path(@collection.owner, @collection, page.work, page), onclick: "resultClicked();")
             p.nodata_text == t('.page_not_translated', help_translate: help_translate)
 
       -current_version = page.page_versions[0]
       -if current_version && current_version.page_version > 0
         small.work-page_edited
-          -user_link = link_to(current_version.user.display_name, user_profile_path(current_version.user))
+          -user_link = link_to(current_version.user.display_name, user_profile_path(current_version.user), onclick: "resultClicked();")
           -edit_time = distance_of_time_in_words(current_version.created_on, Time.now, include_seconds: true)
           = t('.last_edit', edit_time: edit_time, user_link: user_link).html_safe
+
+-content_for :javascript
+  javascript:
+    function resultClicked() {
+      $.ajax({
+        url: '/search_attempt/click',
+        type: 'GET',
+      })
+    };

--- a/app/views/search_attempt/show.html.slim
+++ b/app/views/search_attempt/show.html.slim
@@ -16,12 +16,12 @@ section.search(style='width: 50%; float: right;')
         .project-list_projects
           .projects-owner
             h3.projects-owner_title
-              =link_to sr.owner.display_name, user_profile_path(sr.owner)
+              =link_to sr.owner.display_name, user_profile_path(sr.owner), onclick: "resultClicked();"
           .projects
             div.projects_details
               .projects_collection
                 h5
-                  =link_to sr.title, collection_path(sr.owner.slug, sr.id)
+                  =link_to sr.title, collection_path(sr.owner.slug, sr.id), onclick: "resultClicked();"
                 .projects_collection_snippet
                   = to_snippet(sr.intro_block)
     
@@ -31,7 +31,7 @@ section.search(style='width: 50%; float: right;')
         .project-list_projects
           .projects-owner
             h3.projects-owner_title
-              =link_to owner.display_name, user_profile_path(owner)
+              =link_to owner.display_name, user_profile_path(owner), onclick: "resultClicked();"
             -if owner.about.present?
               .description
                 =owner.about
@@ -44,7 +44,16 @@ section.search(style='width: 50%; float: right;')
                     =image_tag(project.picture_url(:thumb), alt: project.title)
                 .projects_collection
                   h5
-                    =link_to project.title, collection_path(owner, project)
+                    =link_to project.title, collection_path(owner, project), onclick: "resultClicked();"
                   -unless snippet.empty?
                     .projects_collection_snippet =snippet
-            .projects_link =link_to t('.more'), user_profile_path(owner)
+            .projects_link =link_to t('.more'), user_profile_path(owner), onclick: "resultClicked();"
+
+-content_for :javascript
+  javascript:
+    function resultClicked() {
+      $.ajax({
+        url: '/search_attempt/click',
+        type: 'GET',
+      })
+    };

--- a/app/views/shared/_breadcrumbs.html.slim
+++ b/app/views/shared/_breadcrumbs.html.slim
@@ -1,14 +1,25 @@
 -path = []
 -if session[:search_attempt_id] && (@collection || @work || @user)
   -search_attempt = SearchAttempt.find(session[:search_attempt_id])
-  -path.push(link_to t('.search_results'), search_attempt_show_path(search_attempt))
+
+  -if search_attempt.search_type == "findaproject"
+    -path.push(link_to t('.search_results'), search_attempt_show_path(search_attempt))
 -if @document_set && @document_set.title.present? && (@work || @article)
   -path.push(link_to @document_set.title, document_set_path(@document_set.owner, @document_set))
 -elsif @collection && @collection.title.present? && (@work || @article)
   -path.push(link_to @collection.title, collection_path(@collection.owner, @collection))
 
+-if search_attempt && search_attempt.search_type == "collection-title" && (@work || @page || @article)
+  -path.push(link_to t('.search_results'), collection_path(@collection.owner, @collection.slug, search_attempt_id: search_attempt.id))
+
 -if @work && @work.title.present? && (@page || @article)
   -path.push(link_to @work.title, collection_read_work_path(@collection.owner, @collection, @work))
+
+-if search_attempt && (@page || @article)
+  -if search_attempt.search_type == "collection" 
+    -path.push(link_to t('.search_results'), paged_search_path(search_attempt))
+  -elsif search_attempt.search_type == "work" && (@page || @article)
+    -path.push(link_to t('.search_results'), paged_search_path(search_attempt))
 
 -if path.present? && @quality_sampling.nil?
   -unless (controller_name == 'transcribe' && @collection && @work && @page && current_page?(collection_oneoff_review_page_path(@collection.owner, @collection, @page))) || (@work && @page && @user && current_page?(collection_user_review_page_path))

--- a/config/locales/admin/admin-en.yml
+++ b/config/locales/admin/admin-en.yml
@@ -100,7 +100,13 @@ en:
       owner: Owner
       owner_filter: Filter to only transcribers
       query: Query
+      search_type:
+        collection: Collection
+        collection-title: Title / Metadata
+        findaproject: Find a Project
+        work: Work
       start_date: Start date
+      type: Type
       user: User
     settings:
       flag_blacklist: 'Terms to flag as potential abusive content:'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -211,6 +211,7 @@ Fromthepage::Application.routes.draw do
 
   scope 'search_attempt', as: 'search_attempt' do
     get 'create', to: 'search_attempt#create'
+    get 'click', to: 'search_attempt#click'
     get ':id', to: 'search_attempt#show', as: 'show'
   end
 
@@ -340,8 +341,7 @@ Fromthepage::Application.routes.draw do
   get 'guest_dashboard' => 'dashboard#guest'
   get 'findaproject', to: 'dashboard#landing_page', as: :landing_page
   get 'collections', to: 'dashboard#collections_list', as: :collections_list
-  post 'display_search', to: 'display#search'
-  get 'paged_search', to: 'display#paged_search'
+  get 'paged_search/:id', to: 'display#paged_search', as: :paged_search
   get 'demo', to: 'demo#index'
 
   scope 'feature', as: 'feature' do

--- a/db/migrate/20230804144422_add_collections_and_works_to_search_attempts.rb
+++ b/db/migrate/20230804144422_add_collections_and_works_to_search_attempts.rb
@@ -1,0 +1,7 @@
+class AddCollectionsAndWorksToSearchAttempts < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :search_attempts, :collection, null: true
+    add_reference :search_attempts, :work, null: true
+    add_column :search_attempts, :search_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_02_141742) do
+ActiveRecord::Schema.define(version: 2023_08_04_144422) do
 
   create_table "ahoy_activity_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.datetime "date"
@@ -657,9 +657,14 @@ ActiveRecord::Schema.define(version: 2023_08_02_141742) do
     t.bigint "user_id"
     t.boolean "owner", default: false
     t.string "slug"
+    t.bigint "collection_id"
+    t.bigint "work_id"
+    t.string "search_type"
+    t.index ["collection_id"], name: "index_search_attempts_on_collection_id"
     t.index ["slug"], name: "index_search_attempts_on_slug", unique: true
     t.index ["user_id"], name: "index_search_attempts_on_user_id"
     t.index ["visit_id"], name: "index_search_attempts_on_visit_id"
+    t.index ["work_id"], name: "index_search_attempts_on_work_id"
   end
 
   create_table "sections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|


### PR DESCRIPTION
_Resolves #3730_

This tracks searches on collections by text, works by text, and collections by title/metadata. It does so using the same `SearchAttempt` model used for Find a Project searches. The search results pages are unchanged and remain on the `collection#paged_search` and `collection#show` pages. However, the backend now goes through the `search_attempt#create` action to record the search, and the results pages use this SearchAttempt object to find the search's results.

I also improved  search result click tracking to be much more straightforward and reliable. Clicking on a search result calls a JavaScript method (via `onclick`) which calls a `search_attempt#click` action via AJAX.

### Breadcrumbs

Collection/work search results also have breadcrumbs to return to search results once a result is clicked.

![breadcrumbs](https://github.com/benwbrum/fromthepage/assets/35716893/d1abfcbe-11af-4b26-a5b2-4e8014b11b1a)

### Admin tracking

I split the searches/day and average hits statistics into Find a Project searches and collection/work searches.

![admin stats](https://github.com/benwbrum/fromthepage/assets/35716893/d9b90cb6-574e-4e87-9a52-e2601089b700)

The searches table now has fields for search type, collection, and work. You can filter by search type!

![admin table](https://github.com/benwbrum/fromthepage/assets/35716893/e8e33e43-029c-4688-b552-055ea881659d)

The csv searches export now has fields for search type, collection id, collection title, work id, and work title.

![export](https://github.com/benwbrum/fromthepage/assets/35716893/d82124c4-a4fb-4330-8b72-46a63dbde921)

