### PR TITLE
Added collection notes bulk export for #3738

### DIFF
--- a/app/controllers/bulk_export_controller.rb
+++ b/app/controllers/bulk_export_controller.rb
@@ -124,6 +124,7 @@ class BulkExportController < ApplicationController
         :work_id,
         :include_metadata, 
         :include_contributors,
+        :collection_notes,
         :report_arguments => [
           :start_date, 
           :end_date, 

--- a/app/controllers/concerns/export_service.rb
+++ b/app/controllers/concerns/export_service.rb
@@ -151,6 +151,12 @@ module ExportService
     out.write(export_tables_as_csv(work))
   end
 
+  def export_collection_notes_csv(out:, collection:)
+    path = "collection_notes.csv"
+    out.put_next_entry(path)
+    out.write(export_notes_as_csv(collection))
+  end
+
   def export_tei(work:, out:, export_user:, by_work:, original_filenames:)
     if by_work
       path = File.join(path_from_work(work, original_filenames), 'tei', "tei.xml")
@@ -787,5 +793,33 @@ private
     csv
   end
 
+  def export_notes_as_csv(collection)
+    headers = [
+      :note,
+      :contributor,
+      :page_link,
+      :page_title,
+      :work_title,
+      :date
+    ]
 
+    notes = collection.notes.order(created_at: :desc)
+    rows = notes.map {|n|
+      [
+        n.body,
+        n.user.display_name,
+        collection_display_page_url(n.collection.owner, n.collection, n.work, n.page.id),
+        n.page.title,
+        n.work.title,
+        n.created_at
+      ]
+    }
+
+    csv = CSV.generate(:headers => true) do |records|
+      records << headers
+      rows.each do |row|
+          records << row
+      end
+    end
+  end
 end

--- a/app/helpers/export_helper.rb
+++ b/app/helpers/export_helper.rb
@@ -99,6 +99,10 @@ module ExportHelper
       export_static_site(dirname: 'site', out: out, collection: bulk_export.collection)
     end
 
+    if bulk_export.collection_notes
+      export_collection_notes_csv(out: out, collection: bulk_export.collection)
+    end
+
     if bulk_export.work_level? || bulk_export.page_level?
       by_work = bulk_export.organization == BulkExport::Organization::WORK_THEN_FORMAT
       original_filenames = bulk_export.use_uploaded_filename

--- a/app/views/export/index.html.slim
+++ b/app/views/export/index.html.slim
@@ -19,6 +19,16 @@ p.big
         span =t('.export_to_contentdm')
     span =t('.export_to_contentdm_description')
 
+h2 =t('.export_all_notes')
+=form_for :bulk_export, url: bulk_export_create_path(collection_id: @collection.id) do |f|
+  =f.hidden_field :collection_notes, value: true
+  p.big
+    span.fright(style="margin-left: 30px")
+      =link_to '#', class: 'button btnExport', id: 'btnExportNotes', onclick: "$(this).closest('form').submit();" do
+        =svg_symbol '#icon-export', class: 'icon'
+        span =t('.export_all_notes_as_csv')      
+    span =t('.export_all_notes_description')
+
 -if @collection.text_entry?
   h2 =t('.export_individual_works')
   p.big =t('.export_individual_works_description')

--- a/config/locales/export/export-de.yml
+++ b/config/locales/export/export-de.yml
@@ -13,6 +13,9 @@ de:
       export_metadata: FromThePage-Export von %{work} aus %{collection} von %{time}.
     index:
       api: API
+      export_all_notes: Alle Notizen exportieren
+      export_all_notes_as_csv: Alle Notizen als CSV exportieren
+      export_all_notes_description: Exportieren Sie alle Notizen aus der gesamten Sammlung in eine CSV-Datei.
       export_all_works: Alle Werke exportieren
       export_all_works_description: Wählen Sie Formate und spezifische Einstellungen aus, um die gesamte Sammlung in eine ZIP-Datei zu exportieren.
       export_as: Exportieren als

--- a/config/locales/export/export-en.yml
+++ b/config/locales/export/export-en.yml
@@ -13,6 +13,9 @@ en:
       export_metadata: FromThePage export of %{work} from %{collection} made on %{time}.
     index:
       api: API
+      export_all_notes: Export All Notes
+      export_all_notes_as_csv: Export All Notes as CSV
+      export_all_notes_description: Export all notes from the entire collection in a CSV file.
       export_all_works: Export All Works
       export_all_works_description: Choose formats and granularities to export the entire collection in a zip file.
       export_as: Export As

--- a/config/locales/export/export-es.yml
+++ b/config/locales/export/export-es.yml
@@ -13,6 +13,9 @@ es:
       export_metadata: Exportación FromThePage de %{work} desde %{collection} realizada en %{time}.
     index:
       api: API
+      export_all_notes: Exportar todas las notas
+      export_all_notes_as_csv: Exportar todas las notas como CSV
+      export_all_notes_description: Exporte todas las notas de toda la colección en un archivo CSV.
       export_all_works: Exportar todo el contenido
       export_all_works_description: Elije los formatos y las granularidades para exportar toda la colección en un archivo zip.
       export_as: Exportar como

--- a/config/locales/export/export-fr.yml
+++ b/config/locales/export/export-fr.yml
@@ -13,6 +13,9 @@ fr:
       export_metadata: Exportation FromThePage de %{work} à partir de %{collection} effectuée sur %{time}.
     index:
       api: API
+      export_all_notes: Exporter toutes les notes
+      export_all_notes_as_csv: Exporter toutes les notes au format CSV
+      export_all_notes_description: Exportez toutes les notes de l'ensemble de la collection dans un fichier CSV.
       export_all_works: Exporter toutes les œuvres
       export_all_works_description: Choisir les formats et les granularités pour exporter toute la collection dans un fichier zip.
       export_as: Exporter sous

--- a/config/locales/export/export-pt.yml
+++ b/config/locales/export/export-pt.yml
@@ -13,6 +13,9 @@ pt:
       export_metadata: Exportação FromThePage de %{work} de %{collection} feita em %{time}.
     index:
       api: API
+      export_all_notes: Exportar todas as notas
+      export_all_notes_as_csv: Exportar todas as notas como CSV
+      export_all_notes_description: Exporte todas as notas de toda a coleção em um arquivo CSV.
       export_all_works: Exportar todo o trabalho
       export_all_works_description: Escolha formatos e granularidades para exportar toda a coleção em um arquivo zip.
       export_as: Exportar como

--- a/db/migrate/20230814171021_add_collection_notes_to_bulk_exports.rb
+++ b/db/migrate/20230814171021_add_collection_notes_to_bulk_exports.rb
@@ -1,0 +1,5 @@
+class AddCollectionNotesToBulkExports < ActiveRecord::Migration[6.0]
+  def change
+    add_column :bulk_exports, :collection_notes, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -111,6 +111,7 @@ ActiveRecord::Schema.define(version: 2023_06_01_130844) do
     t.boolean "collection_activity"
     t.boolean "collection_contributors"
     t.string "report_arguments"
+    t.boolean "collection_notes"
     t.index ["collection_id"], name: "index_bulk_exports_on_collection_id"
     t.index ["document_set_id"], name: "index_bulk_exports_on_document_set_id"
     t.index ["user_id"], name: "index_bulk_exports_on_user_id"
@@ -1117,6 +1118,7 @@ ActiveRecord::Schema.define(version: 2023_06_01_130844) do
     t.index ["slug"], name: "index_works_on_slug", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "bulk_exports", "collections"
   add_foreign_key "bulk_exports", "document_sets"
   add_foreign_key "bulk_exports", "users"


### PR DESCRIPTION
_Resolves #3738_ 

This adds a bulk export for all notes in a collection, to allow project owners to preserve & review notes.

The export is located on the collection export page:

![export page](https://github.com/benwbrum/fromthepage/assets/35716893/c0381e18-218c-4c59-a1a5-ebcfa5f834a5)

And here's how the exported CSV file looks, with the Utah Birth Certificates collection as example:

![export csv](https://github.com/benwbrum/fromthepage/assets/35716893/a78da8b6-7e1e-4063-b9d4-b522568e28fe)
