### PR TITLE
Implemented DataTables to deed list for #3739

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -337,7 +337,7 @@ Object.assign(DataTable.defaults, {
 
   "drawCallback": function(oSettings) {
     // don't show pagination if only one page
-    if (oSettings._iDisplayLength > oSettings.fnRecordsDisplay() || oSettings._iDisplayLength == -1) {
+    if (oSettings._iDisplayLength >= oSettings.fnRecordsDisplay() || oSettings._iDisplayLength == -1) {
         $(oSettings.nTableWrapper).find('.dataTables_paginate').hide();
     } else {
         $(oSettings.nTableWrapper).find('.dataTables_paginate').show();

--- a/app/views/deed/list.html.slim
+++ b/app/views/deed/list.html.slim
@@ -14,27 +14,50 @@ h1 =t('.activity_stream')
   -else
     h3 =t('.user_title', title: @user.display_name)
 
-table.datagrid.striped
-  -@deeds.each do |d|
-    tr
-      td
-        =link_to(user_profile_path(d.user), class: 'userpic userpic-small')
-          =profile_picture(d.user)
-      td.w100.toleft
-        -if @collection.nil?
-          -if d.collection.show_to?(current_user) || (d.work && d.work.access_object(current_user))
-            =render(:partial => 'deed/deed.html', :locals => { :deed => d, :long_view => true })
+table.datagrid.striped#deeds-list
+  thead 
+    th
+    th= t('.deed')
+    th= t('.type')
+    th= t('.time')
+  tbody
+    -@deeds.each do |d|
+      tr
+        td
+          =link_to(user_profile_path(d.user), class: 'userpic userpic-small')
+            =profile_picture(d.user)
+        td.w100.toleft
+          -if @collection.nil?
+            -if d.collection.show_to?(current_user) || (d.work && d.work.access_object(current_user))
+              =render(:partial => 'deed/deed.html', :locals => { :deed => d, :long_view => true })
+            -else
+              =raw(strip_tags(render(:partial => 'deed/deed.html', :locals => { :deed => d, :long_view => true })))
           -else
-            =raw(strip_tags(render(:partial => 'deed/deed.html', :locals => { :deed => d, :long_view => true })))
-        -else
-          =render(:partial => 'deed/deed.html', :locals => { :deed => d, :long_view => true, :suppress_collection => true })
-          
-      td
-        small.label(class="deed-type-#{d.deed_type}") =t(d.deed_type_name)
-      td.nowrap
-        =time_tag(d.created_at, class: 'small fglight')
-          =t('.time_ago_in_words', time: time_ago_in_words(d.created_at))
-br
-small.legend
-  =will_paginate @deeds, { :class => 'deed-pager', :page_links => false, :previous_label => t('.newer_activity'), :next_label => t('.older_activity') }
-br
+            =render(:partial => 'deed/deed.html', :locals => { :deed => d, :long_view => true, :suppress_collection => true })
+            
+        td
+          small.label(class="deed-type-#{d.deed_type}") =t(d.deed_type_name)
+        td.nowrap (data-order="#{d.created_at.to_i}")
+          =time_tag(d.created_at, class: 'small fglight')
+            =t('.time_ago_in_words', time: time_ago_in_words(d.created_at))
+
+-content_for :javascript
+  javascript:
+    $(document).ready( function () {
+      console.log("Hey");
+      // initialize the works list datatable
+      $('#deeds-list').DataTable( {
+        // don't allow sorting on the user icon column
+        'columnDefs': [ {
+          'targets': [0], 
+          'orderable': false, 
+        } ],
+        // Initially sort by recency
+        "order": [[3, 'desc']]
+      } );
+
+      // fix the layout of the pagination controls
+      $('select[name="deeds-list_length"]').parent().before('Show ');
+      $('select[name="deeds-list_length"]').parent().after(' entries');
+
+    } );


### PR DESCRIPTION
_Resolves #3739_

This is meant to solve filtering/searching collection notes by implementing DataTables which comes with a search. Because the notes list is made by filtering the deed list to only notes, I just edited the deed list to use DataTables.

Here's the notes list, it can quickly be filtered and sorted:
![image](https://github.com/benwbrum/fromthepage/assets/35716893/2a5a8a9a-5c9a-46f5-8c44-52c5c24c24c7)

And this also changes the all deeds list:
![image](https://github.com/benwbrum/fromthepage/assets/35716893/d2f5b4f1-6dd9-42e3-a833-252eb74499d4)

If we don't want to change the deeds list, I can separate it from the notes list.