### PR TITLE
Don't let transcribers remove works on docset works list for #3769

### DIFF
--- a/app/views/document_sets/_set_works.html.slim
+++ b/app/views/document_sets/_set_works.html.slim
@@ -1,30 +1,40 @@
-=form_for :document_set, url: document_set_remove_from_set_path, method: :get do |f|
-  =hidden_field_tag :collection_id, @collection.slug
-  table#works-list.collection-work-stats.datagrid.striped
-    thead 
-      th =t('.work_title')
-      th =t('.progress')
-      th.progress_bar
-      th.nowrap =t('.most_recent_activity')
-      th.nowrap =t('.collaboration')
+-if user_signed_in? && current_user.like_owner?(@collection)
+  =form_for :document_set, url: document_set_remove_from_set_path, method: :get, html:{ id: 'document_set' } do |f|
+    =hidden_field_tag :collection_id, @collection.slug
+
+table#works-list.collection-work-stats.datagrid.striped
+  thead 
+    th =t('.work_title')
+    th =t('.progress')
+    th.progress_bar
+    th.nowrap =t('.most_recent_activity')
+    th.nowrap =t('.collaboration')
+    -if user_signed_in? && current_user.like_owner?(@collection)
       th.nowrap =t('.remove_from_set')
-    tbody
-      -@works.each do |w|
-        tr.document_set
-          -work_stats(w)
-          td =link_to w.title, collection_read_work_path(w.collection.owner, w.collection, w)
-          td (data-order="#{w.work_statistic.complete}")
-            = t('.n_pages', count: w.work_statistic.total_pages)
-            = @wording
-          td.w15
-            =render partial: 'shared/progress', locals: { collection: @collection}
-          -most_recent_activity = w.deeds.first&.created_at || w.created_on
-          td (data-order="#{most_recent_activity.to_i}")
-            =l(most_recent_activity, format: :short)
-          td =w.restrict_scribes  ? t('.restricted') : t('.unrestricted')
-          td =check_box_tag("work[#{w.id}]", "work[#{w.id}]", false,{"title" => t('.remove_title_from_document_set', title: w.title)})
+    -else
+      th
+  tbody
+    -@works.each do |w|
+      tr.document_set
+        -work_stats(w)
+        td =link_to w.title, collection_read_work_path(w.collection.owner, w.collection, w)
+        td (data-order="#{w.work_statistic.complete}")
+          = t('.n_pages', count: w.work_statistic.total_pages)
+          = @wording
+        td.w15
+          =render partial: 'shared/progress', locals: { collection: @collection}
+        -most_recent_activity = w.deeds.first&.created_at || w.created_on
+        td (data-order="#{most_recent_activity.to_i}")
+          =l(most_recent_activity, format: :short)
+        td =w.restrict_scribes  ? t('.restricted') : t('.unrestricted')
+        -if user_signed_in? && current_user.like_owner?(@collection)
+          td =check_box_tag("work[#{w.id}]", "work[#{w.id}]", false, {form: 'document_set', "title" => t('.remove_title_from_document_set', title: w.title)})
+        -else
+          td
+
+-if user_signed_in? && current_user.like_owner?(@collection) 
   br
-  .aright =button_tag t('.remove_works')
+  .aright =button_tag t('.remove_works'), form: 'document_set'
 
 -content_for :javascript
   javascript:


### PR DESCRIPTION
_Fixes #3769_

Transcribers can't see the 'Remove from set' column anymore:
![image](https://github.com/benwbrum/fromthepage/assets/35716893/cd44acbd-3b0a-4b39-8af2-2ef559626d07)

and the `remove_from_set` form is gone altogether from their HTML. 

The owner view remains the same, functionality intact.
