### PR TITLE
Only use datatables on collection notes list for #3776

### DIFF
--- a/app/controllers/deed_controller.rb
+++ b/app/controllers/deed_controller.rb
@@ -42,13 +42,16 @@ class DeedController < ApplicationController
     end
 
     @deeds = @deed.order('deeds.created_at DESC').paginate :page => params[:page], :per_page => PAGES_PER_SCREEN
+    @paginate = true
   end
 
   def notes
     if @collection
-      @deeds = @collection.deeds.where(deed_type: DeedType::NOTE_ADDED).order('deeds.created_at DESC').includes(:note, :page, :user, :work, :collection).paginate :page => params[:page], :per_page => PAGES_PER_SCREEN
+      @deeds = @collection.deeds.where(deed_type: DeedType::NOTE_ADDED).order('deeds.created_at DESC').includes(:note, :page, :user, :work, :collection)
+      @paginate = false
     else
       @deeds = Deed.where(deed_type: DeedType::NOTE_ADDED).order('deeds.created_at DESC').joins(:collection).includes(:note, :page, :user, :work).where("collections.restricted = 0").paginate :page => params[:page], :per_page => PAGES_PER_SCREEN
+      @paginate = true
     end
     render :list
   end

--- a/app/views/deed/list.html.slim
+++ b/app/views/deed/list.html.slim
@@ -40,24 +40,29 @@ table.datagrid.striped#deeds-list
         td.nowrap (data-order="#{d.created_at.to_i}")
           =time_tag(d.created_at, class: 'small fglight')
             =t('.time_ago_in_words', time: time_ago_in_words(d.created_at))
+-if @paginate
+  br
+  small.legend
+    =will_paginate @deeds, { :class => 'deed-pager', :page_links => false, :previous_label => t('.newer_activity'), :next_label => t('.older_activity') }
+  br
 
--content_for :javascript
-  javascript:
-    $(document).ready( function () {
-      console.log("Hey");
-      // initialize the works list datatable
-      $('#deeds-list').DataTable( {
-        // don't allow sorting on the user icon column
-        'columnDefs': [ {
-          'targets': [0], 
-          'orderable': false, 
-        } ],
-        // Initially sort by recency
-        "order": [[3, 'desc']]
+-else
+  -content_for :javascript
+    javascript:
+      $(document).ready( function () {
+        // initialize the works list datatable
+        $('#deeds-list').DataTable( {
+          // don't allow sorting on the user icon column
+          'columnDefs': [ {
+            'targets': [0], 
+            'orderable': false, 
+          } ],
+          // Initially sort by recency
+          "order": [[3, 'desc']]
+        } );
+
+        // fix the layout of the pagination controls
+        $('select[name="deeds-list_length"]').parent().before('Show ');
+        $('select[name="deeds-list_length"]').parent().after(' entries');
+
       } );
-
-      // fix the layout of the pagination controls
-      $('select[name="deeds-list_length"]').parent().before('Show ');
-      $('select[name="deeds-list_length"]').parent().after(' entries');
-
-    } );

--- a/config/locales/deed/deed-de.yml
+++ b/config/locales/deed/deed-de.yml
@@ -13,6 +13,8 @@ de:
       activity_stream: Aktivitätenüberblick
       collection_title: 'Sammlung: %{title}'
       deed: Tat
+      newer_activity: Neuere Aktivität
+      older_activity: Ältere Aktivität
       owner_title: 'Projektinhaber:in: %{title}'
       time: Zeit
       time_ago_in_words: Vor %{time}

--- a/config/locales/deed/deed-en.yml
+++ b/config/locales/deed/deed-en.yml
@@ -37,6 +37,8 @@ en:
       activity_stream: Activity Stream
       collection_title: 'Collection: %{title}'
       deed: Deed
+      newer_activity: Newer Activity
+      older_activity: Older Activity
       owner_title: 'Owner: %{title}'
       time: Time
       time_ago_in_words: "%{time} ago"

--- a/config/locales/deed/deed-es.yml
+++ b/config/locales/deed/deed-es.yml
@@ -35,6 +35,8 @@ es:
       activity_stream: Flujo de Actividad
       collection_title: 'Colección: %{title}'
       deed: Escritura
+      newer_activity: Actividad más reciente
+      older_activity: Actividad anterior
       owner_title: 'Propietario: %{title}'
       time: Tiempo
       time_ago_in_words: Hace %{time}

--- a/config/locales/deed/deed-fr.yml
+++ b/config/locales/deed/deed-fr.yml
@@ -37,6 +37,8 @@ fr:
       activity_stream: Flux d'activité
       collection_title: 'Collection : %{title}'
       deed: Acte
+      newer_activity: Activité plus récente
+      older_activity: Activité plus ancienne
       owner_title: 'Propriétaire : %{title}'
       time: Temps
       time_ago_in_words: Il y a %{time}

--- a/config/locales/deed/deed-pt.yml
+++ b/config/locales/deed/deed-pt.yml
@@ -35,6 +35,8 @@ pt:
       activity_stream: Fluxo de Atividade
       collection_title: 'Coleção: %{title}'
       deed: Obra
+      newer_activity: Atividade mais recente
+      older_activity: Atividade mais antiga
       owner_title: 'Proprietário: %{title}'
       time: Tempo
       time_ago_in_words: Há %{time}


### PR DESCRIPTION
This (temporarily?) addresses two issues:
1. All deed & note lists were being truncated to 50 items because the `.paginate` call was mistakenly still being called on them. 
2. If they were not being truncated, there would be major performance issues with loading a large amount of rows without pagination.

The notes list for a collection -- the focus of #3739 -- is still using DataTables & will now load _all_ notes on a collection. I tested this with around 500 entries and had no performance issues.

Deeds lists, and notes lists without a collection, are back to using `will_paginate` as per usual, no DataTables, so there won't be any performance issues on long lists.