### PR TITLE
Added document sets to search attempts for #3775

### DIFF
--- a/app/controllers/display_controller.rb
+++ b/app/controllers/display_controller.rb
@@ -113,7 +113,7 @@ class DisplayController < ApplicationController
         session[:search_attempt_id] = @search_attempt.id
       end
       # restrict to pages that include that subject
-      @collection = @search_attempt.collection
+      @collection = @search_attempt.collection || @search_attempt.document_set || @search_attempt.work.collection
       @work = @search_attempt&.work
       pages = @search_attempt.results
       @pages = pages.paginate(page: params[:page])

--- a/app/views/admin/searches.html.slim
+++ b/app/views/admin/searches.html.slim
@@ -33,20 +33,13 @@ table.admin-grid.datagrid.striped
     -@searches.each do |search|
       tr
         td.toleft
-          -if search.search_type == 'findaproject'
-            -link = search_attempt_show_path(search)
-          -elsif search.search_type == 'collection'
-            -link = paged_search_path(search)
-          -elsif search.search_type == 'collection-title'
-            -link = collection_path(search.collection.owner, search.collection.slug, search_attempt_id: search.id)
-          -else #Work
-            -link = paged_search_path(search)
-
-          div =link_to search.query, link
+          div =link_to search.query, search.results_link
         td.nowrap =t(".search_type.#{search.search_type}")
         td
           -if search.collection 
             =link_to search.collection.title, collection_path(search.collection.owner, search.collection)
+          -elsif search.document_set 
+            =link_to search.document_set.title, collection_path(search.document_set.owner, search.document_set)
           -elsif search.work
             =link_to search.work.collection.title, collection_path(search.work.collection.owner, search.work.collection)
         td 

--- a/app/views/collection/show.html.slim
+++ b/app/views/collection/show.html.slim
@@ -91,13 +91,19 @@
         =link_to @collection.owner.display_name, user_profile_path(@collection.owner)
 
     =form_tag({:controller => 'search_attempt', :action => 'create'}, :method => :get, class: 'collection-search') do
-      =hidden_field_tag('collection_id', @collection.slug)
+      -if @collection.is_a?(DocumentSet)
+        =hidden_field_tag('document_set_id', @collection.slug)
+      -else
+        =hidden_field_tag('collection_id', @collection.slug)
       =search_field_tag :search, nil, placeholder: t('.search_the_text'), "aria-label" => t('.search_the_text_1')
       =button_tag t('.search')
       =label_tag 'search_string', t('.search_the_text_1'), class: 'hidden'
 
     =form_tag({:controller => 'search_attempt', :action => 'create'}, method: :get, enforce_utf8: false, class: 'collection-search') do
-      =hidden_field_tag('collection_id', @collection.slug, {:id => "collection id for search work"})
+      -if @collection.is_a?(DocumentSet)
+        =hidden_field_tag('document_set_id', @collection.slug, {:id => "document set id for search work"})
+      -else
+        =hidden_field_tag('collection_id', @collection.slug, {:id => "collection id for search work"})
       =search_field_tag :search_by_title, @search_attemp&.query, placeholder: t('.search_by_title'), "aria-label" => t('.search_by_title_1')
       =button_tag t('.search')
       =label_tag 'search', t('.search_by_title_1'), class: 'hidden'

--- a/app/views/shared/_breadcrumbs.html.slim
+++ b/app/views/shared/_breadcrumbs.html.slim
@@ -15,11 +15,8 @@
 -if @work && @work.title.present? && (@page || @article)
   -path.push(link_to @work.title, collection_read_work_path(@collection.owner, @collection, @work))
 
--if search_attempt && (@page || @article)
-  -if search_attempt.search_type == "collection" 
-    -path.push(link_to t('.search_results'), paged_search_path(search_attempt))
-  -elsif search_attempt.search_type == "work" && (@page || @article)
-    -path.push(link_to t('.search_results'), paged_search_path(search_attempt))
+-if search_attempt && (@page || @article) && search_attempt.search_type == "collection" || search_attempt.search_type == "work"
+  -path.push(link_to t('.search_results'), paged_search_path(search_attempt))
 
 -if path.present? && @quality_sampling.nil?
   -unless (controller_name == 'transcribe' && @collection && @work && @page && current_page?(collection_oneoff_review_page_path(@collection.owner, @collection, @page))) || (@work && @page && @user && current_page?(collection_user_review_page_path))

--- a/app/views/shared/_breadcrumbs.html.slim
+++ b/app/views/shared/_breadcrumbs.html.slim
@@ -15,7 +15,7 @@
 -if @work && @work.title.present? && (@page || @article)
   -path.push(link_to @work.title, collection_read_work_path(@collection.owner, @collection, @work))
 
--if search_attempt && (@page || @article) && search_attempt.search_type == "collection" || search_attempt.search_type == "work"
+-if search_attempt && (@page || @article) && (search_attempt.search_type == "collection" || search_attempt.search_type == "work")
   -path.push(link_to t('.search_results'), paged_search_path(search_attempt))
 
 -if path.present? && @quality_sampling.nil?

--- a/db/migrate/20230911200902_add_document_sets_to_search_attempts.rb
+++ b/db/migrate/20230911200902_add_document_sets_to_search_attempts.rb
@@ -1,0 +1,5 @@
+class AddDocumentSetsToSearchAttempts < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :search_attempts, :document_set, null: true
+  end
+end


### PR DESCRIPTION
_Resolves #3775_

This adds a `document_set_id` field to `SearchAttempts` so that any document sets that are searched on are not coerced into the 
`collection` field. In result, this fixes the bug where searching on a document set can redirect to a search on the _collection_ with the same ID or slug. 
Some of the search attempt logic was also cleaned up & simplified in the process 😊