### PR TITLE
Implemented server-side datatables for notes list for #3790

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,3 +125,5 @@ gem 'intercom', '~> 3.9.0'
 gem 'newrelic_rpm'
 
 gem 'open3'
+
+gem 'ajax-datatables-rails', '~> 1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
       safely_block (>= 0.2.1)
     airbrussh (1.4.1)
       sshkit (>= 1.6.1, != 1.7.0)
+    ajax-datatables-rails (1.0.0)
+      railties (>= 4.2)
     akami (1.3.1)
       gyoku (>= 0.4.0)
       nokogiri
@@ -597,6 +599,7 @@ DEPENDENCIES
   acts_as_list
   acts_as_tree
   ahoy_matey
+  ajax-datatables-rails (~> 1.0.0)
   autoprefixer-rails
   better_errors
   binding_of_caller

--- a/app/controllers/deed_controller.rb
+++ b/app/controllers/deed_controller.rb
@@ -42,19 +42,6 @@ class DeedController < ApplicationController
     end
 
     @deeds = @deed.order('deeds.created_at DESC').paginate :page => params[:page], :per_page => PAGES_PER_SCREEN
-    @paginate = true
   end
-
-  def notes
-    if @collection
-      @deeds = @collection.deeds.where(deed_type: DeedType::NOTE_ADDED).order('deeds.created_at DESC').includes(:note, :page, :user, :work, :collection)
-      @paginate = false
-    else
-      @deeds = Deed.where(deed_type: DeedType::NOTE_ADDED).order('deeds.created_at DESC').joins(:collection).includes(:note, :page, :user, :work).where("collections.restricted = 0").paginate :page => params[:page], :per_page => PAGES_PER_SCREEN
-      @paginate = true
-    end
-    render :list
-  end
-
 
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -77,6 +77,19 @@ class NotesController < ApplicationController
     @pages = @collection.pages.where.not(last_note_updated_at: nil).reorder(last_note_updated_at: :desc).paginate :page => params[:page], :per_page => PAGES_PER_SCREEN
   end
 
+  def list
+    respond_to do |format|
+      format.html
+      format.json { 
+        render json: NoteDatatable.new(
+          params, 
+          view_context: view_context, 
+          collection_id: params[:collection_id]
+        ) 
+      }
+    end
+  end
+
   private
 
   def note_params

--- a/app/datatables/note_datatable.rb
+++ b/app/datatables/note_datatable.rb
@@ -1,0 +1,71 @@
+class NoteDatatable < AjaxDatatablesRails::ActiveRecord 
+  extend Forwardable
+
+  def_delegators :@view, 
+    :link_to, 
+    :time_tag,
+    :time_ago_in_words,
+    :collection_display_page_path,
+    :collection_read_work_path,
+    :collection_path,
+    :user_profile_path
+
+  def initialize(params, options = {})
+    @view = options[:view_context]
+    @collection = Collection.find(options[:collection_id]) if options[:collection_id]
+    super 
+  end
+
+  def view_columns
+    @view_columns ||= {
+      userpic:    { searchable: false, orderable: false },
+      user:       { source: "User.display_name"},      
+      note:       { source: "Note.title"},
+      page:       { source: "Page.title"},
+      work:       { source: "Work.title"},
+      collection: { source: "Collection.title" },
+      time:       { source: "Note.created_at" }
+    }
+  end
+
+  def data
+    records.map do |record|
+      {
+        userpic:    userpic(record),
+        user:       link_to(record.user&.display_name, user_profile_path(record.user)),
+        note:       record.title,
+        page:       link_to(record.page.title, collection_display_page_path(record.collection.owner, record.collection, record.work, record.page)),
+        work:       link_to(record.work.title, collection_read_work_path(record.collection.owner, record.collection, record.work)),
+        collection: link_to(record.collection.title, collection_path(record.collection.owner, record.collection)),
+        time:       timestamp(record)
+      }
+    end
+  end
+
+  def get_raw_records
+    if @collection
+      @collection.notes
+        .joins(:collection, :page, :work, :user)
+        .reorder('')
+    else
+      Note.includes(:collection).where("collections.restricted = 0")
+        .joins(:collection, :page, :work, :user)
+        .reorder('')
+    end
+  end
+
+  private
+
+  def userpic(record)
+    link_to user_profile_path(record.user) do
+      ActionController::Base.new.render_to_string("shared/_profile_picture", :locals => { :user => record.user, :gravatar_size => nil })
+    end
+  end
+
+  def timestamp(record)
+    time_tag(record.created_at, class: 'small fglight') do
+      I18n.t('time_ago_in_words', time: time_ago_in_words(record.created_at))
+    end
+  end
+
+end

--- a/app/views/admin/index.html.slim
+++ b/app/views/admin/index.html.slim
@@ -40,7 +40,7 @@ table.admin-grid.datagrid.striped
   =link_to admin_work_list_path do
     .counter.link(data-prefix="#{number_with_delimiter @works_count}") #{'Work'.pluralize(@works_count)}
   .counter(data-prefix="#{number_with_delimiter @articles_count}") #{'Article'.pluralize(@articles_count)}
-  =link_to deed_notes_path do
+  =link_to notes_list_path do
     .counter.link(data-prefix="#{number_with_delimiter @notes_count}") #{'Note'.pluralize(@notes_count)}
   .counter
   =link_to admin_owner_list_path do

--- a/app/views/collection/show.html.slim
+++ b/app/views/collection/show.html.slim
@@ -133,7 +133,7 @@
           span.deed-short_content
             ==t('.user_wrote_note', user: user, note: text)
     small.legend
-      =link_to t('.show_more'), deed_notes_path(@collection.slug), class: 'button outline round'
+      =link_to t('.show_more'), notes_list_path(collection_id: @collection.slug), class: 'button outline round'
 
     h3 =t('.recent_edits')
     -cache @collection.most_recent_deed_created_at do

--- a/app/views/deed/list.html.slim
+++ b/app/views/deed/list.html.slim
@@ -40,29 +40,7 @@ table.datagrid.striped#deeds-list
         td.nowrap (data-order="#{d.created_at.to_i}")
           =time_tag(d.created_at, class: 'small fglight')
             =t('.time_ago_in_words', time: time_ago_in_words(d.created_at))
--if @paginate
-  br
-  small.legend
-    =will_paginate @deeds, { :class => 'deed-pager', :page_links => false, :previous_label => t('.newer_activity'), :next_label => t('.older_activity') }
-  br
-
--else
-  -content_for :javascript
-    javascript:
-      $(document).ready( function () {
-        // initialize the works list datatable
-        $('#deeds-list').DataTable( {
-          // don't allow sorting on the user icon column
-          'columnDefs': [ {
-            'targets': [0], 
-            'orderable': false, 
-          } ],
-          // Initially sort by recency
-          "order": [[3, 'desc']]
-        } );
-
-        // fix the layout of the pagination controls
-        $('select[name="deeds-list_length"]').parent().before('Show ');
-        $('select[name="deeds-list_length"]').parent().after(' entries');
-
-      } );
+br
+small.legend
+  =will_paginate @deeds, { :class => 'deed-pager', :page_links => false, :previous_label => t('.newer_activity'), :next_label => t('.older_activity') }
+br

--- a/app/views/notes/list.html.slim
+++ b/app/views/notes/list.html.slim
@@ -1,0 +1,75 @@
+-content_for :page_title
+  =t('.notes')
+  -if @collection
+    =" - #{@collection.title}"
+
+h1 =t('.notes')
+-if @collection
+  h3 =t('.collection_title', title: @collection.title)
+
+-if @collection
+  -source = notes_list_path(format: :json, collection_id: @collection.slug)
+-else
+  -source = notes_list_path(format: :json)
+table.datagrid.striped#notes-list(data-source="#{source}")
+  thead 
+    th
+    th= t('.user')
+    th= t('.note')
+    th= t('.page')
+    th= t('.work')
+    th= t('.collection')
+    th= t('.time')
+  tbody
+
+-if @collection
+  -content_for :javascript
+    javascript: 
+      $(document).ready ( function() {
+        showCollection = false;
+      })
+-else
+  -content_for :javascript
+    javascript: 
+      $(document).ready ( function() {
+        showCollection = true;
+      })
+-content_for :javascript
+  javascript:
+    $(document).ready( function () {
+      // initialize the notes list datatable
+      $('#notes-list').DataTable( {
+        // server-side processing
+        "serverSide": true,
+        "ajax": {
+          "url": $('#deeds-list').data('source')
+        },
+        "columns": [
+          {"data": "userpic", "name": "userpic"},
+          {"data": "user", "name": "user"},
+          {"data": "note", "name": "note"},
+          {"data": "page", "name": "page"},
+          {"data": "work", "name": "work"},
+          {"data": "collection", "name": "collection"},
+          {"data": "time", "name": "time"}
+        ],
+
+        // don't allow sorting on the user icon column
+        'columnDefs': [ { 'targets': [0], 'orderable': false } ],
+        // Initially sort by recency
+        "order": [[6, 'desc']],
+
+        // hide the collection column for the collection notes list
+        "drawCallback": function( settings ) {
+          if (showCollection) {
+            $('#notes-list').DataTable().column(5).visible(true);
+          } else {
+            $('#notes-list').DataTable().column(5).visible(false);
+          }
+        }
+      } );
+
+      // fix the layout of the pagination controls
+      $('select[name="notes-list_length"]').parent().before('Show ');
+      $('select[name="notes-list_length"]').parent().after(' entries');
+    } );

--- a/config/initializers/ajax_datatables_rails.rb
+++ b/config/initializers/ajax_datatables_rails.rb
@@ -1,0 +1,3 @@
+AjaxDatatablesRails.configure do |config|
+    config.db_adapter = :mysql
+end

--- a/config/locales/notes/notes-de.yml
+++ b/config/locales/notes/notes-de.yml
@@ -21,7 +21,7 @@ de:
       page: Seite
       time: Zeit
       user: Benutzer
-      work: Arbeiten
+      work: Werk
     note:
       cancel: Abbrechen
       confirm_delete_message: Möchten Sie diese Anmerkung wirklich löschen?

--- a/config/locales/notes/notes-de.yml
+++ b/config/locales/notes/notes-de.yml
@@ -13,6 +13,15 @@ de:
       page_notes: Seitenanmerkungen
       pages_and_notes_counts: "%{posts_count} Anmerkungen auf %{topics_count} Seiten"
       total_notes: "%{count} Anmerkungen"
+    list:
+      collection: Sammlung
+      collection_title: 'Sammlung: %{title}'
+      note: Notiz
+      notes: Anmerkungen
+      page: Seite
+      time: Zeit
+      user: Benutzer
+      work: Arbeiten
     note:
       cancel: Abbrechen
       confirm_delete_message: Möchten Sie diese Anmerkung wirklich löschen?

--- a/config/locales/notes/notes-en.yml
+++ b/config/locales/notes/notes-en.yml
@@ -13,6 +13,15 @@ en:
       page_notes: Page Notes
       pages_and_notes_counts: "%{posts_count} notes on %{topics_count} pages"
       total_notes: "%{count} notes"
+    list:
+      collection: Collection
+      collection_title: 'Collection: %{title}'
+      note: Note
+      notes: Notes
+      page: Page
+      time: Time
+      user: User
+      work: Work
     note:
       cancel: Cancel
       confirm_delete_message: Are you sure you want to delete this note?

--- a/config/locales/notes/notes-es.yml
+++ b/config/locales/notes/notes-es.yml
@@ -13,6 +13,15 @@ es:
       page_notes: Notas de página
       pages_and_notes_counts: "%{posts_count} notas en %{topics_count} páginas"
       total_notes: "%{count} notas"
+    list:
+      collection: Recopilación
+      collection_title: 'Colección: %{title}'
+      note: Nota
+      notes: Notas
+      page: Página
+      time: Tiempo
+      user: Usuario
+      work: Trabajar
     note:
       cancel: Cancelar
       confirm_delete_message: Confirma que deseas eliminar esta nota.

--- a/config/locales/notes/notes-es.yml
+++ b/config/locales/notes/notes-es.yml
@@ -21,7 +21,7 @@ es:
       page: Página
       time: Tiempo
       user: Usuario
-      work: Trabajar
+      work: Obra
     note:
       cancel: Cancelar
       confirm_delete_message: Confirma que deseas eliminar esta nota.

--- a/config/locales/notes/notes-fr.yml
+++ b/config/locales/notes/notes-fr.yml
@@ -13,6 +13,15 @@ fr:
       page_notes: Remarques sur les pages
       pages_and_notes_counts: "%{posts_count} notes sur %{topics_count} pages"
       total_notes: "%{count} remarques"
+    list:
+      collection: Collection
+      collection_title: Collecte : %{title}
+      note: Note
+      notes: Remarques
+      page: Page
+      time: Temps
+      user: Utilisateur
+      work: Travail
     note:
       cancel: Annuler
       confirm_delete_message: Voulez-vous vraiment supprimer cette note ?

--- a/config/locales/notes/notes-fr.yml
+++ b/config/locales/notes/notes-fr.yml
@@ -21,7 +21,7 @@ fr:
       page: Page
       time: Temps
       user: Utilisateur
-      work: Travail
+      work: Œuvre
     note:
       cancel: Annuler
       confirm_delete_message: Voulez-vous vraiment supprimer cette note ?

--- a/config/locales/notes/notes-pt.yml
+++ b/config/locales/notes/notes-pt.yml
@@ -13,6 +13,15 @@ pt:
       page_notes: Notas de página
       pages_and_notes_counts: "%{posts_count} notas em %{topics_count} páginas"
       total_notes: "%{count} notas"
+    list:
+      collection: Coleção
+      collection_title: 'Coleção: %{title}'
+      note: Observação
+      notes: Notas
+      page: Página
+      time: Tempo
+      user: Do utilizador
+      work: Trabalhar
     note:
       cancel: Cancelar
       confirm_delete_message: Você tem certeza que deseja apagar esta nota?

--- a/config/locales/notes/notes-pt.yml
+++ b/config/locales/notes/notes-pt.yml
@@ -21,7 +21,7 @@ pt:
       page: Página
       time: Tempo
       user: Do utilizador
-      work: Trabalhar
+      work: Obra
     note:
       cancel: Cancelar
       confirm_delete_message: Você tem certeza que deseja apagar esta nota?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,9 @@ Fromthepage::Application.routes.draw do
 
   iiif_for 'riiif/image', at: '/image-service'
 
+  scope 'notes', as: 'notes' do
+    get 'list(/:collection_id)', to: 'notes#list', as: 'list'
+  end
   resources :notes
 
 
@@ -239,7 +242,6 @@ Fromthepage::Application.routes.draw do
 
   scope 'deed', as: 'deed' do
     get 'list', to: 'deed#list'
-    get 'notes(/:collection_id)', to: 'deed#notes', as: 'notes'
   end
 
   scope 'static', as: 'static' do

--- a/spec/models/deed_spec.rb
+++ b/spec/models/deed_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Deed, type: :model do
       allow_any_instance_of(Deed).to receive(:calculate_prerender_mailer)
 
       first_deed = create(:deed, deed_type: deed_type)
+      sleep 0.5
       second_deed = create(:deed, deed_type: deed_type)
 
       expect(Deed.order_by_recent_activity.first).to eq(second_deed)


### PR DESCRIPTION
_Resolves #3790_

After implementing DataTables on the notes & deeds list, these pages have performance issues on long lists because all of the rows must be loaded by the server at once.
To fix this, this PR changes the notes DataTable to use [server-side processing](https://datatables.net/manual/server-side). This means that the server only loads the currently displayed rows at once, eliminating the issue for large tables. This also means that all sorting and searching is handled on the server-side instead of the client-side, resulting in a slower UI (but it's consistent over all table lengths!)

I used the [ajax-datatables-rails](https://github.com/jbox-web/ajax-datatables-rails) gem, which handles a majority of the server-side processing. 

I split the deeds list and notes list, so the deeds list is always paginated and the notes list is always a DataTable. Now, the notes list has individual sortable columns rather than one large "deed" column. 

The notes list for a collection:
![image](https://github.com/benwbrum/fromthepage/assets/35716893/14d134be-1048-4f29-890c-46e65c95a021)

The all notes list:
![image](https://github.com/benwbrum/fromthepage/assets/35716893/4ed51943-e5a2-4773-86e1-6f38cd3af602)



