### PR TITLE
First pass at supporting CDM vanity URLs for #3791

### DIFF
--- a/lib/contentdm_translator.rb
+++ b/lib/contentdm_translator.rb
@@ -110,7 +110,7 @@ module ContentdmTranslator
 
 
   def self.iiif_manifest_is_cdm?(at_id)
-    at_id.match(/contentdm.oclc.org/)
+    at_id.match(/contentdm.oclc.org/) || at_id.match(/iiif\/info\/\w+\/\d+\/manifest.json/)
   end
 
   def self.cdm_item_info_from_iiif(at_id)


### PR DESCRIPTION
Closes #3791

Note that this will need to be tested in production, as other problems may occur as after-effects of the changes to CONTENTdm URLs.