### PR TITLE
Encoding parameters and capistrano directory for #1603

### DIFF
--- a/config/database.travis.yml
+++ b/config/database.travis.yml
@@ -1,7 +1,8 @@
 test:
   database: test
   adapter: mysql2
-  encoding: utf8
+  encoding: utf8mb4
+  collation: utf8mb4_unicode_ci
   username: travis
   variables:
     sql_mode: TRADITIONAL

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -27,7 +27,7 @@ set :linked_files, %w{config.ru config/database.yml config/environments/producti
 
 # Default value for linked_dirs is []
 # set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
-set :linked_dirs, ["log", "public/images/working", "public/uploads", "tmp", "public/images/uploaded", "public/images/fordham", "public/images/zebrapedia"]
+set :linked_dirs, ["log", "public/images/working", "public/uploads", "tmp", "public/images/uploaded", "public/images/fordham", "public/images/zebrapedia", "public/text"]
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }


### PR DESCRIPTION
Change the encoding of the database adapter to actually use fixes for #1603 