### PR TITLE
"Rebound" effect in OpenSeadragon viewer

### DIFF
--- a/app/views/shared/_osd_div.html.slim
+++ b/app/views/shared/_osd_div.html.slim
@@ -74,7 +74,7 @@
         previousButton: "osd_prev",
         nextButton: "osd_next",
         maxZoomPixelRatio: 10,
-        visibilityRatio: 1,
+        visibilityRatio: 0.5,
         fitBounds: true,
         preserveViewport: true,
         showReferenceStrip: #{@page.nil?},


### PR DESCRIPTION
This small PR addresses issue #3247: the bounce-back effect that users experience when dragging the image outside of the viewer area.

The effect is controlled by OpenSeadragons's `visibilityRatio` init argument. In your current setting (visibilityRatio = 1), OpenSeadragon will attempt to bounce the image back to a state where __the viewer shows no empty background.__ Consequently, if users have a narrow viewport set, then attempts to drag the image to an "extreme edge" position  (as reported in issue #3247) can easily lead to this effect.

- user drags the image slightly out of the image
- the inertial bounce-back effect pushes the image back (possibly overshooting the original starting position)

The easiest way to address this is to set `visibilityRatio` to a more relaxed setting, like 0.5. This instructs OSD to allow 50% of empty background before bouncing the image back, thus preventing the effect in most cases. (0.5 is actually the default. Therefore you could also remove the init argument in this particular case!)

An alternative approach (not implemented in this PR!) would be to combine:

```
visibilityRatio: 1,
constrainDuringPan: true
```

This will prohibit empty background in OSD altogether, and apply the constraint immediately during panning. I.e. there is no way to ever push the image out of the viewer, and there is no inertial rebound effect that bounces the image back. Instead, the image just stops as soon as the user reaches the edge.

An example of this combination is shown at the [official OSD docs here](https://openseadragon.github.io/examples/ui-zoom-and-pan/). 