### PR TITLE
Removed 'fitBounds' init parameter

### DIFF
--- a/app/views/shared/_osd_div.html.slim
+++ b/app/views/shared/_osd_div.html.slim
@@ -75,7 +75,6 @@
         nextButton: "osd_next",
         maxZoomPixelRatio: 10,
         visibilityRatio: 0.5,
-        fitBounds: true,
         preserveViewport: true,
         showReferenceStrip: #{@page.nil?},
         referenceStripScroll: 'vertical',


### PR DESCRIPTION
## In this PR

This small PR removes the unused `fitBounds` parameter from the OpenSeadragon initialization.