### PR TITLE
Suppress text exports for blank pages in #4019

### DIFF
--- a/app/controllers/concerns/export_service.rb
+++ b/app/controllers/concerns/export_service.rb
@@ -231,15 +231,15 @@ module ExportService
     case name
     when "verbatim"
       out.put_next_entry path
-      out.write page.verbatim_transcription_plaintext
+      out.write page.verbatim_transcription_plaintext if page.status != Page::STATUS_BLANK
     when "expanded"
       if page.collection.subjects_disabled
         out.put_next_entry path
-        out.write page.emended_transcription_plaintext
+        out.write page.emended_transcription_plaintext if page.status != Page::STATUS_BLANK
       end
     when "searchable"
       out.put_next_entry path
-      out.write page.search_text      
+      out.write page.search_text if page.status != Page::STATUS_BLANK
     end
   end
 
@@ -254,11 +254,11 @@ module ExportService
       case name
       when "verbatim"
         out.put_next_entry path
-        out.write page.verbatim_translation_plaintext
+        out.write page.verbatim_translation_plaintext if page.status != Page::STATUS_BLANK
       when "expanded"
         if page.collection.subjects_disabled
           out.put_next_entry path
-          out.write page.emended_translation_plaintext
+          out.write page.emended_translation_plaintext if page.status != Page::STATUS_BLANK
         end
       end
     end
@@ -344,7 +344,7 @@ module ExportService
     out.put_next_entry path
 
     page_view = xml_to_html(page.xml_text, true, false, page.work.collection)
-    out.write page_view
+    out.write page_view if page.status != Page::STATUS_BLANK
   end
 
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -162,7 +162,7 @@ class Work < ApplicationRecord
   end
 
   def verbatim_transcription_plaintext
-    self.pages.map { |page| page.verbatim_transcription_plaintext}.join("\n\n\n")
+    self.pages.select{|page| page.status != Page::STATUS_BLANK}.map{ |page| page.verbatim_transcription_plaintext}.join("\n\n\n")
   end
 
   def verbatim_translation_plaintext
@@ -170,7 +170,7 @@ class Work < ApplicationRecord
   end
 
   def emended_transcription_plaintext
-    self.pages.map { |page| page.emended_transcription_plaintext}.join("\n\n\n")
+    self.pages.select{|page| page.status != Page::STATUS_BLANK}.map { |page| page.emended_transcription_plaintext}.join("\n\n\n")
   end
 
   def emended_translation_plaintext
@@ -178,7 +178,7 @@ class Work < ApplicationRecord
   end
 
   def searchable_plaintext
-    self.pages.map { |page| page.search_text}.join("\n\n\n")
+    self.pages.select{|page| page.status != Page::STATUS_BLANK}.map { |page| page.search_text}.join("\n\n\n")
   end
 
   def suggest_next_page_title

--- a/app/views/export/facing_edition.html.erb
+++ b/app/views/export/facing_edition.html.erb
@@ -36,7 +36,9 @@
 <% end %>
 
 ### <%= page.title %>
+<% if page.status != Page::STATUS_BLANK %>
 <%= raw(xml_to_pandoc_md(page.xml_text, @preserve_linebreaks, true)) %>
+<% end %>
 
 <% if @work.supports_translation && !page.xml_translation.blank?%>
 ### <%= page.title %>

--- a/app/views/export/show.html.erb
+++ b/app/views/export/show.html.erb
@@ -26,11 +26,13 @@
       <div id="page-<%=page.id%>">
         <h3><a name="page-<%=page.id%>"><%= page.title %></a></h3>
         <div class="page-content">
-          <% if @target == :jekyll %>
-            <% puts page.id %>
-            <%= raw(xml_to_html(page.xml_text, false, :jekyll)) %>
-          <% else %>
-            <%= raw(xml_to_html(page.xml_text, true, true)) %>
+          <% if page.status != Page::STATUS_BLANK %>
+            <% if @target == :jekyll %>
+              <% puts page.id %>
+              <%= raw(xml_to_html(page.xml_text, false, :jekyll)) %>
+            <% else %>
+              <%= raw(xml_to_html(page.xml_text, true, true)) %>
+            <% end %>
           <% end %>
         </div>
 

--- a/app/views/export/tei.html.erb
+++ b/app/views/export/tei.html.erb
@@ -295,7 +295,9 @@ xml:id="export">
           <div xml:id="<%=page_id_to_xml_id(page.id, @context.translation_mode)%>">
         <% end%>
           <fw type="pageNum"><%= page.title %></fw>
-          <%= raw(xml_to_export_tei(page.xml_text, @context, page.id, true))%>
+          <% if page.status != Page::STATUS_BLANK %>
+            <%= raw(xml_to_export_tei(page.xml_text, @context, page.id, true))%>
+          <% end %>
           <% notes = page.notes %>
           <% if notes && notes.length > 0 %>
             <% notes.each do |note| %>
@@ -328,7 +330,9 @@ xml:id="export">
         <div xml:id="<%=page_id_to_xml_id(page.id, @context.translation_mode)%>">
       <% end%>
         <fw type="pageNum"><%= page.title %></fw>
-        <%= raw(xml_to_export_tei(page.xml_text, @context, page.id))%>
+        <% if page.status != Page::STATUS_BLANK %>
+          <%= raw(xml_to_export_tei(page.xml_text, @context, page.id, true))%>
+        <% end %>
         <% notes = page.notes %>
         <% if notes && notes.length > 0 %>
           <% notes.each do |note| %>

--- a/app/views/export/text.html.erb
+++ b/app/views/export/text.html.erb
@@ -24,7 +24,9 @@
       <div id="page-<%=page.id%>">
         <h3><%= page.title %></h3>
         <div class="page-content">
-          <%= raw(xml_to_html(page.xml_text, true, true)) %>
+          <% if page.status != Page::STATUS_BLANK %>
+            <%= raw(xml_to_html(page.xml_text, true, true)) %>
+          <% end %>
         </div>
         <% if page.notes.present? %>
           <div class="page-notes">

--- a/app/views/export/transcript.html.erb
+++ b/app/views/export/transcript.html.erb
@@ -24,7 +24,9 @@
       <div id="page-<%=page.id%>">
         <h3><%= page.title %></h3>
         <div class="page-content">
-          <%= raw(xml_to_html(page.xml_text, true, true)) %>
+          <% if page.status != Page::STATUS_BLANK %>
+            <%= raw(xml_to_html(page.xml_text, true, true)) %>
+          <% end %>
         </div>
         <% if page.notes.present? %>
           <div class="page-notes">


### PR DESCRIPTION
Closes #4019 by suppressing blank page text exports in *all formats*.