### PR TITLE
Mostly fixes regression caused by #4037; removes js error

### DIFF
--- a/app/views/transcribe/display_page.html.slim
+++ b/app/views/transcribe/display_page.html.slim
@@ -89,6 +89,8 @@
               =f.text_field :title
           -if !@collection.field_based
             =f.text_area(:source_text, class: 'page-editarea_textarea', autocomplete: "off", autocorrect: "off", autocapitalize: "off", spellcheck: @collection.enable_spellcheck, 'aria-label': t('.edit_transcription'))
+            -text_direction = Rtl.rtl?(@collection.text_language) ? 'rtl' : 'ltr'  
+            =render({ :partial => '/shared/codemirror', :locals => { :textarea => "page_source_text", :text_direction => text_direction} })
           -else
             =render ({partial: 'transcription_field/field_layout', locals: {collection_id: @collection, transcribe: true}})
 
@@ -101,8 +103,6 @@ h2.legend =t('.notes_and_questions')
 .page-notes
   =render :partial => "notes/notes"
 
--text_direction = Rtl.rtl?(@collection.text_language) ? 'rtl' : 'ltr'  
-=render({ :partial => '/shared/codemirror', :locals => { :textarea => "page_source_text", :text_direction => text_direction} })
 
 #custom-alert
   #custom-alert-box
@@ -157,6 +157,16 @@ h2.legend =t('.notes_and_questions')
       $('[data-layout-set]').on('click', function() {
         var mode = $(this).data('layout-set');
         Cookies.set('transcribe_layout_mode', mode, { expires: 365 });
+
+        window.removeEventListener('scroll', freezeTableColumn);
+        window.addEventListener('scroll', function (e) {
+          if(mode === 'ttb') {
+            freezeTableColumn('.page-imagescan', '.spreadsheet', '.ht_clone_top');
+          } else {
+            freezeTableColumn('.page-toolbar', '.spreadsheet', '.ht_clone_top');
+          } 
+        });
+
         $('[data-layout-mode]').attr('data-layout-mode', mode);
 
         if (typeof viewer !== 'undefined') {


### PR DESCRIPTION
Addresses #4037.  Removes JS error for non-Codemirror transcription.  

To test loading side-by-side pages with headers once deployed.