### PR TITLE
Fixed highlight bug on #4098

### DIFF
--- a/app/controllers/display_controller.rb
+++ b/app/controllers/display_controller.rb
@@ -117,6 +117,7 @@ class DisplayController < ApplicationController
       @work = @search_attempt&.work
       pages = @search_attempt.results
       @pages = pages.paginate(page: params[:page])
+      @search_string = "\"#{params[:id].split("-")[0]}\""
     end
     logger.debug "DEBUG #{@search_string}"
   end


### PR DESCRIPTION
After some investigation, I found an empty string was passed into highlight function. 
I added search_string to else case.  It works well now! 

![image](https://github.com/benwbrum/fromthepage/assets/159004143/476c1a9f-7578-47ce-a28b-0ec3814d4968)


Closes #4098