### PR TITLE
4074 - Validate html before saving

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -40,6 +40,10 @@ class Collection < ApplicationRecord
   has_many :ahoy_activity_summaries
 
   validates :title, presence: true, length: { minimum: 3, maximum: 255 }
+  validates :intro_block, html: { message: ->(_, _) { I18n.t('errors.html_syntax_error') } },
+                          length: { maximum: 16.megabytes - 1 }
+  validates :footer_block, html: { message: ->(_, _) { I18n.t('errors.html_syntax_error') } },
+                           length: { maximum: 16.megabytes - 1 }
   validates :slug, format: { with: /[[:alpha:]]/ }
 
   before_create :set_transcription_conventions
@@ -89,12 +93,12 @@ class Collection < ApplicationRecord
   def text_and_metadata_entry?
     self.data_entry_type == DataEntryType::TEXT_AND_METADATA
   end
-  
+
   def subjects_enabled
     !subjects_disabled
   end
 
-  module ReviewType 
+  module ReviewType
     OPTIONAL = 'optional'
     REQUIRED = 'required'
     RESTRICTED = 'restricted'

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -57,6 +57,8 @@ class Work < ApplicationRecord
 
   validates :title, presence: true, length: { minimum: 3, maximum: 255 }
   validates :slug, uniqueness: { case_sensitive: true }, format: { with: /[-_[:alpha:]]/ }
+  validates :description, html: { message: ->(_, _) { I18n.t('errors.html_syntax_error') } },
+                          length: { maximum: 16.megabytes - 1 }
   validate :document_date_is_edtf
 
   mount_uploader :picture, PictureUploader

--- a/app/validators/html_validator.rb
+++ b/app/validators/html_validator.rb
@@ -3,7 +3,7 @@ class HtmlValidator < ActiveModel::EachValidator
     return unless value&.match?(/<[^>]+>/) # Regex to check if it follows html syntax
 
     begin
-      REXML::Document.new(value)
+      REXML::Document.new("<html>#{value}</html>")
     rescue REXML::ParseException
       message = options[:message] || :html_syntax_error
       record.errors.add(attribute, message)

--- a/app/validators/html_validator.rb
+++ b/app/validators/html_validator.rb
@@ -1,0 +1,12 @@
+class HtmlValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return unless value&.match?(/<[^>]+>/) # Regex to check if it follows html syntax
+
+    begin
+      REXML::Document.new(value)
+    rescue REXML::ParseException
+      message = options[:message] || :html_syntax_error
+      record.errors.add(attribute, message)
+    end
+  end
+end

--- a/config/locales/activerecord/activerecord-de.yml
+++ b/config/locales/activerecord/activerecord-de.yml
@@ -3,6 +3,7 @@ de:
   activerecord:
     attributes:
       collection:
+        intro_block: Beschreibung
         slug: URL
         title: Titel
       document_set:

--- a/config/locales/activerecord/activerecord-en.yml
+++ b/config/locales/activerecord/activerecord-en.yml
@@ -3,6 +3,7 @@ en:
   activerecord:
     attributes:
       collection:
+        intro_block: Description
         slug: URL
         title: Title
       document_set:

--- a/config/locales/activerecord/activerecord-es.yml
+++ b/config/locales/activerecord/activerecord-es.yml
@@ -3,6 +3,7 @@ es:
   activerecord:
     attributes:
       collection:
+        intro_block: Descripción
         slug: URL
         title: Título
       document_set:

--- a/config/locales/activerecord/activerecord-fr.yml
+++ b/config/locales/activerecord/activerecord-fr.yml
@@ -3,6 +3,7 @@ fr:
   activerecord:
     attributes:
       collection:
+        intro_block: Description
         slug: URL
         title: Titre
       document_set:

--- a/config/locales/activerecord/activerecord-pt.yml
+++ b/config/locales/activerecord/activerecord-pt.yml
@@ -3,6 +3,7 @@ pt:
   activerecord:
     attributes:
       collection:
+        intro_block: Descrição
         slug: URL
         title: Titulo
       document_set:

--- a/config/locales/errors/errors-de.yml
+++ b/config/locales/errors/errors-de.yml
@@ -1,0 +1,4 @@
+---
+de:
+  errors:
+    html_syntax_error: ungültige html-syntax

--- a/config/locales/errors/errors-en.yml
+++ b/config/locales/errors/errors-en.yml
@@ -1,0 +1,4 @@
+---
+en:
+  errors:
+    html_syntax_error: invalid html syntax

--- a/config/locales/errors/errors-es.yml
+++ b/config/locales/errors/errors-es.yml
@@ -1,0 +1,4 @@
+---
+es:
+  errors:
+    html_syntax_error: sintaxis html inválida

--- a/config/locales/errors/errors-fr.yml
+++ b/config/locales/errors/errors-fr.yml
@@ -1,0 +1,4 @@
+---
+fr:
+  errors:
+    html_syntax_error: syntaxe html invalide

--- a/config/locales/errors/errors-pt.yml
+++ b/config/locales/errors/errors-pt.yml
@@ -1,0 +1,4 @@
+---
+pt:
+  errors:
+    html_syntax_error: sintaxe html inválida


### PR DESCRIPTION
Based on issue #4074 

Added a reusable html_validator that utilizes `REXML::ParseException` to handle invalid html syntax.

Usage:
```
class YourModel < ApplicationRecord
   validates :your_field, html: true
```

Optionally we can pass specific messages (useful for model-specific translations):
```
class YourModel < ApplicationRecord
   validates :your_field, html: { message: 'Custom error message' }
```


html_validator component can have more features in future such as adding validation for limiting number of characters EXCLUDING html tags so I decided in favor of making it it's own validator class.