### PR TITLE
3484 - Select all works on document set edit screen

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -23,5 +23,4 @@
 //= link datatables.min.js
 //= link annotorious/annotorious-openseadragon.js
 //= link annotorious/annotorious-openseadragon-textlayer.js
-
-
+//= link select_all.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,6 +18,7 @@
 //= require handsontable.full.min
 //= require datatables.min
 //= require clipboard
+//= require select_all
 
 ;(function($, window, document, undefined) {
 
@@ -289,6 +290,8 @@ $(function() {
   $('[data-assign-categories]').categoriesSelect();
 
   $('[data-multi-select]').multiSelect();
+
+  $('[data-select-all]').selectAll();
 
   // Category tree expand/collapse
   $('.tree-bullet').on('click', function(e) {

--- a/app/assets/javascripts/select_all.js
+++ b/app/assets/javascripts/select_all.js
@@ -1,0 +1,18 @@
+(function($) {
+  $.fn.selectAll = function() {
+    return this.each(function() {
+      var $selectAllCheckbox = $(this);
+      var $classSelector = $selectAllCheckbox.attr('data-select-all');
+      var $checkboxes = $(`input:checkbox.${$classSelector}`);
+
+      $selectAllCheckbox.on('change', function() {
+        var isChecked = $(this).prop('checked');
+        $checkboxes.prop('checked', isChecked);
+      });
+
+      $checkboxes.on('click', function() {
+        $selectAllCheckbox.prop('checked', false);
+      });
+    });
+  };
+})(jQuery);

--- a/app/views/document_sets/index.html.slim
+++ b/app/views/document_sets/index.html.slim
@@ -50,6 +50,7 @@ br
           th =t('.status')
           -@collection.document_sets.each do |document_set|
             th
+              =check_box_tag(nil, nil, false, style: 'margin-right: 5px;', data: { select_all: "document_set_#{document_set.id}" })
               =document_set.title
               /! consider making this header vertical or rotate 45 degrees via css so that long document set titles do not mess up the display
       tbody
@@ -73,7 +74,7 @@ br
             -ids = work.document_sets.ids
             -@collection.document_sets.each do |document_set|
               td
-                =check_box_tag("work_assignment[#{work.slug}][#{document_set.slug}]", "true", ids.include?(document_set.id), {"title"=>t('.toggle_work_in_document_set', work: work.title, document_set: document_set.title)})
+                =check_box_tag("work_assignment[#{work.slug}][#{document_set.slug}]", "true", ids.include?(document_set.id), title: t('.toggle_work_in_document_set', work: work.title, document_set: document_set.title), class: "document_set_#{document_set.id}")
     br
     =hidden_field_tag(:page, params[:page])
     =submit_tag t('.save')

--- a/app/views/document_sets/settings.html.slim
+++ b/app/views/document_sets/settings.html.slim
@@ -7,7 +7,7 @@
     =render 'edit'
 
     h2#manage =t('.manage_works')
-    
+
     =form_tag(collection_settings_path(@collection.owner, @collection), method: :get, enforce_utf8: false, class: 'collection-search') do
       =validation_summary @collection.errors
       =hidden_field_tag('collection_id', @collection.slug)
@@ -24,14 +24,16 @@
           tr
             th =t('.work')
             th =t('.status')
-            th =t('.add')
+            th
+              =check_box_tag(nil, nil, false, style: 'margin: 0 5px 0 7px;', data: { select_all: 'works' })
+              =t('.add')
         tbody
           -@works.each do |work|
             tr
               td
                 =work.title
                 -if work.supports_translation
-                  span 
+                  span
                     translate
                 -if work.ia_work && work.ia_work.use_ocr
                   span
@@ -50,7 +52,7 @@
                       span(style="width:#{@progress_review}%")
 
               td.document_set
-                =check_box_tag("work[#{work.id}]", "work[#{work.id}]", false, {"title" => t('.add_work_title_to_document_set', work_title: work.title)})
+                =check_box_tag("work[#{work.id}]", "work[#{work.id}]", false, { title: t('.add_work_title_to_document_set', work_title: work.title), class: 'works' })
       br
       .aright
         =submit_tag t('.save')

--- a/app/views/sc_collections/explore_collection.html.slim
+++ b/app/views/sc_collections/explore_collection.html.slim
@@ -1,7 +1,7 @@
 .columns
   article.maincol
     h4= t('.collection', sc_collection: (@sc_collection.label))
-    .iiif-import 
+    .iiif-import
       p= t('.id', id: (@sc_collection.at_id))
 
     .iiif-collection
@@ -24,7 +24,7 @@
     -unless @sc_collection.v3?
       -if @sc_collection.service['first'] || @sc_collection.service['next'] || @sc_collection.service['prev']
         p= t('.this_collection_is_divided')
-        -if @sc_collection.service['first']  
+        -if @sc_collection.service['first']
           =link_to t('.first_page'), {:action => 'explore_collection', :at_id => (@sc_collection.service['first']['@id'] || @sc_collection.service['first'])}
         -if @sc_collection.service['next']
           =link_to t('.next_page'), {:action => 'explore_collection', :at_id => (@sc_collection.service['next']['@id']||@sc_collection.service['next'])}
@@ -45,7 +45,7 @@
           =select_tag :collection_id, target_collection_options(new_collection), id: 'manifest_import', prompt: t('.select_a_collection_to_import_into'), required: true, 'aria-label' => t('.select_a_collection')
           =button_tag t('.import_checked_manifests')
 
-        =check_box_tag("select_all", 1, true)
+        =check_box_tag("select_all", 1, true, data: { select_all: 'manifest_checks' })
         |&nbsp;&nbsp;
         =label_tag 'select_all', t('.select_all_manifests')
 
@@ -93,20 +93,3 @@
               };
           });
         });
-
-        $(function(){
-          $('#select_all').on('change', function(){
-            if (this.checked){
-              $('.manifest_checks').prop('checked', true);
-            } else if (!this.checked) {
-              $('.manifest_checks').prop('checked', false);
-            }
-          });
-        });
-
-        $(function(){
-          $('.manifest_checks').on('click', function(){
-            $('#select_all').prop('checked', false);
-          });
-        });
-

--- a/spec/features/document_sets_spec.rb
+++ b/spec/features/document_sets_spec.rb
@@ -29,23 +29,37 @@ describe "document sets", :order => :defined do
     work.save!
   end
 
-  it "edits a document set (start at collection level)" do
-    login_as(@owner, :scope => :user)
+  it 'edits a document set (start at collection level)', js: true do
+    login_as(@owner, scope: :user)
     visit dashboard_owner_path
     page.find('.maincol').find('a', text: @collection.title).click
-    page.find('.tabs').click_link("Sets")
+    page.find('.tabs').click_link('Sets')
     expect(page).to have_content("Document Sets for #{@collection.title}")
     within(page.find('#sets')) do
       within(page.find('tr', text: @document_sets.first.title)) do
-          page.find('a', text: 'Edit').click
+        page.find('a', text: 'Edit').click
       end
     end
-    page.fill_in 'document_set_title', with: "Edited Test Document Set 1"
+    page.fill_in 'document_set_title', with: 'Edited Test Document Set 1'
     page.find_button('Save Document Set').click
-    expect(DocumentSet.find_by(id: @document_sets.first.id).title).to eq "Edited Test Document Set 1"
+    expect(DocumentSet.find_by(id: @document_sets.first.id).title).to eq 'Edited Test Document Set 1'
     expect(page.find('h1')).to have_content(@document_sets.first.title)
+
+    # Set all checkboxes off
+    page.all('input[type="checkbox"].works', visible: false).each do |checkbox|
+      checkbox.set(false)
+    end
+
+    # Click select all
+    page.find('input[type="checkbox"][data-select-all="works"]', visible: false).check
+    expect(page.find('input[type="checkbox"][data-select-all="works"]', visible: false)).to be_checked
+
+    # Expect all checkboxes are true
+    page.all('input[type="checkbox"].works', visible: false).each do |checkbox|
+      expect(checkbox).to be_checked
+    end
   end
-  
+
   it "makes a document set private" do
     login_as(@owner, :scope => :user)
     #create an additional document set to make private
@@ -185,9 +199,9 @@ describe "document sets", :order => :defined do
 
     # test activity stream for set
     visit collection_path(@set.owner, @set)
-    expect(page).to have_content "Test private note"    
+    expect(page).to have_content "Test private note"
     find("#show-more-deeds").click
-    expect(page).to have_content "Test private note"    
+    expect(page).to have_content "Test private note"
     page.find('a', text: @set.works.first.pages.first.title).click
     expect(page.current_path).to eq collection_display_page_path(@set.owner, @set, @set.works.first, @set.works.first.pages.first)
 
@@ -195,9 +209,9 @@ describe "document sets", :order => :defined do
     # test activity stream for collection
     login_as(@owner, :scope => :user)
     visit collection_path(@set.owner, @set.collection)
-    expect(page).to have_content "Test private note"    
+    expect(page).to have_content "Test private note"
     find("#show-more-deeds").click
-    expect(page).to have_content "Test private note"    
+    expect(page).to have_content "Test private note"
     page.find('a', text: @set.works.first.pages.first.title).click
     expect(page.current_path).to eq collection_display_page_path(@set.owner, @set.collection, @set.works.first, @set.works.first.pages.first)
   end
@@ -436,7 +450,7 @@ describe "document sets", :order => :defined do
     login_as(@owner, :scope => :user)
     visit edit_collection_path(@collection.owner, @collection)
     page.find('.side-tabs').click_link('Look & Feel')
-    page.uncheck('Enable document sets') 
+    page.uncheck('Enable document sets')
     sleep(1)
     expect(page.find_link("Edit Sets")).to match_css('[disabled]')
     expect(Collection.find_by(id: @collection.id).supports_document_sets).to be false
@@ -475,7 +489,7 @@ describe "document sets", :order => :defined do
     @set.works.each do |w|
       expect(page).to have_content w.title
     end
-    #check the old path 
+    #check the old path
     #(this variable is stored at the beginning of the test, so it's the original)
     visit "/#{@owner.slug}/#{@set.slug}"
     expect(page).to have_selector('h1', text: @set.title)


### PR DESCRIPTION
Added select_all.js

USAGE:
1. For the select_all checkbox, add `data-select-all="#{unique_identifier_class}"`, where the value unique_identifier_class is arbitrary.
2. For all checkboxes to be affected, add the unique_identifier_class