### PR TITLE
2527 - Activity emails shouldn't link to "transcribe" page

### DIFF
--- a/app/views/user_mailer/added_note.html.slim
+++ b/app/views/user_mailer/added_note.html.slim
@@ -4,7 +4,7 @@ p= t('.message', work: @page.work.title, collection: @page.collection.title)
 
 p "#{@note.body}"
 
-span =link_to t('user_mailer.click_here'), collection_transcribe_page_url(@page.collection.owner, @page.collection, @page.work, @page, only_path: false)
+span =link_to t('user_mailer.click_here'), collection_display_page_url(@page.collection.owner, @page.collection, @page.work, @page, only_path: false)
 span =t('.html.view_note', collection: @page.collection.title, work: @page.work.title)
 
 -unless @note.collection.owner.display_name.blank?

--- a/app/views/user_mailer/added_note.text.erb
+++ b/app/views/user_mailer/added_note.text.erb
@@ -4,7 +4,7 @@
 
 "<%=@note.body%>"
 
-<%= t('.text.view_note', collection: @page.collection.title, work: @page.work.title, url: (collection_transcribe_page_url(@page.collection.owner, @page.collection, @page.work, @page, only_path: false))) %>
+<%= t('.text.view_note', collection: @page.collection.title, work: @page.work.title, url: (collection_display_page_url(@page.collection.owner, @page.collection, @page.work, @page, only_path: false))) %>
 
 <% unless @note.collection.owner.display_name.blank? %>
     <%= t('user_mailer.text.closing', from: @note.collection.owner.display_name) %>

--- a/app/views/user_mailer/nightly_user_activity.html.slim
+++ b/app/views/user_mailer/nightly_user_activity.html.slim
@@ -15,7 +15,7 @@ p =t('.message')
   p
   h3(style="margin-bottom:0") =t('.new_notes')
   -@user_activity.active_note_pages.each do |page|
-    =link_to t('user_mailer.click_here'), collection_transcribe_page_url(page.collection.owner, page.collection, page.work, page, only_path: false)
+    =link_to t('user_mailer.click_here'), collection_display_page_url(page.collection.owner, page.collection, page.work, page, only_path: false)
     =t('.html.to_view_note', page: page.title, collection: page.work.access_object(@user_activity.user).title, work: page.work.title)
     p
 

--- a/app/views/user_mailer/nightly_user_activity.text.erb
+++ b/app/views/user_mailer/nightly_user_activity.text.erb
@@ -14,7 +14,7 @@
   <%= t('.new_notes') %>
   <% @user_activity.active_note_pages.each do |page| %>
     <%= t('.note_added', work: page.work.title, collection: page.work.collection.title) %>
-    <%= t('.text.to_view_note', work: page.work.title, page: page.title, url: (collection_transcribe_page_url(page.collection.owner, page.collection, page.work, page, only_path: false))) %>
+    <%= t('.text.to_view_note', work: page.work.title, page: page.title, url: (collection_display_page_url(page.collection.owner, page.collection, page.work, page, only_path: false))) %>
   <%end%>
 <%end%>
 


### PR DESCRIPTION
Followed notes from @sylvieed 