### PR TITLE
1682 - Error when viewing notes with no page

### DIFF
--- a/app/datatables/note_datatable.rb
+++ b/app/datatables/note_datatable.rb
@@ -57,7 +57,7 @@ class NoteDatatable < AjaxDatatablesRails::ActiveRecord
           userpic:    userpic(record),
           user:       link_to(record.user&.display_name, user_profile_path(record.user)),
           note:       record.title,
-          page:       link_to(record.page.title, collection_display_page_path(record.collection.owner, record.collection, record.work, record.page)),
+          page:       record.page.nil? ? '' : link_to(record.page.title, collection_display_page_path(record.collection.owner, record.collection, record.work, record.page)),
           work:       link_to(record.work.title, collection_read_work_path(record.collection.owner, record.collection, record.work)),
           collection: link_to(record.collection.title, collection_path(record.collection.owner, record.collection)),
           time:       timestamp(record)
@@ -68,15 +68,10 @@ class NoteDatatable < AjaxDatatablesRails::ActiveRecord
 
   def get_raw_records
     if @collection
-      if @collection.metadata_only_entry?
-        @collection.notes
-          .joins(:collection, :work, :user)
-          .reorder('')
-      else
-        @collection.notes
-          .joins(:collection, :page, :work, :user)
-          .reorder('')
-      end
+      @collection.notes
+        .joins(:collection, :work, :user)
+        .left_outer_joins(:page)
+        .reorder('')
     else
       Note.includes(:collection).where("collections.restricted = 0")
         .joins(:collection, :page, :work, :user)

--- a/app/views/collection/show.html.slim
+++ b/app/views/collection/show.html.slim
@@ -142,6 +142,8 @@
         -else
           -if @collection.text_and_metadata_entry?
             -text = link_to truncate(note_title, :length => 100), metadata_overview_collection_work_path(@collection.owner, @collection, note.work)
+          -elsif note.page.nil?
+            -text = truncate(note_title, :length => 100)
           -else
             -text = link_to truncate(note_title, :length => 100), collection_display_page_path(@collection.owner, @collection, note.work, note.page)
         .deed-short.small


### PR DESCRIPTION
#1682 

It seems the issue is regarding orphaned notes (when page_id: nil).

Approach done here is to render plain text instead of link when note.page.nil


BUT to be more elaborate, need answer to some of these questions:
SHOULD we allow page_id to be nullable in note? (In my local db dump there are 0 notes with page_id: nil. Looking at the notes model though it seems that it can be made for a work and not a page, not sure how this all works so please clarify).
