### PR TITLE
4189 - Missing message when user resets password

### DIFF
--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -26,7 +26,13 @@ module DeviseHelper
     errors = if resource.errors.empty?
                flash_alerts
              else
-               resource.errors.messages.map { |key, msg| "#{I18n.t("devise.errors.keys.#{key}")} #{msg.first}" }
+               resource.errors.messages.map do |key, msg|
+                 if key == :reset_password_token
+                   I18n.t('devise.errors.messages.reset_password.invalid_token')
+                 else
+                   "#{I18n.t("devise.errors.keys.#{key}")} #{msg.first}"
+                 end
+               end
              end
 
     messages = errors.map { |msg| content_tag(:li, msg) }.join

--- a/config/locales/devise/devise-de.yml
+++ b/config/locales/devise/devise-de.yml
@@ -15,6 +15,8 @@ de:
         login:
           exclusion: ist ungültig
           format: darf keine spitzen Klammern (<, >) enthalten
+        reset_password:
+          invalid_token: Ihr Link zum Zurücksetzen des Passworts ist ungültig oder abgelaufen. Fordern Sie ein weiteres Link zum Zurücksetzen des Passworts an, um fortzufahren.
     failure:
       already_authenticated: Sie sind bereits angemeldet.
       inactive: Ihr Benutzerkonto ist noch nicht aktiviert.

--- a/config/locales/devise/devise-en.yml
+++ b/config/locales/devise/devise-en.yml
@@ -15,6 +15,8 @@ en:
         login:
           exclusion: is invalid
           format: can't contain angle brackets (<, >)
+        reset_password:
+          invalid_token: 'Your reset password link is invalid or expired. Request another reset password to continue.'
     failure:
       already_authenticated: You are already signed in.
       inactive: Your account is not activated yet.

--- a/config/locales/devise/devise-es.yml
+++ b/config/locales/devise/devise-es.yml
@@ -15,6 +15,8 @@ es:
         login:
           exclusion: ist ungültig
           format: no puede contener corchetes angulares (<, >)
+        reset_password:
+          invalid_token: Su enlace para restablecer la contraseña no es válido o ha caducado. Solicite otro restablecimiento de contraseña para continuar.
     failure:
       already_authenticated: Ya has iniciado sesión.
       inactive: Tu cuenta aún no ha sido activada.

--- a/config/locales/devise/devise-fr.yml
+++ b/config/locales/devise/devise-fr.yml
@@ -15,6 +15,8 @@ fr:
         login:
           exclusion: n'est pas valide
           format: ne peut pas contenir de chevrons (<, >)
+        reset_password:
+          invalid_token: Votre lien de réinitialisation de mot de passe est invalide ou a expiré. Demandez un autre mot de passe de réinitialisation pour continuer.
     failure:
       already_authenticated: Vous êtes déjà connecté.
       inactive: Votre compte n'est pas encore activé.

--- a/config/locales/devise/devise-pt.yml
+++ b/config/locales/devise/devise-pt.yml
@@ -15,6 +15,8 @@ pt:
         login:
           exclusion: não é válido
           format: não pode conter colchetes angulares (<, >)
+        reset_password:
+          invalid_token: O link de redefinição de senha é inválido ou expirou. Solicite outra redefinição de senha para continuar.
     failure:
       already_authenticated: Você já entrou na sua conta.
       inactive: A sua conta ainda não foi ativada.


### PR DESCRIPTION
The error is likely due to invalid reset password token (maybe expired).

I believe we need a custom message here. Only saying `Reset password token is invalid`, which would be the default message, is lacking in prompting the user what was the error to begin with. I suggest overriding the message format when it is about reset_password_token errors to this:

```
Your reset password link is invalid or expired. Request another reset password to continue.
```

Let me know your thoughts @benwbrum @saracarl 