### PR TITLE
2313 - Abandon subject without losing transcription

### DIFF
--- a/app/views/transcribe/assign_categories.html.slim
+++ b/app/views/transcribe/assign_categories.html.slim
@@ -1,3 +1,14 @@
+ruby:
+  if @text_type == 'translation'
+    cancel_path = collection_translate_page_path(@collection.owner, @collection, @work, @page.id,
+      rollback_unset_ids: @unassigned_articles.pluck(:id), rollback_delete_ids: @new_article_ids)
+    continue_path = collection_translate_page_path(@collection.owner, @collection, @work, @next_page_id)
+  else
+    cancel_path = collection_transcribe_page_path(@collection.owner, @collection, @work, @page.id,
+      rollback_unset_ids: @unassigned_articles.pluck(:id), rollback_delete_ids: @new_article_ids)
+    continue_path = collection_transcribe_page_path(@collection.owner, @collection, @work, @next_page_id)
+  end
+
 =render({ :partial => '/shared/page_tabs', :locals => { :selected => 3, :page_id => @page.id }})
 
 .headline
@@ -21,8 +32,5 @@ p.big =t('.uncategorized_subjects_mentioned')
         option(data-level=level value=c.id selected=selected aria-label=t('.options') *language_attrs(@collection)) =c.title
 
 span.legend
-  -if @text_type == 'translation'
-    -next_path = collection_translate_page_path(@collection.owner, @collection, @work, @page.id)
-  -else
-    -next_path = collection_transcribe_page_path(@collection.owner, @collection, @work, @page.id)
-  =link_to t('.continue'), next_path, class: 'button outline round'
+  =link_to t('.cancel'), cancel_path, class: 'button outline round', style: 'margin: 0 0.5rem';
+  =link_to t('.continue'), continue_path, class: 'button outline round', style: 'margin: 0 0.5rem';

--- a/config/locales/transcribe/transcribe-de.yml
+++ b/config/locales/transcribe/transcribe-de.yml
@@ -3,6 +3,7 @@ de:
   transcribe:
     assign_categories:
       assign_categories: Kategorien zuweisen
+      cancel: Stornieren
       continue: Weitermachen
       manage_categories: Kategorien verwalten
       options: Optionen

--- a/config/locales/transcribe/transcribe-en.yml
+++ b/config/locales/transcribe/transcribe-en.yml
@@ -3,6 +3,7 @@ en:
   transcribe:
     assign_categories:
       assign_categories: Assign categories
+      cancel: Cancel
       continue: Continue
       manage_categories: Manage Categories
       options: options

--- a/config/locales/transcribe/transcribe-es.yml
+++ b/config/locales/transcribe/transcribe-es.yml
@@ -3,6 +3,7 @@ es:
   transcribe:
     assign_categories:
       assign_categories: Asignar categorías
+      cancel: Cancelar
       continue: Continuar
       manage_categories: Administrar Categorías
       options: Opciones

--- a/config/locales/transcribe/transcribe-fr.yml
+++ b/config/locales/transcribe/transcribe-fr.yml
@@ -3,6 +3,7 @@ fr:
   transcribe:
     assign_categories:
       assign_categories: Attribuer des catégories
+      cancel: Annuler
       continue: Continuer
       manage_categories: Gérer les catégories
       options: options

--- a/config/locales/transcribe/transcribe-pt.yml
+++ b/config/locales/transcribe/transcribe-pt.yml
@@ -3,6 +3,7 @@ pt:
   transcribe:
     assign_categories:
       assign_categories: Atribuir categorias
+      cancel: Cancelar
       continue: Continuar
       manage_categories: Controlar Categorias
       options: opções


### PR DESCRIPTION
Discussions so far with @benwbrum 


I'm playing around the functionality. Correct me in if I am wrong here, but I think these should be the cases:

1. I want to go back and make some changes
    a. We click on cancel button. This should not assign a category, BUT I would assume this should also NOT create the subject, otherwise why cancel in the first place.
    
2. I want to save my changes
    a. We click on save or continue button. THIS should assign categories and redirect back to same page (in case we want to edit some texts, add new subjects, etc).
    b. Regardless if they assign the category here, the subject SHOULD persist.
    
3. I want to save and continue to next page
    a. It creates and assigns subject and redirects to next page
    
I believe this should be the case, as was described by the user on the ticket

> I just spelled it wrong or left out a punctuation so I don't actually want to be creating a new subject...

Clicking cancel should NOT persist the subject at hand. 

That being said, I first went ahead and implement what was instructed in ticket where:
1. Clicking cancel will take me back to editing page and will not save assigned categories (but subjects will persist)
2. Clicking continue should redirect to the next appropriate page.


I took out the third button named `next` This is because past ticket made the `continue` dependent on the workflow. i.e. If save was clicked it should remain in same page, if done was clicked it will go to next page. So I believe only 2 buttons are relevant here (cancel and continue).


Tagging @saracarl  as well