### PR TITLE
Bypass validations when updating most recent deed date for #4182

### DIFF
--- a/app/models/deed.rb
+++ b/app/models/deed.rb
@@ -89,13 +89,13 @@ class Deed < ApplicationRecord
 
   def update_collections_most_recent_deed
     if self.collection
-      self.collection.update(most_recent_deed_created_at: self.created_at)
+      self.collection.update_columns(most_recent_deed_created_at: self.created_at)
     end
   end
 
   def update_works_most_recent_deed
     if self.work
-      self.work.update(most_recent_deed_created_at: self.created_at)
+      self.work.update_columns(most_recent_deed_created_at: self.created_at)
     end
   end
 


### PR DESCRIPTION
The activity stream on `collection#show` is cached on `@collection.most_recent_deed_created_at`, however this value was not being updated for several collections.  

On further review, this was caused by the addition of validations to check for valid XHTML in `collection.intro_block`.  Since [the after_save deed callback](https://github.com/benwbrum/fromthepage/blob/development/app/models/deed.rb#L90-L100) was calling `update`, validations were being checked.  If a collection failed validation (as was the case for these collections), we were not updating the column on the record.

Since there is no way a volunteer can address validation failures on `collection.intro_blcok` when they are merely transcribing a page, I've changed this logic to `update_columns`, which by-passes validations.