### PR TITLE
4302 - Missing page breaks on facing pdf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get -qq update
-          sudo apt-get install -y ghostscript poppler-utils graphviz
+          sudo apt-get install -y ghostscript poppler-utils graphviz pandoc texlive-full
           bundle install --jobs 4 --retry 3
       - name: Create db
         run: bundle exec rake db:create

--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,7 @@ end
 group :test do
   gem 'capybara'
   gem 'database_cleaner'
+  gem 'rails-controller-testing'
   gem 'selenium-webdriver'
   gem 'shoulda'
   gem 'simplecov',      require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -461,6 +461,10 @@ GEM
       bundler (>= 1.15.0)
       railties (= 6.1.7.6)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -721,6 +725,7 @@ DEPENDENCIES
   rack-mini-profiler
   rack-reverse-proxy
   rails (= 6.1.7.6)
+  rails-controller-testing
   rails-i18n (~> 6.0.0)
   recaptcha
   riiif!

--- a/app/controllers/concerns/export_service.rb
+++ b/app/controllers/concerns/export_service.rb
@@ -71,7 +71,6 @@ module ExportService
 
     file_stub = "#{@work.slug.gsub('-','_')}_#{time_stub}"
     md_file = File.join(temp_dir, "#{file_stub}.md")
-    tex_file = File.join(temp_dir, "#{file_stub}.tex")
 
     if format == 'pdf'
       output_file = File.join(temp_dir, "#{file_stub}.pdf")
@@ -84,19 +83,7 @@ module ExportService
     # run pandoc against the temp directory
     log_file = File.join(temp_dir, "#{file_stub}.log")
 
-    # Convert to tex
-    cmd = "pandoc --from markdown+superscript+pipe_tables -o #{tex_file} #{md_file} --verbose --abbreviations=/dev/null -V colorlinks=true > #{log_file} 2>&1"
-    puts cmd
-    logger.info(cmd)
-    system(cmd)
-
-    # Preprocess
-    tex_content = File.read(tex_file)
-    modified_content = tex_content.gsub('\textquotesingle ', "'")
-    File.open(tex_file, 'w') { |file| file.write(modified_content) }
-
-    # Convert to final format
-    cmd = "pandoc -o #{output_file} #{tex_file} --pdf-engine=xelatex --verbose --abbreviations=/dev/null -V colorlinks=true > #{log_file} 2>&1"
+    cmd = "pandoc --from markdown+superscript+pipe_tables -o #{output_file} #{md_file} --pdf-engine=xelatex --verbose --abbreviations=/dev/null -V colorlinks=true  > #{log_file} 2>&1"
     puts cmd
     logger.info(cmd)
     system(cmd)

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -70,7 +70,6 @@ class ExportController < ApplicationController
     cookies['download_finished'] = 'true'
   end
 
-
   def subject_coocurrence_csv
     send_data(@collection.export_subject_coocurrence_as_csv,
               :filename => "fromthepage_subject_coocurrence_export_#{@collection.id}_#{Time.now.utc.iso8601}.csv",

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -230,7 +230,7 @@ class ExportController < ApplicationController
   def sort_filtered_data
     return if params[:sort].blank?
 
-    direction = params[:order].downcase == 'desc' ? 'DESC' : 'ASC'
+    direction = params[:order]&.downcase == 'desc' ? 'DESC' : 'ASC'
 
     case params[:sort].downcase
     when 'title'

--- a/app/helpers/abstract_xml_helper.rb
+++ b/app/helpers/abstract_xml_helper.rb
@@ -3,6 +3,7 @@ module AbstractXmlHelper
 
   SANITIZE_ALLOWED_TAGS = %w(table tr td th thead tbody tfoot caption colgroup col a abbr acronym address b big blockquote br cite code del dfn div em font h1 h2 h3 h4 h5 h6 hr i img ins kbd li ol p pre q s samp small span strike strong sub sup tt u ul var time)
   SANITIZE_ALLOWED_ATTRIBUTES = %w(id name class data-tooltip title src alt width height style href)
+  SANITIZE_SINGLE_QUOTE_TAGS = %w(b strong i em u s mark q code pre kbd)
 
   def source_to_html(source)
     html = source.gsub(/\n/, "<br/>")
@@ -157,7 +158,7 @@ module AbstractXmlHelper
       # convert to a span
       depth = e.attributes["depth"]
       title = e.attributes["title"]
-      
+
       span = e
       e.name = 'span'
       span.add_attribute('class', "depth#{depth}")
@@ -165,7 +166,7 @@ module AbstractXmlHelper
 
     doc.elements.each("//head") do |e|
       # convert to a span
-      depth = 2      
+      depth = 2
       span = e
       e.name = 'span'
       span.add_attribute('class', "depth#{depth}")
@@ -270,13 +271,20 @@ module AbstractXmlHelper
     if @page
       doc.elements.each("//texFigure") do |e|
         position = e.attributes["position"]
-        
+
         span = REXML::Element.new('img')
         span.add_attribute('src', (file_to_url(TexFigure.artifact_file_path(@page.id, position)) + "?timestamp=" + Time.now.to_i.to_s))
-        
+
         e.replace_with(span)
       end
-      
+
+    end
+
+    # \textquotesingle fix
+    SANITIZE_SINGLE_QUOTE_TAGS.each do |tag|
+      doc.elements.each("//#{tag}") do |e|
+        e.text = e.text.gsub("'", "`")
+      end
     end
 
     # now our doc is correct - what do we do with it?

--- a/spec/requests/export_controller_spec.rb
+++ b/spec/requests/export_controller_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+describe ExportController do
+  before do
+    User.current_user = owner
+  end
+
+  let(:owner) { User.first }
+  let!(:collection) { create(:collection, owner_user_id: owner.id) }
+  let!(:work) { create(:work, collection: collection, owner_user_id: owner.id) }
+  let(:xml_text) { "<?xml version='1.0' encoding='UTF-8'?> <page> This <u>shouldn't</u> break export. </page>" }
+  let!(:page) { create(:page, work: work, xml_text: xml_text, status: :transcribed) }
+
+  describe '#index' do
+    let(:action_path) { collection_export_path(owner, collection) }
+    let(:params) { {} }
+
+    let(:subject) { get action_path, params: params }
+
+    it 'renders status and template' do
+      login_as owner
+      subject
+
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:index)
+    end
+
+    context 'with search params' do
+      let(:params) { { search: work.title, sort: 'title', order: 'desc', per_page: '-1' } }
+
+      it 'renders status and template' do
+        login_as owner
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(:index)
+      end
+    end
+  end
+
+  describe '#list' do
+    let(:action_path) { export_list_path }
+    let(:params) do
+      {
+        collection_id: collection.id,
+        search: work.title,
+        sort: 'title',
+        order: 'desc',
+        per_page: '-1'
+      }
+    end
+
+    let(:subject) { get action_path, params: params }
+
+    it 'renders status and template' do
+      login_as owner
+      subject
+
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(partial: '_list')
+    end
+  end
+
+  describe '#printable' do
+    let(:action_path) { export_printable_path(collection, work) }
+    let(:params) { {} }
+
+    let(:subject) { post action_path, params: params }
+
+    context 'as pdf' do
+      let(:params) { { edition: 'text', format: 'pdf' } }
+
+      it 'renders status' do
+        login_as owner
+        subject
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'as doc' do
+      let(:params) { { edition: 'text', format: 'doc' } }
+
+      it 'renders status' do
+        login_as owner
+        subject
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/requests/export_controller_spec.rb
+++ b/spec/requests/export_controller_spec.rb
@@ -13,9 +13,8 @@ describe ExportController do
 
   describe '#index' do
     let(:action_path) { collection_export_path(owner, collection) }
-    let(:params) { {} }
 
-    let(:subject) { get action_path, params: params }
+    let(:subject) { get action_path }
 
     it 'renders status and template' do
       login_as owner
@@ -24,31 +23,11 @@ describe ExportController do
       expect(response).to have_http_status(:ok)
       expect(response).to render_template(:index)
     end
-
-    context 'with search params' do
-      let(:params) { { search: work.title, sort: 'title', order: 'desc', per_page: '-1' } }
-
-      it 'renders status and template' do
-        login_as owner
-        subject
-
-        expect(response).to have_http_status(:ok)
-        expect(response).to render_template(:index)
-      end
-    end
   end
 
   describe '#list' do
-    let(:action_path) { export_list_path }
-    let(:params) do
-      {
-        collection_id: collection.id,
-        search: work.title,
-        sort: 'title',
-        order: 'desc',
-        per_page: '-1'
-      }
-    end
+    let(:action_path) { export_list_path(collection_id: collection.id) }
+    let(:params) { { search: work.title, per_page: '-1' } }
 
     let(:subject) { get action_path, params: params }
 
@@ -58,6 +37,66 @@ describe ExportController do
 
       expect(response).to have_http_status(:ok)
       expect(response).to render_template(partial: '_list')
+    end
+
+    context 'sort by title' do
+      let(:params) { { search: work.title, sort: 'title' } }
+
+      it 'renders status and template' do
+        login_as owner
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(partial: '_list')
+      end
+    end
+
+    context 'sort by page count' do
+      let(:params) { { search: work.title, sort: 'page_count', order: 'asc' } }
+
+      it 'renders status and template' do
+        login_as owner
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(partial: '_list')
+      end
+    end
+
+    context 'sort by indexed count' do
+      let(:params) { { search: work.title, sort: 'indexed_count' } }
+
+      it 'renders status and template' do
+        login_as owner
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(partial: '_list')
+      end
+    end
+
+    context 'sort by completed count' do
+      let(:params) { { search: work.title, sort: 'indexed_count' } }
+
+      it 'renders status and template' do
+        login_as owner
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(partial: '_list')
+      end
+    end
+
+    context 'sort by reviewed count' do
+      let(:params) { { search: work.title, sort: 'reviewed_count' } }
+
+      it 'renders status and template' do
+        login_as owner
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(partial: '_list')
+      end
     end
   end
 


### PR DESCRIPTION
https://github.com/jgm/pandoc/issues/2330

Pandoc seems to not support page break when converting from `latex` to `pdf`.
There are existing lua filters as workaround for this, but nothing made yet for a pdf output.

Ironically, our old approach of directly uploading from `md` to `pdf` supports `\newpage` and other tags, but we go back to initial issue of unsupported font  for \textsinglequote. So this PR will revert to old approach and fix the initial issue at #4297 

After much research on the matter, I have pinpointed the error to Xelatex being not fully compatible with fonts (fontenc for example, which is what is being used for pdfs). To resolve this I switched out the pdf engine from `xelatex` to `pdflatex` and everything worked correctly.

@benwbrum @saracarl is there any particular reason for using xelatex engine? If there is none I think this proposed solution should be acceptable.