### PR TITLE
#4319: only gsub if there is text

### DIFF
--- a/app/helpers/abstract_xml_helper.rb
+++ b/app/helpers/abstract_xml_helper.rb
@@ -283,7 +283,9 @@ module AbstractXmlHelper
     # \textquotesingle fix
     SANITIZE_SINGLE_QUOTE_TAGS.each do |tag|
       doc.elements.each("//#{tag}") do |e|
-        e.text = e.text.gsub("'", "`")
+        if e.text
+          e.text = e.text.gsub("'", "`")
+        end
       end
     end
 


### PR DESCRIPTION
Closes #4319

(It turns out that this was caused by calling `gsub` on elements that had `nil` `.text`)