### PR TITLE
4264 - Bootstrap css classes not working

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -388,6 +388,10 @@ h3, .thredded--post-form--title {
   }
 }
 
+.bs {
+  @import "bootstrap.min";
+}
+
 @import "datepicker/datepicker";
 @import "jquery.ui.all";
 @import "handsontable.min";


### PR DESCRIPTION
This takes on a different, safer approach.

We add 'bs' as the namespace whenever we want to use bootstrap css. This will preserve all existing css classes we have.

@benwbrum @saracarl 