### PR TITLE
4311 - Missing display name fix

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -150,8 +150,9 @@ class User < ApplicationRecord
     end
   end
 
-
   def update_display_name
+    self.real_name = nil if self.real_name.blank?
+
     if self.owner
       self.display_name = self.real_name
     else
@@ -287,9 +288,9 @@ class User < ApplicationRecord
 
   def display_name
     if self.guest
-      "Guest"
+      'Guest'
     else
-      self[:display_name] || self[:login]
+      self[:display_name].presence || self[:login]
     end
   end
 


### PR DESCRIPTION
The fix works in 2 parts:

We update the callback `update_display_name` to set real_name and display_name to `nil` in case the string value is blank. This will prevent new records with ' ' display_name values from being created.

Second is we update the display_name override to detect [:display_name] presence, otherwise use login. This will help us so that we don't need to do a migration to fix bad data