### PR TITLE
Replace link in configuration test mailer views with actual collection list link

### DIFF
--- a/app/views/system_mailer/config_test.html.erb
+++ b/app/views/system_mailer/config_test.html.erb
@@ -3,8 +3,8 @@
 </h2>
 
 <p>
-	Check the sender and from email addresses to make sure they're right.a
+	Check the sender and from email addresses to make sure they're right.
 </p>
 <p>
-	This link should go to the collection list: <%= link_to 'click me', { controller: 'admin', action: 'uploads', only_path: false } %>
+	This link should go to the <%= link_to 'collection list', { controller: 'admin', action: 'collection_list', only_path: false } %>.
 </p>

--- a/app/views/system_mailer/config_test.html.erb
+++ b/app/views/system_mailer/config_test.html.erb
@@ -6,5 +6,5 @@
 	Check the sender and from email addresses to make sure they're right.
 </p>
 <p>
-	This link should go to the <%= link_to 'collection list', { controller: 'admin', action: 'collection_list', only_path: false } %>.
+	This link should go to the <%= link_to 'collection list', admin_collection_list_url %>.
 </p>

--- a/app/views/system_mailer/config_test.text.erb
+++ b/app/views/system_mailer/config_test.text.erb
@@ -3,4 +3,4 @@ FromThePage email configuration test
 Check the sender and from email addresses to make sure they're right.
 
 This link should go to the collection list: 
-<%= url_for({ controller: 'admin', action: 'collection_list', only_path: false }) %>
+<%= admin_collection_list_url %>

--- a/app/views/system_mailer/config_test.text.erb
+++ b/app/views/system_mailer/config_test.text.erb
@@ -3,4 +3,4 @@ FromThePage email configuration test
 Check the sender and from email addresses to make sure they're right.
 
 This link should go to the collection list: 
-<%= url_for({ controller: 'admin', action: 'uploads', only_path: false }) %>
+<%= url_for({ controller: 'admin', action: 'collection_list', only_path: false }) %>


### PR DESCRIPTION
There was a typo in the HTML mailer view, an extra 'a'. And the link that suggests it goes to the collection list is a link to the uploads. This PR fixes both.