### PR TITLE
Remove hardcoded 'www.' from "current URL"s in forms

### DIFF
--- a/app/views/document_sets/_edit.html.slim
+++ b/app/views/document_sets/_edit.html.slim
@@ -13,7 +13,7 @@
       tr
         th.hidden= t('.url')
         td 
-          p.nomargin.settings ==t('.current_url_for_this_work', current_url: "<b>#{Rails.application.routes.default_url_options[:host]}/#{@document_set.owner.slug}/#{@document_set.slug}</b>")
+          p.nomargin.settings ==t('.current_url_for_this_work', current_url: "<b>#{collection_url(@document_set.owner.slug, @document_set.slug)}</b>")
       tr
         td(colspan="2")
           =f.label :description, t('.description'), class: 'above'

--- a/app/views/document_sets/_edit.html.slim
+++ b/app/views/document_sets/_edit.html.slim
@@ -13,7 +13,7 @@
       tr
         th.hidden= t('.url')
         td 
-          p.nomargin.settings ==t('.current_url_for_this_work', current_url: "<b>www.#{Rails.application.routes.default_url_options[:host]}/#{@document_set.owner.slug}/#{@document_set.slug}</b>")
+          p.nomargin.settings ==t('.current_url_for_this_work', current_url: "<b>#{Rails.application.routes.default_url_options[:host]}/#{@document_set.owner.slug}/#{@document_set.slug}</b>")
       tr
         td(colspan="2")
           =f.label :description, t('.description'), class: 'above'

--- a/app/views/user/update_profile.html.slim
+++ b/app/views/user/update_profile.html.slim
@@ -20,10 +20,10 @@
               .userpic =image_tag(@user.picture_url(:thumb), alt: @user.display_name)
         tr
           th= t('.user_url')
-          td www.#{Rails.application.routes.default_url_options[:host]}/#{@user.slug}
+          td =user_profile_url(@user)
         tr
           th= t('.sign_up_url')
-          td www.#{Rails.application.routes.default_url_options[:host]}/#{@user.slug}/sign_up
+          td =new_for_owner_url(@user)
         tr
           th =f.label :slug, t('.url')
           td =f.text_field :slug, value: @user.slug


### PR DESCRIPTION
It bothered me that "current URL" items in forms for updating a user profile or document set include `www.`, whereas our FromThePage does not have that. In fact, we don't have `www.` in our DNS records.

This PR updates the views to remove it. Based on a comment by @WillNigel23 on #4397 I used the URL helper where available, but I could not find a route for the document set.