### PR TITLE
Install RuboCop Rails to actually run RuboCop in CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,1 @@
+require: rubocop-rails

--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,7 @@ group :development, :test do
   gem 'pry-awesome_print'
   gem 'pry-byebug'
   gem 'rspec-rails'
+  gem 'rubocop-rails'
 end
 
 gem 'dotenv', group: [:development, :test], require: 'dotenv/load'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -321,6 +321,7 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
+    language_server-protocol (3.17.0.3)
     launchy (3.0.0)
       addressable (~> 2.8)
       childprocess (~> 5.0)
@@ -408,6 +409,7 @@ GEM
       sanitize
     open3 (0.2.1)
     orm_adapter (0.5.0)
+    parallel (1.26.3)
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
@@ -518,10 +520,29 @@ GEM
       rspec-support (~> 3.13)
     rspec-support (3.13.1)
     rtl (0.6.0)
+    rubocop (1.65.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.4, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.2)
+      parser (>= 3.3.0.4)
+    rubocop-rails (2.27.0)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.52.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
     ruby-openai (6.5.0)
       event_stream_parser (>= 0.3.0, < 2.0.0)
       faraday (>= 1)
       faraday-multipart (>= 1)
+    ruby-progressbar (1.13.0)
     ruby-saml (1.17.0)
       nokogiri (>= 1.13.10)
       rexml
@@ -732,6 +753,7 @@ DEPENDENCIES
   rmagick
   rspec-rails
   rtl
+  rubocop-rails
   ruby-openai
   rubyzip
   rvm1-capistrano3


### PR DESCRIPTION
I noticed that the "Run RuboCop" step in CI is always skipped, because RuboCop is not in the Gemfile(.lock). This PR adds RuboCop and RuboCop Rails. I followed <https://github.com/rubocop/rubocop-rails#rubocop-configuration-file> to add the `.rubocop.yml` file, although there is more to configure.