### PR TITLE
Use the appropriate Capybara methods.

### DIFF
--- a/spec/features/archive_import_spec.rb
+++ b/spec/features/archive_import_spec.rb
@@ -23,7 +23,7 @@ describe 'IA import actions', order: :defined do
       click_link('Import From Archive.org')
       fill_in 'detail_url', with: ia_link
       click_button('Import Work')
-      click_button('Import Anyway') if page.has_button?('Import Anyway')
+      page.accept_confirm if page.has_button?('Import Anyway')
       expect(page).to have_content('Manage Archive.org Import')
       select @collection.title, from: 'collection_id'
       click_button('Publish Work')
@@ -42,7 +42,7 @@ describe 'IA import actions', order: :defined do
       click_link('Import From Archive.org')
       fill_in 'detail_url', with: ia_link
       click_button('Import Work')
-      click_button('Import Anyway') if page.has_button?('Import Anyway')
+      page.accept_confirm if page.has_button?('Import Anyway')
       expect(ia_work_count + 1).to eq IaWork.all.count
       expect(page).to have_content('Manage Archive.org Import')
       page.check('use_ocr')

--- a/spec/features/archive_import_spec.rb
+++ b/spec/features/archive_import_spec.rb
@@ -66,7 +66,6 @@ describe 'IA import actions', order: :defined do
     sleep(3)
     fill_in_editor_field('Test OCR Correction')
     find('#finish_button_top').click
-    sleep(3)
     page.find('a.page-nav_prev').click
     expect(page).to have_content('Test OCR Correction')
     expect(page.find('.tabs')).to have_content('Correct')

--- a/spec/features/export_spec.rb
+++ b/spec/features/export_spec.rb
@@ -71,8 +71,8 @@ describe "export tasks" do
     expect(page).to have_content("Export Individual Works")
     page.find('tr', text: @work.title).click_link("Plain text")
     expect(page.current_path).to eq ("/export/work_plaintext_verbatim")
-    expect(page.all('pre', text: @work.title))
-    expect(page.all('pre', text: @page.title))
+    expect(page).to have_css('pre', text: @work.title)
+    expect(page).to have_css('pre', text: @page.title)
   end
 
   it "exports a work as tei" do

--- a/spec/features/field_based_spec.rb
+++ b/spec/features/field_based_spec.rb
@@ -109,16 +109,14 @@ describe "collection settings js tasks", :order => :defined do
     message = accept_alert do
       page.click_link("Next page")
     end
-    sleep(3)
-    expect(message).to have_content("You have unsaved changes.")
+    expect(message).to have_content("You have unsaved changes.", wait: 3)
     visit collection_transcribe_page_path(@collection.owner, @collection, test_page.work, test_page)
     #previous page arrow - make sure it also works with notes
     fill_in('Write a new note or ask a question...', with: "Test two")
     message = accept_alert do
       page.click_link("Previous page")
     end
-    sleep(3)
-    expect(message).to have_content("You have unsaved changes.")
+    expect(message).to have_content("You have unsaved changes.", wait: 3)
   end
 
   #note: these are hidden unless there is table data

--- a/spec/features/forum_spec.rb
+++ b/spec/features/forum_spec.rb
@@ -25,7 +25,7 @@ describe "forum tab for collection", :order => :defined do
     page.find('.tabs').click_link("Settings")
     page.find('.side-tabs').click_link('Look & Feel')
     page.check('Enable forums')
-    sleep(1)
+    expect(page).to have_checked_field('Enable forums')
     visit current_path # reload page to get the new forum tab
     page.find('.tabs').click_link("Forum")
     expect(page).to have_content("All Messageboards")
@@ -35,8 +35,8 @@ describe "forum tab for collection", :order => :defined do
     page.find('.tabs').click_link("Settings")
     page.find('.side-tabs').click_link('Look & Feel')
     page.uncheck('Enable forums')
-    sleep(1)
-    visit current_path 
+    expect(page).to have_unchecked_filed('Enable forums')
+    visit current_path
     expect(page.find('.tabs')).to_not have_content("Forum")
   end
 

--- a/spec/features/metadata_description_spec.rb
+++ b/spec/features/metadata_description_spec.rb
@@ -25,7 +25,8 @@ describe "Metadata Description" do
     visit edit_collection_path(@owner, @collection)
     page.find('.side-tabs').click_link("Task Configuration")
     page.check("Enable metadata description")
-    sleep(1)
+    expect(page).to have_checked_field('Enable metadata description')
+
     button = page.find_link 'Edit Metadata Form'
     expect(button['disabled']).not_to eq('disabled')
     expect(Collection.find(@collection.id).data_entry_type).to eq(Collection::DataEntryType::TEXT_AND_METADATA)
@@ -33,7 +34,8 @@ describe "Metadata Description" do
     visit edit_collection_path(@owner, @collection)
     page.find('.side-tabs').click_link("Task Configuration")
     page.uncheck("Enable metadata description")
-    sleep(1)
+    expect(page).to have_unchecked_field('Enable metadata description')
+
     button = page.find_link 'Edit Metadata Form'
     expect(button['disabled']).to eq('disabled')
     expect(@collection.data_entry_type).to eq(Collection::DataEntryType::TEXT_ONLY)
@@ -50,7 +52,7 @@ describe "Metadata Description" do
       visit edit_collection_path(@owner, @collection)
       page.find('.side-tabs').click_link("Task Configuration")
       page.check("Enable metadata description")
-      sleep(1)
+      expect(page).to have_checked_field('Enable metadata description')
 
       visit collection_path(@owner, @collection)
       page.find('.tabs').click_link("Metadata Fields")


### PR DESCRIPTION
Capybara provides some useful methods for E2E testing. These methods also wait automatically for target elements to appear. Therefore, using the provided methods instead of sleep usually makes tests more stable. For this reason, I tried replacing the existing code with these methods.

e.g.) 
[page.accept_confirm](https://rubydoc.info/github/jnicklas/capybara/Capybara/Session:accept_confirm) method 


