### PR TITLE
Call Mixpanel only when enabled

### DIFF
--- a/app/views/contact/form.html.slim
+++ b/app/views/contact/form.html.slim
@@ -26,6 +26,5 @@
       <br>
       =button_tag t('.submit'), class: 'big'
 
-  javascript:  mixpanel.track("Contact Us");
-
-
+  -unless MIXPANEL_ID.blank?
+    javascript:  mixpanel.track("Contact Us");

--- a/app/views/contact/send_email.html.slim
+++ b/app/views/contact/send_email.html.slim
@@ -10,4 +10,5 @@
 
     =link_to t('.start_free_trial'), users_new_trial_path
 
-javascript: mixpanel.track("Contact Us - Thank You");
+-unless MIXPANEL_ID.blank?
+  javascript: mixpanel.track("Contact Us - Thank You");

--- a/app/views/static/at.html.slim
+++ b/app/views/static/at.html.slim
@@ -45,7 +45,5 @@
       p Our first FromThePage project was for the San Diego Museum of Natural History in 2010, and we're proud that archives, museums, and libraries across the world have run projects on FromThePage.  Some names you might recognize are Stanford University Archives, The British Library, and the state archives of Alabama, Virginia, California, North Carolina, Maryland, and Indiana.  (Don't worry, there are plenty of smaller institutions, too, like the Yaquina Head Lighthouses, the LA County Public Library and the Indianapolis Public Library.)
 
 
-javascript:  mixpanel.track("Archivists Tale");
-
-
-
+-unless MIXPANEL_ID.blank?
+  javascript:  mixpanel.track("Archivists Tale");

--- a/app/views/static/meredithsstory.html.slim
+++ b/app/views/static/meredithsstory.html.slim
@@ -80,5 +80,5 @@ hr
         li: a href="https://www.alabamahistorydiy.org/wwi-service-records" Alabama World War I Service Records Project
         li: a href="https://www.worldwar1centennial.org/index.php/alabama-wwi-blog/4380-alabama-history-diy-wwi-service-records.html" Meredith’s project announcement and call for volunteer transcribers
 
-      
-javascript:  mixpanel.track("Merediths Story");
+-unless MIXPANEL_ID.blank?
+  javascript:  mixpanel.track("Merediths Story");

--- a/app/views/static/natsstory.html.slim
+++ b/app/views/static/natsstory.html.slim
@@ -75,4 +75,5 @@ hr
         ' “Over the past months, I have developed a style of doing the transcriptions. When I start on a given day, I usually read through the next several pages and then do my transcriptions. Usually, before I stop (and I typically do my transcriptions while I’m eating lunch at work), I will read the next couple days. One way this helps is that if there is something obscure on the current page, it will sometimes be explained on a subsequent page. Also, by reading it several times, I have a better chance of deciphering her handwriting.”
         Nat Wooding to Ben Brumfield, December 19, 2013
 
-javascript:  mixpanel.track("Nats Story");
+-unless MIXPANEL_ID.blank?
+  javascript:  mixpanel.track("Nats Story");

--- a/app/views/static/software.html.slim
+++ b/app/views/static/software.html.slim
@@ -141,7 +141,5 @@
 
     hr
 
-javascript:  mixpanel.track("Contact Us");
-
-
-
+-unless MIXPANEL_ID.blank?
+  javascript:  mixpanel.track("Contact Us");

--- a/app/views/static/splash.html.slim
+++ b/app/views/static/splash.html.slim
@@ -110,4 +110,5 @@ section.spotlight
 
           =link_to 'Learn More', '/stanforduniversityarchives/jls'
 
-javascript: mixpanel.track("Landing Page");
+-unless MIXPANEL_ID.blank?
+  javascript: mixpanel.track("Landing Page");


### PR DESCRIPTION
This fixes #4452 by adding the condition for inclusion of the `mixpanel.track` calls to the views that did not have this.