### PR TITLE
Schema patches:

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -163,6 +163,7 @@ class Collection < ApplicationRecord
             query: query,
             fields: [
               "title^2",
+              "title.no_underscores^1.3",
               "intro_block",
               "slug"
             ]

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -156,6 +156,7 @@ class Page < ApplicationRecord
 
     search_fields = [
       "title^2",
+      "title.no_underscores^1.3",
       "search_text^1.5",
       "content_english",
       "content_french",

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -210,6 +210,7 @@ class Work < ApplicationRecord
 
     search_fields = [
       "title^2",
+      "title.no_underscores^1.3",
       "searchable_metadata.identifier_whitespace^1.5",
       "searchable_metadata"
     ]

--- a/lib/elastic/schema/collection.json
+++ b/lib/elastic/schema/collection.json
@@ -30,7 +30,14 @@
 				"type": "text"
 			},
 			"title": {
-				"type": "text"
+				"type": "text",
+				"analyzer": "general",
+				"fields": {
+					"no_underscores": {
+						"type": "text",
+						"analyzer": "general_no_underscores"
+					}
+				}
 			}
 		}
 	}

--- a/lib/elastic/schema/page.json
+++ b/lib/elastic/schema/page.json
@@ -29,22 +29,25 @@
 				"type": "keyword"
 			},
 			"search_text": {
-				"type": "text"
+				"type": "text",
+				"analyzer": "general"
 			},
 			"source_text": {
 				"type": "text",
-				"fields": {
-					"search": {
-						"type": "text",
-						"analyzer": "general"
-					}
-				}
+				"analyzer": "general"
 			},
 			"source_translation": {
 				"type": "text"
 			},
 			"title": {
-				"type": "text"
+				"type": "text",
+				"analyzer": "general",
+				"fields": {
+					"no_underscores": {
+						"type": "text",
+						"analyzer": "general_no_underscores"
+					}
+				}
 			}
 		}
 	}

--- a/lib/elastic/schema/template.json
+++ b/lib/elastic/schema/template.json
@@ -43,6 +43,16 @@
 						"lowercase"
 					]
 				},
+				"general_no_underscores": {
+					"char_filter": [
+						"html_strip",
+						"replace_underscores"
+					],
+					"tokenizer": "standard",
+					"filter": [
+						"lowercase"
+					]
+				},
 				"general_whitespace": {
 					"char_filter": [
 						"html_strip"
@@ -54,7 +64,8 @@
 				},
 				"identifier_whitespace": {
 					"char_filter": [
-						"html_strip"
+						"html_strip",
+						"drop_wildcards"
 					],
 					"tokenizer": "whitespace",
 					"filter": [
@@ -135,6 +146,18 @@
 						"stop_swedish",
 						"stem_swedish"
 					]
+				}
+			},
+			"char_filter": {
+				"replace_underscores": {
+					"type": "pattern_replace",
+					"pattern": "\\_",
+					"replacement": " "
+				},
+				"drop_wildcards": {
+					"type": "pattern_replace",
+					"pattern": "\\*",
+					"replacement": ""
 				}
 			},
 			"filter": {

--- a/lib/elastic/schema/work.json
+++ b/lib/elastic/schema/work.json
@@ -21,7 +21,13 @@
 			},
 			"title": {
 				"type": "text",
-				"analyzer": "general"
+				"analyzer": "general",
+				"fields": {
+					"no_underscores": {
+						"type": "text",
+						"analyzer": "general_no_underscores"
+					}
+				}
 			},
 			"searchable_metadata": {
 				"type": "text",


### PR DESCRIPTION
- Drop wildcard from identifier analysis as it can cause match-all behavior due to drop purewords filter.
- Expand terms with underscores into `title.no_underscores` and use in search.