### PR TITLE
Refactor aliases and add utility scripts for #4575

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -190,7 +190,7 @@ class Collection < ApplicationRecord
             }
           },
           # Need index filter for cross collection search
-          {prefix: {_index: "ftp_collection"}}
+          {prefix: {_index: ElasticUtil::Index::COLLECTION}}
         ]
       }
     }

--- a/app/models/concerns/elastic_delta.rb
+++ b/app/models/concerns/elastic_delta.rb
@@ -22,20 +22,20 @@ module ElasticDelta
   # Map model types to collection names
   def get_index_for_type(type)
     if type.is_a?(Collection)
-      return 'ftp_collection'
+      return ElasticUtil::Index::COLLECTION
     elsif type.is_a?(DocumentSet)
-      return 'ftp_collection' # DocSets intentionally put into collection for now
+      return ElasticUtil::Index::COLLECTION # DocSets intentionally put into collection for now
     elsif type.is_a?(Page)
-      return 'ftp_page'
+      return ElasticUtil::Index::PAGE
     elsif type.is_a?(User)
-      return 'ftp_user'
+      return ElasticUtil::Index::USER
     elsif type.is_a?(Work)
-      return 'ftp_work'
+      return ElasticUtil::Index::WORK
     end
   end
 
   def es_update
-    index = get_index_for_type(self)
+    index = ElasticUtil.env_index(get_index_for_type(self))
     doc_id = self.id
     body = self.as_indexed_json().except(:_id)
 
@@ -76,7 +76,7 @@ module ElasticDelta
     doc_id = self.id
 
     # Only delete a single page if not destroyed by association
-    if index == 'ftp_page' && destroyed_by_association
+    if index == ElasticUtil::Index::PAGE && destroyed_by_association
       return
     end
 
@@ -114,7 +114,7 @@ module ElasticDelta
     }
 
     ElasticUtil.safe_delete_by_query(
-      index: 'ftp_page',
+      index: ElasticUtil::Index::PAGE,
       body: q
     )
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -219,7 +219,7 @@ class Page < ApplicationRecord
             }
           },
           # Need index filter for cross collection search
-          {prefix: {_index: "ftp_page"}}
+          {prefix: {_index: ElasticUtil::Index::PAGE}}
         ]
       }
     }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -169,7 +169,7 @@ class User < ApplicationRecord
         },
         filter: [
           # Need index filter for cross collection search
-          {prefix: {_index: "ftp_user"}}
+          {prefix: {_index: ElasticUtil::Index::USER}}
         ]
       }
     }

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -23,7 +23,7 @@ set :branch, 'ui-design'
 # set :pty, true
 
 # Default value for :linked_files is []
-set :linked_files, %w{config.ru config/database.yml config/environments/production.rb config/initializers/01fromthepage.rb config/initializers/rack_attack.rb config/initializers/omniauth.rb config/newrelic.yml public/robots.txt}
+set :linked_files, %w{config.ru config/database.yml config/environments/production.rb config/initializers/01fromthepage.rb config/initializers/rack_attack.rb config/initializers/omniauth.rb config/newrelic.yml public/robots.txt index-state.json}
 
 # Default value for linked_dirs is []
 # set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}

--- a/lib/tasks/elasticsearch_permissions_sync.rake
+++ b/lib/tasks/elasticsearch_permissions_sync.rake
@@ -78,7 +78,7 @@ namespace :fromthepage do
   def sync_collections_and_docsets(after, limit)
     q = gen_range_query(after, limit)
 
-    resp = ElasticUtil.safe_search(index: 'ftp_collection', body: q)
+    resp = ElasticUtil.safe_search(index: ElasticUtil::Index::COLLECTION, body: q)
 
     collection_ids = resp['hits']['hits']
       .select { |x| !x['_source']['is_docset'] } 
@@ -90,27 +90,27 @@ namespace :fromthepage do
 
     collection_ids.each do |coll_id|
       c = Collection.find(coll_id)
-      ElasticUtil.reindex(c.pages, 'ftp_page')
-      ElasticUtil.reindex(c.works, 'ftp_work')
+      ElasticUtil.reindex(c.pages, ElasticUtil::Index::PAGE)
+      ElasticUtil.reindex(c.works, ElasticUtil::Index::WORK)
     end
 
     docset_ids.each do |docset_id|
       ds = DocumentSet.find(docset_id)
-      ElasticUtil.reindex(ds.pages, 'ftp_page')
-      ElasticUtil.reindex(ds.works, 'ftp_work')
+      ElasticUtil.reindex(ds.pages, ElasticUtil::Index::PAGE)
+      ElasticUtil.reindex(ds.works, ElasticUtil::Index::WORK)
     end
   end
 
   def sync_works(after, limit)
     q = gen_range_query(after, limit)
 
-    resp = ElasticUtil.safe_search(index: 'ftp_work', body: q)
+    resp = ElasticUtil.safe_search(index: ElasticUtil::Index::WORK, body: q)
     work_ids = resp['hits']['hits']
       .map { |x| x['_id'] }
 
     work_ids.each do |work_id|
       w = Work.find(work_id)
-      ElasticUtil.reindex(w.pages, 'ftp_page')
+      ElasticUtil.reindex(w.pages, ElasticUtil::Index::PAGE)
     end
   end
 
@@ -119,6 +119,6 @@ namespace :fromthepage do
     terminus_ad_quem = DateTime.strptime(limit.to_s,'%s')
     pending = Page.where(updated_at: [terminus_a_quo..terminus_ad_quem])
 
-    ElasticUtil.reindex(pending, 'ftp_page')
+    ElasticUtil.reindex(pending, ElasticUtil::Index::PAGE)
   end
 end


### PR DESCRIPTION
Closes #4575.

This pull request adds code to do the following:
* Eliminate reliance on ElasticSearch aliases, forcing all updates and queries to be made against the `ELASTIC_SEARCH` environment variable, or the ELASTIC_SEARCH constant set in the initializer if that is not available.  In production we should use the initializer to determine which suite of indices we run against.  Changes to the configuration done in development--and populations of the indices done in production once those changes have been tested--should use the environment variable from the rake tasks until they are ready to be queried against in production.
* Add a new rake task, `fromthepage:es_stats` that shows which indices are currently being used and show the health and document counts of those and other indices
* Add a new rake task, `fromthepage:es_get` that takes an argument representing a FromThePage database ID for work, collection, page, or user and queries ES to see if any hits are teturend.
## es_stats example
```
ELASTIC_SUFFIX=ftp_production_left ELASTIC_ENABLE=true rake fromthepage:es_stats
/home/benwbrum/.rvm/rubies/ruby-2.7.3/lib/ruby/2.7.0/net/protocol.rb:66: warning: already initialized constant Current index stats:
ftp_work_ftp_production_left:	yellow	open	218194 documents
ftp_user_ftp_production_left:	yellow	open	2710 documents
ftp_page_ftp_production_left:	yellow	open	4003059 documents
ftp_collection_ftp_production_left:	yellow	open	3428 documents

All index stats:
ftp_work_ftpprod:	yellow	open	0 documents
ftp_user_bendev:	yellow	open	1998 documents
ftp_page_bendev:	yellow	open	144000 documents
ftp_user_ftpprod:	yellow	open	0 documents
ftp_collection_ftpprod:	yellow	open	0 documents
ftp_page_dandev:	yellow	open	3519437 documents
test_index:	yellow	open	1 documents
ftp_collection_dandev:	yellow	open	3073 documents
ftp_collection_bendev:	yellow	open	3190 documents
dlwdebug_2:	yellow	open	0 documents
ftp_user_dandev:	yellow	open	1966 documents
ftp_work_bendev:	yellow	open	0 documents
ftp_page_ftpprod:	yellow	open	0 documents
ftp_work_dandev:	yellow	open	168213 documents
```

## es_get example
```
ELASTIC_SUFFIX=ftp_production_left ELASTIC_ENABLE=true rake fromthepage:es_get[100]
Checking index: ftp_collection_ftp_production_left
"{\"_index\":\"ftp_collection_ftp_production_left\",\"_id\":\"100\",\"found\":false}"

Checking index: ftp_page_ftp_production_left
"{\"_index\":\"ftp_page_ftp_production_left\",\"_id\":\"100\",\"found\":false}"

Checking index: ftp_user_ftp_production_left
"{\"_index\":\"ftp_user_ftp_production_left\",\"_id\":\"100\",\"found\":false}"

Checking index: ftp_work_ftp_production_left
"{\"_index\":\"ftp_work_ftp_production_left\",\"_id\":\"100\",\"_version\":1,\"_seq_no\":69,\"_primary_term\":1,\"found\":true,\"_source\":{}}"
```
