### PR TITLE
Fix variable reference in ScManifest.lang_keys_from_object

### DIFF
--- a/app/models/sc_manifest.rb
+++ b/app/models/sc_manifest.rb
@@ -288,7 +288,7 @@ class ScManifest < ApplicationRecord
     if object.is_a? Array
       lang_keys = object.map{ |hash| lang_keys_from_hash(hash) }.flatten
     else
-      lang_keys = lang_keys_from_hash(hash)
+      lang_keys = lang_keys_from_hash(object)
     end
     lang_keys.tally
   end


### PR DESCRIPTION
## Summary
- fix undefined variable in `ScManifest.lang_keys_from_object`

## Testing
- `bundle exec rspec spec/models/sc_manifest.rb -e 'lang_keys_from_object'` *(fails: rbenv: version `2.7.3` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849c91602988322ad72699811e7ba1a