### PR TITLE
Fix subject page link context

### DIFF
--- a/app/views/article/_article_links.html.slim
+++ b/app/views/article/_article_links.html.slim
@@ -8,6 +8,7 @@
         -parameter = link.text_type == "translation" ? true : false
         =svg_symbol '#icon-page', class: 'icon'
         =link_to link.page.title, collection_display_page_path(@collection.owner, @collection, link.page.work, link.page, translation: parameter)
+        span.fglight ==" #{t('.in_the_work', work: link.page.work.title)}"
         =="&nbsp;&mdash;&nbsp;#{link.display_text}"
         -if parameter
           =="&nbsp(#{link.text_type})"

--- a/config/locales/article/article-de.yml
+++ b/config/locales/article/article-de.yml
@@ -9,6 +9,7 @@ de:
         one: 1 Entität bezieht sich auf %{article}
         other: "%{count} Entitäten beziehen sich auf %{article}"
       show_pages_that_mention: Seiten in allen Werken anzeigen, die %{article} erwähnen
+      in_the_work: " im %{work}"
     combine_duplicate:
       selected_subjects_combined: Ausgewählte Entitäten kombiniert mit %{title}
     delete:

--- a/config/locales/article/article-en.yml
+++ b/config/locales/article/article-en.yml
@@ -9,6 +9,7 @@ en:
         one: 1 subject refers to %{article}
         other: "%{count} subjects refer to %{article}"
       show_pages_that_mention: Show pages that mention %{article} in all works
+      in_the_work: "in %{work}"
     combine_duplicate:
       selected_subjects_combined: Selected subjects combined with %{title}
     delete:

--- a/config/locales/article/article-es.yml
+++ b/config/locales/article/article-es.yml
@@ -9,6 +9,7 @@ es:
         one: 1 sujeto se refiere a %{article}
         other: "%{count} sujetos se refieren a %{article}"
       show_pages_that_mention: Mostrar páginas que mencionen %{article} en todos las obras
+      in_the_work: " en %{work}"
     combine_duplicate:
       selected_subjects_combined: Asignaturas seleccionadas combinadas con %{title}
     delete:

--- a/config/locales/article/article-fr.yml
+++ b/config/locales/article/article-fr.yml
@@ -9,6 +9,7 @@ fr:
         one: 1 sujet fait référence à %{article}
         other: "%{count} sujets font référence à %{article}"
       show_pages_that_mention: Afficher les pages qui mentionnent %{article} dans tous les œuvres
+      in_the_work: "dans %{work}"
     combine_duplicate:
       selected_subjects_combined: Sujets sélectionnés combinés avec %{title}
     delete:

--- a/config/locales/article/article-pt.yml
+++ b/config/locales/article/article-pt.yml
@@ -9,6 +9,7 @@ pt:
         one: 1 assunto refere-se a %{article}
         other: "%{count} assuntos referem-se a %{article}"
       show_pages_that_mention: Mostrar páginas que mencionam %{article} em todos as obras
+      in_the_work: " em %{work}"
     combine_duplicate:
       selected_subjects_combined: Temas selecionados combinados com %{title}
     delete:


### PR DESCRIPTION
## Summary
- show the work title when listing pages that reference a subject
- fix translation strings so non-English locales omit redundant "work" wording

## Testing
- `bundle exec rspec spec/models/page_spec.rb` *(fails: rbenv version `2.7.3` is not installed)*


------
https://chatgpt.com/codex/tasks/task_e_6849d7a345448322bc48134117fa8dcd