### PR TITLE
Fix duplicate slug cleanup (#4067 duplicate slugs)

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -106,6 +106,7 @@ class Collection < ApplicationRecord
   before_create :set_link_help
   after_create :create_categories
   after_save :set_next_untranscribed_page
+  after_save :cleanup_duplicate_slug, if: -> { saved_change_to_slug? }
 
   mount_uploader :picture, PictureUploader
 
@@ -368,6 +369,20 @@ class Collection < ApplicationRecord
   def uniquify_slug
     if DocumentSet.where(slug: self.slug).exists?
       self.slug = self.slug+'-collection'
+    end
+  end
+
+  def cleanup_duplicate_slug
+    duplicates = FriendlyId::Slug
+                   .where(slug: slug, sluggable_type: %w[Collection DocumentSet])
+                   .where.not(sluggable_type: self.class.name, sluggable_id: id)
+
+    duplicates.each do |dup|
+      obj = dup.sluggable
+      next unless obj.respond_to?(:owner_user_id)
+      next unless obj.owner_user_id == owner_user_id
+      next if obj.slug == slug
+      dup.destroy if obj.slugs.count > 1
     end
   end
 

--- a/app/models/document_set.rb
+++ b/app/models/document_set.rb
@@ -54,6 +54,7 @@ class DocumentSet < ApplicationRecord
   has_many :bulk_exports, dependent: :delete_all
 
   after_save :set_next_untranscribed_page
+  after_save :cleanup_duplicate_slug, if: -> { saved_change_to_slug? }
 
   validates :title, presence: true, length: { minimum: 3, maximum: 255 }
   validates :slug, format: { with: /[[:alpha:]]/ }
@@ -123,6 +124,20 @@ class DocumentSet < ApplicationRecord
 
   def uniquify_slug
     self.slug = "#{slug}-set" if Collection.where(slug: slug).exists?
+  end
+
+  def cleanup_duplicate_slug
+    duplicates = FriendlyId::Slug
+                   .where(slug: slug, sluggable_type: %w[Collection DocumentSet])
+                   .where.not(sluggable_type: self.class.name, sluggable_id: id)
+
+    duplicates.each do |dup|
+      obj = dup.sluggable
+      next unless obj.respond_to?(:owner_user_id)
+      next unless obj.owner_user_id == owner_user_id
+      next if obj.slug == slug
+      dup.destroy if obj.slugs.count > 1
+    end
   end
 
   delegate :metadata_coverages,          to: :collection

--- a/spec/models/document_set_spec.rb
+++ b/spec/models/document_set_spec.rb
@@ -52,4 +52,20 @@ RSpec.describe DocumentSet, type: :model do
       expect(docset.next_untranscribed_page).to eq(page_incomplete)
     end
   end
+
+  describe '#cleanup_duplicate_slug' do
+    it 'removes duplicate slugs from other objects for the same owner' do
+      owner = create(:owner)
+      docset = create(:document_set, owner: owner)
+      dup_slug = docset.slug
+
+      docset.update!(slug: 'new-slug')
+
+      collection = create(:collection, owner: owner)
+      collection.update!(slug: dup_slug)
+
+      types = FriendlyId::Slug.where(slug: dup_slug).pluck(:sluggable_type)
+      expect(types).to eq(['Collection'])
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- clean up duplicate slugs on collection/document set updates
- test that duplicates are removed

Fixes #4067.


------
https://chatgpt.com/codex/tasks/task_e_68506ffa5bf083288c30a920fcc06eb4