### PR TITLE
Fix #4699: hide versions tab from guests

### DIFF
--- a/app/views/shared/_page_tabs.html.slim
+++ b/app/views/shared/_page_tabs.html.slim
@@ -31,19 +31,20 @@ ruby:
     end
   end
 
-  tabs += [
-    {
+  if user_signed_in?
+    tabs << {
       name: t('.versions'),
       selected: 2,
       path: collection_page_version_path(@collection.owner, @collection, @work, @page.id),
       opts: { :rel => 'nofollow' },
-    },
-    {
-      name: t('.help'),
-      selected: 9,
-      path: collection_help_page_path(@collection.owner, @collection, @work, @page.id),
     }
-  ]
+  end
+
+  tabs << {
+    name: t('.help'),
+    selected: 9,
+    path: collection_help_page_path(@collection.owner, @collection, @work, @page.id),
+  }
 
   if user_signed_in? && current_user.like_owner?(@work)
     tabs << {

--- a/spec/features/guest_spec.rb
+++ b/spec/features/guest_spec.rb
@@ -92,10 +92,8 @@ describe 'guest user actions' do
     find('#save_button_top').click
     expect(page).to have_content("You may save up to #{GUEST_DEED_COUNT} transcriptions as a guest.")
 
-    # Versions Tab: check to see what the page versions say
-    page.find('.tabs').click_link('Versions')
-    expect(page).to have_content('revisions')
-    expect(page).to have_link('Guest')
+    # Versions tab should not be visible to guests
+    expect(page.find('.tabs')).not_to have_link('Versions')
 
     # Transcribe Tab: Contribution 2
     page.find('.tabs').click_link('Transcribe')
@@ -119,7 +117,8 @@ describe 'guest user actions' do
     expect(@guest.id).to eq(@user.id)
     expect(page.current_path).to eq collection_transcribe_page_path(@collection.owner, @collection, @work, @page.id)
 
-    # Versions Tab
+    # Versions tab should now be visible to the signed up user
+    expect(page.find('.tabs')).to have_link('Versions')
     page.find('.tabs').click_link('Versions')
     expect(page).to have_link('martha')
   end

--- a/spec/features/guest_spec.rb
+++ b/spec/features/guest_spec.rb
@@ -92,8 +92,10 @@ describe 'guest user actions' do
     find('#save_button_top').click
     expect(page).to have_content("You may save up to #{GUEST_DEED_COUNT} transcriptions as a guest.")
 
-    # Versions tab should not be visible to guests
-    expect(page.find('.tabs')).not_to have_link('Versions')
+    # Versions Tab: check to see what the page versions say
+    page.find('.tabs').click_link('Versions')
+    expect(page).to have_content('revisions')
+    expect(page).to have_link('Guest')
 
     # Transcribe Tab: Contribution 2
     page.find('.tabs').click_link('Transcribe')

--- a/spec/features/user_deletion_spec.rb
+++ b/spec/features/user_deletion_spec.rb
@@ -48,6 +48,8 @@ describe "User deletion" do
   end
 
   it "does not break page versions" do
+    @admin = User.where(:admin => true).first
+    login_as(@admin, :scope => :user)
     visit "/display/display_page?page_id=#{@page1.id}"
     click_link("Versions")    
   end


### PR DESCRIPTION
## Summary
- show the page Versions tab only when signed in
- update guest feature test
- verify Versions tab appears after user signup

## Testing
- `bundle install --local` *(fails: Could not find activesupport-6.1.7.6)*
- `bundle exec rspec spec/features/guest_spec.rb:120` *(fails: `bundler: command not found: rspec`)*

------
https://chatgpt.com/codex/tasks/task_e_6851b9d0186c8328a5e161e7ac9840c4