### PR TITLE
Fix warning by pinning mail gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ gem 'bootsnap', require: false
 gem 'puma'
 
 gem 'active_link_to'
+gem 'mail', '~> 2.7'
 
 gem 'warning'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,11 +348,8 @@ GEM
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.8.1)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
     memory_profiler (1.0.1)
@@ -371,19 +368,10 @@ GEM
     mustache (1.1.1)
     mutex_m (0.2.0)
     mysql2 (0.5.6)
-    net-imap (0.4.10)
-      date
-      net-protocol
-    net-pop (0.1.2)
-      net-protocol
-    net-protocol (0.2.2)
-      timeout
     net-scp (4.0.0)
       net-ssh (>= 2.6.5, < 8.0.0)
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
-    net-smtp (0.5.0)
-      net-protocol
     net-ssh (7.2.3)
     newrelic_rpm (9.13.0)
     nio4r (2.7.1)
@@ -699,6 +687,7 @@ DEPENDENCIES
   bootsnap
   browser (~> 2.0)
   bullet
+  mail (~> 2.7)
   capistrano (~> 3.10)
   capistrano-bundler (~> 1.6)
   capistrano-rails (~> 1.4)


### PR DESCRIPTION
## Summary
- pin the `mail` gem to the 2.7 series
- update `Gemfile.lock` to remove `net-` gems that conflict with Ruby 2.7

This avoids warnings from `Net::ProtocRetryError` constant redefinitions when starting Rails.

## Testing
- `bundle exec rails -v` *(fails: rbenv version `2.7.3` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685b093338f08322acc9126ab4dd3b14