### PR TITLE
Fix admin restriction on bulk export pages

### DIFF
--- a/app/controllers/bulk_export_controller.rb
+++ b/app/controllers/bulk_export_controller.rb
@@ -1,4 +1,5 @@
 class BulkExportController < ApplicationController
+  before_action :authorized?, only: [:index, :show]
   before_action :set_bulk_export, only: [:show, :edit, :download]
 
   PAGES_PER_SCREEN = 20
@@ -159,6 +160,12 @@ class BulkExportController < ApplicationController
       @bulk_export.submit_export_process
 
       flash[:info] = t('.export_running_message', email: (current_user.email))
+    end
+  end
+
+  def authorized?
+    unless user_signed_in? && current_user.admin
+      redirect_to dashboard_path
     end
   end
 

--- a/spec/requests/bulk_export_controller_spec.rb
+++ b/spec/requests/bulk_export_controller_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe BulkExportController do
+  let!(:admin) { create(:admin) }
+  let!(:bulk_export) { create(:bulk_export, user_id: admin.id) }
+
+  describe '#index' do
+    let(:action_path) { bulk_export_index_path }
+    let(:subject) { get action_path }
+
+    it 'redirects when not logged in' do
+      subject
+      expect(response).to have_http_status(:redirect)
+      expect(response).to redirect_to(dashboard_path)
+    end
+
+    it 'renders when logged in as admin' do
+      login_as admin
+      subject
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:index)
+    end
+  end
+
+  describe '#show' do
+    let(:action_path) { bulk_export_show_path(bulk_export_id: bulk_export.id) }
+    let(:subject) { get action_path }
+
+    it 'redirects when not logged in' do
+      subject
+      expect(response).to have_http_status(:redirect)
+      expect(response).to redirect_to(dashboard_path)
+    end
+
+    it 'renders when logged in as admin' do
+      login_as admin
+      subject
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:show)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- restrict bulk export index and show actions to admins only
- add request specs covering unauthenticated and admin access

## Testing
- `bundle exec rspec spec/requests/bulk_export_controller_spec.rb --format documentation --color` *(fails: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_685add32f7108328a4639a3453a9de53