### PR TITLE
Add import_GRI rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ gem 'http_accept_language'
 gem 'rails-i18n', '~> 6.0.0'
 
 gem 'charlock_holmes'
+gem 'roo'
 gem 'forty_facets'
 
 gem 'diffy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,7 +196,6 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    date (3.3.4)
     db_text_search (1.0.0)
       activerecord (>= 4.1.15)
     debug_inspector (1.2.0)
@@ -506,6 +505,9 @@ GEM
       observer (~> 0.1)
       pkg-config (~> 1.4)
     roman (0.2.0)
+    roo (2.10.1)
+      nokogiri (~> 1)
+      rubyzip (>= 1.3.0, < 3.0.0)
     rouge (4.2.1)
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
@@ -635,7 +637,6 @@ GEM
       timeago_js (>= 3.0.2.2)
     tilt (2.3.0)
     timeago_js (3.0.2.2)
-    timeout (0.4.1)
     turbo-rails (2.0.11)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
@@ -687,7 +688,6 @@ DEPENDENCIES
   bootsnap
   browser (~> 2.0)
   bullet
-  mail (~> 2.7)
   capistrano (~> 3.10)
   capistrano-bundler (~> 1.6)
   capistrano-rails (~> 1.4)
@@ -724,6 +724,7 @@ DEPENDENCIES
   jquery-ui-sass-rails
   launchy
   listen
+  mail (~> 2.7)
   memory_profiler
   meta_request
   mysql2
@@ -749,6 +750,7 @@ DEPENDENCIES
   recaptcha
   riiif!
   rmagick
+  roo
   rspec-rails
   rtl
   ruby-openai

--- a/lib/tasks/import_gri.rake
+++ b/lib/tasks/import_gri.rake
@@ -10,6 +10,7 @@ namespace :fromthepage do
     end
 
     work = Work.find(work_id)
+    User.current_user = work.collection.owner
     sheet = Roo::Spreadsheet.open(spreadsheet_path).sheet(0)
     headers = sheet.row(1)
 
@@ -68,8 +69,9 @@ namespace :fromthepage do
       end
 
       page.source_text = lines.join("\n")
+      page.status = Page.statuses[:transcribed]
       if !page.save 
-	binding.pry 
+	       binding.pry 
       end
       puts "Updated page #{page.title} with #{rows.length} rows"
     end

--- a/lib/tasks/import_gri.rake
+++ b/lib/tasks/import_gri.rake
@@ -1,0 +1,83 @@
+namespace :fromthepage do
+  desc 'Import GRI spreadsheet and update pages with markdown tables'
+  task :import_GRI, [:spreadsheet_path, :work_id] => :environment do |t, args|
+    require 'roo'
+    spreadsheet_path = args[:spreadsheet_path]
+    work_id = args[:work_id]
+    if spreadsheet_path.nil? || work_id.nil?
+      puts 'Usage: rake fromthepage:import_GRI[spreadsheet_path,work_id]'
+      next
+    end
+
+    work = Work.find(work_id)
+    sheet = Roo::Spreadsheet.open(spreadsheet_path).sheet(0)
+    headers = sheet.row(1)
+
+    data = Hash.new { |h, k| h[k] = [] }
+
+    (2..sheet.last_row).each do |i|
+      row_values = sheet.row(i)
+      row = Hash[headers.zip(row_values)]
+      stock_book = row['Stock Book ID']
+      data[stock_book] << row
+    end
+
+    work_pages = work.pages.to_a
+
+    data.each do |stock_book_id, rows|
+      page = work_pages.find do |p|
+        p.title == stock_book_id ||
+          File.basename(p.base_image.to_s, File.extname(p.base_image.to_s)) == stock_book_id
+      end
+
+      unless page
+        puts "Page not found for Stock Book ID #{stock_book_id}"
+        next
+      end
+
+      headers_out = [
+        'Row Number',
+        'Stock Number',
+        'Verbatim Object Description',
+        'Object Type',
+        'Culture/Origin',
+        'Location',
+        'Associated Name',
+        'Right Margin Price'
+      ]
+
+      lines = []
+      lines << '| ' + headers_out.join(' | ') + ' |'
+      lines << '| ' + headers_out.map { '---' }.join(' | ') + ' |'
+
+      rows.each do |row|
+        culture = wiki_link(row['Culture/Origin [tag]'], row['Culture/Origin'])
+        location = wiki_link(row['Location [tag]'], row['Location'])
+        assoc = wiki_link(row['Associated name [tag]'], row['Associated Name'])
+        values = [
+          row['Row Number'],
+          row['Stock Number'],
+          row['Verbatim Object Description'],
+          row['Object Type'],
+          culture,
+          location,
+          assoc,
+          row['Right Margin Price']
+        ]
+        lines << '| ' + values.map { |v| v.to_s }.join(' | ') + ' |'
+      end
+
+      page.source_text = lines.join("\n")
+      page.save!
+      puts "Updated page #{page.title} with #{rows.length} rows"
+    end
+  end
+
+  def wiki_link(tag, value)
+    if tag.present? && value.present?
+      "[[#{tag}|#{value}]]"
+    else
+      value.to_s
+    end
+  end
+end

--- a/lib/tasks/import_gri.rake
+++ b/lib/tasks/import_gri.rake
@@ -68,7 +68,9 @@ namespace :fromthepage do
       end
 
       page.source_text = lines.join("\n")
-      page.save!
+      if !page.save 
+	binding.pry 
+      end
       puts "Updated page #{page.title} with #{rows.length} rows"
     end
   end


### PR DESCRIPTION
## Summary
- add `roo` gem for spreadsheet parsing
- create `fromthepage:import_GRI` task to import spreadsheet rows into pages

## Testing
- `bundle exec rake spec` *(fails: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_686e963d6b7c83288347a5a1cbb4bc8c