### PR TITLE
Escape ampersands in TEI export

### DIFF
--- a/app/helpers/export_helper.rb
+++ b/app/helpers/export_helper.rb
@@ -406,9 +406,9 @@ module ExportHelper
     tei << "              <gloss>#{xml_to_export_tei(subject.xml_text,ExportContext.new, "SD#{subject.id}")}</gloss>\n" unless subject.source_text.blank?
     unless subject.bibliography.blank?
       subject.bibliography.split("\n").each do |line|
-        unless line.blank?
-          tei << "<bibl>#{line.chomp}</bibl>"
-        end
+        next if line.blank?
+        escaped_line = ERB::Util.html_escape(line.chomp)
+        tei << "<bibl>#{escaped_line}</bibl>"
       end
     end
 

--- a/app/views/export/tei.html.erb
+++ b/app/views/export/tei.html.erb
@@ -112,9 +112,9 @@ xml:id="<%=@work.identifier||@work.id%>">
         <listPerson>
           <% @person_articles.each do |person| %>
             <person xml:id="S<%=person.id%>">
-              <persName><%= person.title %></persName>
+              <persName><%= h(person.title) %></persName>
               <% unless person.uri.blank? %>
-                <idno><%= person.uri %></idno>
+                <idno><%= h(person.uri) %></idno>
               <% end %>
               <% unless person.birth_date.blank? %>
                 <event type="birth"  when="<%=person.birth_date%>">
@@ -162,7 +162,7 @@ xml:id="<%=@work.identifier||@work.id%>">
               <% unless person.bibliography.blank? %>
                 <% person.bibliography.split("\n").each do |line| %>
                   <% unless line.blank? %>
-                    <bibl><%= line.chomp %></bibl>
+                    <bibl><%= h(line.chomp) %></bibl>
                   <% end %>
                 <% end %>
               <% end %>
@@ -175,9 +175,9 @@ xml:id="<%=@work.identifier||@work.id%>">
         <listPlace>
           <% @place_articles.each do |place| %>
             <place xml:id="S<%=place.id%>">
-              <placeName><%= place.title %></placeName>
+              <placeName><%= h(place.title) %></placeName>
               <% unless place.uri.blank? %>
-                <idno><%= place.uri %></idno>
+                <idno><%= h(place.uri) %></idno>
               <% end %>
               <% if place.categories %>
                 <note type="categorization">
@@ -213,7 +213,7 @@ xml:id="<%=@work.identifier||@work.id%>">
               <% unless place.bibliography.blank? %>
                 <% place.bibliography.split("\n").each do |line| %>
                   <% unless line.blank? %>
-                    <bibl><%= line.chomp %></bibl>
+                    <bibl><%= h(line.chomp) %></bibl>
                   <% end %>
                 <% end %>
               <% end %>


### PR DESCRIPTION
## Summary
- escape bibliography lines when building TEI
- ensure person and place metadata are XML-escaped

## Testing
- `bundle install` *(fails: installing gems like `sassc`)*

------
https://chatgpt.com/codex/tasks/task_e_68700fc8eb9c832891a9cc7201c2aecb