### PR TITLE
Implement ALTO aligner

### DIFF
--- a/lib/alto_aligner.rb
+++ b/lib/alto_aligner.rb
@@ -1,0 +1,72 @@
+module AltoAligner
+  # Produce new ALTO XML for a page by replacing the OCR words with
+  # the words from the page's verbatim transcription.  The original
+  # word bounding boxes are preserved.
+  #
+  # The algorithm first finds uniquely occurring words in both the OCR
+  # text and the corrected text. These unique words are used as anchor
+  # points to recursively align the two word lists. Remaining segments
+  # without anchors are aligned sequentially.
+  def self.corrected_alto_xml(page)
+    raise ArgumentError, 'page must be transcribed' unless page.status_transcribed?
+    raise ArgumentError, 'page must have ALTO XML' unless page.has_alto?
+
+    doc = Nokogiri::XML(page.alto_xml)
+    string_nodes = doc.xpath('//String')
+    ocr_words = string_nodes.map { |s| s['CONTENT'] }
+    corrected_words = page.verbatim_transcription_plaintext.split(/\s+/)
+
+    mapping = align_words(ocr_words, corrected_words)
+    mapping.each do |ocr_idx, cor_idx|
+      next if ocr_idx.nil? || cor_idx.nil?
+      next unless string_nodes[ocr_idx] && corrected_words[cor_idx]
+      string_nodes[ocr_idx]['CONTENT'] = corrected_words[cor_idx]
+    end
+
+    doc.to_xml
+  end
+
+  class << self
+    private
+
+    def align_words(ocr_words, corrected_words)
+      align_span(ocr_words, corrected_words, 0, 0)
+    end
+
+    def align_span(ocr, cor, off_ocr, off_cor)
+      return [] if ocr.empty? || cor.empty?
+
+      anchors = unique_anchors(ocr, cor, off_ocr, off_cor)
+      if anchors.empty?
+        len = [ocr.length, cor.length].min
+        return (0...len).map { |i| [off_ocr + i, off_cor + i] }
+      end
+
+      mapping = []
+      last_o = 0
+      last_c = 0
+      anchors.each do |ao, ac|
+        mapping.concat(align_span(ocr[last_o...ao - off_ocr], cor[last_c...ac - off_cor], off_ocr + last_o, off_cor + last_c))
+        mapping << [ao, ac]
+        last_o = ao - off_ocr + 1
+        last_c = ac - off_cor + 1
+      end
+      mapping.concat(align_span(ocr[last_o..-1] || [], cor[last_c..-1] || [], off_ocr + last_o, off_cor + last_c))
+      mapping
+    end
+
+    def unique_anchors(ocr, cor, off_o, off_c)
+      ocr_pos = Hash.new { |h, k| h[k] = [] }
+      ocr.each_with_index { |w, i| ocr_pos[w] << i }
+      cor_pos = Hash.new { |h, k| h[k] = [] }
+      cor.each_with_index { |w, i| cor_pos[w] << i }
+
+      anchors = []
+      ocr_pos.each do |w, pos|
+        next unless pos.length == 1 && cor_pos[w]&.length == 1
+        anchors << [pos.first + off_o, cor_pos[w].first + off_c]
+      end
+      anchors.sort_by(&:first)
+    end
+  end
+end

--- a/spec/models/alto_aligner_spec.rb
+++ b/spec/models/alto_aligner_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+RSpec.describe AltoAligner do
+  describe '.corrected_alto_xml' do
+    it 'replaces OCR words with words from verbatim transcription' do
+      page = build(:page, :transcribed)
+      allow(page).to receive(:has_alto?).and_return(true)
+      alto = <<~XML
+        <alto>
+          <Layout>
+            <Page>
+              <PrintSpace>
+                <TextBlock>
+                  <TextLine>
+                    <String CONTENT="Helo" HPOS="10" VPOS="10" WIDTH="30" HEIGHT="10"/>
+                    <String CONTENT="world" HPOS="50" VPOS="10" WIDTH="30" HEIGHT="10"/>
+                  </TextLine>
+                </TextBlock>
+              </PrintSpace>
+            </Page>
+          </Layout>
+        </alto>
+      XML
+      allow(page).to receive(:alto_xml).and_return(alto)
+      allow(page).to receive(:verbatim_transcription_plaintext).and_return('Hello world')
+
+      new_xml = AltoAligner.corrected_alto_xml(page)
+      doc = Nokogiri::XML(new_xml)
+      words = doc.xpath('//String').map { |s| s['CONTENT'] }
+      expect(words).to eq(['Hello', 'world'])
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add `AltoAligner` to rebuild ALTO XML from verbatim text
- test ALTO aligning on a stubbed page

## Testing
- `bundle exec rspec spec/models/alto_aligner_spec.rb --format documentation --out /tmp/rspec.txt` *(fails: rbenv version `2.7.3` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68719a0fbd3c8322b49ff818ec562a63