### PR TITLE
4760 - Integrate DelayedJob for job monitoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       RAILS_ENV: test
       MYSQL_ROOT_PASSWORD: password
       MYSQL_SOCKET: /tmp/mysql.sock
+      ENABLE_DELAYED_JOB: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -38,6 +39,9 @@ jobs:
         run: bundle exec rake db:migrate
       - name: Load fixtures
         run: bundle exec rake db:fixtures:load FIXTURES_PATH=spec/fixtures
+      - name: Run Delayed Job worker
+        run: bin/delayed_job start &
+        continue-on-error: true
       - name: Run RuboCop
         run: bundle exec rubocop
         continue-on-error: true

--- a/Gemfile
+++ b/Gemfile
@@ -159,3 +159,7 @@ gem 'ajax-datatables-rails', '~> 1.0.0'
 
 # Elasticsearch client
 gem 'elasticsearch', '8.15.0'
+
+gem 'daemons'
+gem 'delayed_job_active_record'
+gem 'delayed_job_web'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
+    daemons (1.4.1)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.1.0)
@@ -200,6 +201,16 @@ GEM
       activerecord (>= 4.1.15)
     debug_inspector (1.2.0)
     deep_merge (1.2.2)
+    delayed_job (4.1.13)
+      activesupport (>= 3.0, < 9.0)
+    delayed_job_active_record (4.1.11)
+      activerecord (>= 3.0, < 9.0)
+      delayed_job (>= 3.0, < 5)
+    delayed_job_web (1.4.4)
+      activerecord (> 3.0.0)
+      delayed_job (> 2.0.3)
+      rack-protection (>= 1.5.5)
+      sinatra (>= 1.4.4)
     deprecation (1.1.0)
       activesupport
     device_detector (1.0.7)
@@ -365,6 +376,8 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.4.0)
     mustache (1.1.1)
+    mustermann (3.0.3)
+      ruby2_keywords (~> 0.0.1)
     mutex_m (0.2.0)
     mysql2 (0.5.6)
     net-scp (4.0.0)
@@ -445,6 +458,9 @@ GEM
       rack (< 4)
     rack-mini-profiler (3.3.1)
       rack (>= 1.2.0)
+    rack-protection (3.2.0)
+      base64 (>= 0.1.0)
+      rack (~> 2.2, >= 2.2.4)
     rack-proxy (0.7.7)
       rack
     rack-reverse-proxy (0.12.0)
@@ -579,6 +595,11 @@ GEM
     simplecov-html (0.12.3)
     simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
+    sinatra (3.2.0)
+      mustermann (~> 3.0)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.2.0)
+      tilt (~> 2.0)
     slim (5.2.1)
       temple (~> 0.10.0)
       tilt (>= 2.1.0)
@@ -696,7 +717,10 @@ DEPENDENCIES
   charlock_holmes
   clipboard-rails
   config
+  daemons
   database_cleaner
+  delayed_job_active_record
+  delayed_job_web
   devise
   devise-encryptable
   devise_masquerade (~> 1.2.0)

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,8 +37,8 @@ module Fromthepage
     config.upload_host=nil
 
 
-  # load overrides for Thredded and other engines
-  # config/application.rb
+    # load overrides for Thredded and other engines
+    # config/application.rb
     overrides = "#{Rails.root}/app/overrides"
     Rails.autoloaders.main.ignore(overrides)
 
@@ -47,9 +47,14 @@ module Fromthepage
         load override
       end
     end
+
+    if Settings.enable_delayed_job
+      config.active_job.queue_adapter = :delayed_job
+    else
+      config.active_job.queue_adapter = :async
+    end
   end
 
-
-  #uncomment for development of SSO
-  #Rails.application.config.action_controller.forgery_protection_origin_check=false
+  # uncomment for development of SSO
+  # Rails.application.config.action_controller.forgery_protection_origin_check=false
 end

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,0 +1,16 @@
+if Settings.enable_delayed_job
+  Delayed::Worker.destroy_failed_jobs = false
+  Delayed::Worker.sleep_delay = 60
+  Delayed::Worker.max_attempts = 3
+  Delayed::Worker.max_run_time = 60.minutes
+  Delayed::Worker.read_ahead = 10
+  Delayed::Worker.default_queue_name = 'default'
+  Delayed::Worker.delay_jobs = !Rails.env.test?
+  Delayed::Worker.raise_signal_exceptions = :term
+  Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))
+
+  DelayedJobWeb.use Rack::Auth::Basic do |username, password|
+    user = User.find_by(login: username)
+    user&.valid_password?(password) && user.admin?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Fromthepage::Application.routes.draw do
+  mount DelayedJobWeb, at: '/delayed_job' if Settings.enable_delayed_job
+
   resources :external_api_requests
   # TODO make the URL fall under user and collection profile
   scope ':user_slug' do

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,5 @@
 ---
+enable_delayed_job: <%= ENV['ENABLE_DELAYED_JOB'] == 'true' %>
 spammy_emails:
   tlds:
     - io

--- a/db/migrate/20250716175147_create_delayed_jobs.rb
+++ b/db/migrate/20250716175147_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration[6.1]
+  def self.up
+    create_table :delayed_jobs do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_06_11_171909) do
+ActiveRecord::Schema.define(version: 2025_07_16_175147) do
 
   create_table "ahoy_activity_summaries", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.datetime "date"
@@ -269,6 +269,21 @@ ActiveRecord::Schema.define(version: 2025_06_11_171909) do
     t.index ["visit_id"], name: "index_deeds_on_visit_id"
     t.index ["work_id", "created_at"], name: "index_deeds_on_work_id_and_created_at"
     t.index ["work_id", "deed_type", "user_id", "created_at"], name: "index_deeds_on_work_id_and_deed_type_and_user_id_and_created_at"
+  end
+
+  create_table "delayed_jobs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at", precision: 6
+    t.datetime "updated_at", precision: 6
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   create_table "document_set_collaborators", id: false, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|


### PR DESCRIPTION
Will be adding this in wiki once PR is merged:

h2. Async job monitoring

FromThePage provides optional asynchronous job adapter `delayed_job` which will store async jobs to db which allow admins to monitor and manage job logs.

To enable, set environment variable `ENABLE_DELAYED_JOB=true`. Once set, running `rails server` should move all async job processes thru delayed_job adapter. This will only enqueue the jobs in DB. In order to start processing them, we need to start a worker. Run `bin/delayed_job run` to start a worker. 

For production environment, every `redeploy` or server restart, we will need to run `bin/delayed_job stop` then `bin/delayed_job start` to restart the workers.

More info about [delayed_job](https://github.com/collectiveidea/delayed_job) here.