### PR TITLE
Fix last seen date on profile

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -441,6 +441,10 @@ class User < ApplicationRecord
     end
   end
 
+  def last_deed_at
+    deeds.maximum(:created_at)
+  end
+
   def self.search(search)
     wildcard = "%#{search}%"
     where("display_name LIKE ? OR login LIKE ? OR real_name LIKE ? OR email LIKE ?", wildcard, wildcard, wildcard, wildcard)

--- a/app/views/user/_user_profile.html.slim
+++ b/app/views/user/_user_profile.html.slim
@@ -23,8 +23,8 @@ section.user-profile
         br
       span ="#{number_with_delimiter(user.deeds.count)} #{t('user.profile.contribution', count: user.deeds.count)}"
       span = t('user.profile.user_since', date: l(user.created_at.to_date))
-      -if user.last_sign_in_at.present?
-        span = t('user.profile.last_seen', date: l(user.last_sign_in_at.to_date))
+      -if user.last_deed_at.present?
+        span = t('user.profile.last_seen', date: l(user.last_deed_at.to_date))
 
 h2 =t('user.profile.recent_activity_by', user_display_name: @user.display_name)
 table.datagrid.striped

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+RSpec.describe User, type: :model do
+  describe '#last_deed_at' do
+    let(:user) { create(:user) }
+
+    it 'returns the created_at of the most recent deed' do
+      allow_any_instance_of(Deed).to receive(:calculate_prerender)
+      allow_any_instance_of(Deed).to receive(:calculate_prerender_mailer)
+      older = create(:deed, user: user, deed_type: DeedType.all_types.first, created_at: 2.days.ago)
+      newest = create(:deed, user: user, deed_type: DeedType.all_types.first, created_at: 1.day.ago)
+      expect(user.last_deed_at.to_i).to eq(newest.created_at.to_i)
+      Deed.destroy(older.id)
+      Deed.destroy(newest.id)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- show last deed date on user profiles as "last seen"
- support new `User#last_deed_at`
- test `last_deed_at`

## Testing
- `bundle exec rspec spec/models/user_spec.rb --format doc` *(fails: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_687e8d85ae508328a0301faebc7aba32