### PR TITLE
Add note about overnight stats update

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -391,6 +391,12 @@ class DashboardController < ApplicationController
     end
     @time_duration = time_spent_in_date_range(current_user.id, @start_date_hours, @end_date_hours)
 
+    last_summary = AhoyActivitySummary.where(user_id: current_user.id)
+                                      .where.not(collection_id: nil)
+                                      .order(date: :desc)
+                                      .first
+    @last_calculation_date = last_summary&.date&.end_of_day
+
     raw = Deed.where(user_id: current_user.id, created_at: [@start_date_hours..@end_date_hours]).pluck(:collection_id, :page_id).uniq
     @collection_id_to_page_count = raw.select { |collection_id, page_id| !page_id.nil? }.map{ |collection_id, page_id| collection_id }.tally
     @user_collections = Collection.find(@collection_id_to_page_count.keys).sort{|a,b| a.owner.display_name <=> b.owner.display_name}

--- a/app/views/dashboard/your_hours.html.slim
+++ b/app/views/dashboard/your_hours.html.slim
@@ -15,6 +15,9 @@ h2 = t('.select_new_date')
 
 h3 = t('.hours_details_message', user_name: current_user.real_name, time_duration: @time_duration, start_date: l(@start_date_hours), end_date: l(@end_date_hours))
 
+- time_ago = @last_calculation_date.present? ? I18n.t('time_ago_in_words', time: time_ago_in_words(@last_calculation_date)) : ''
+p = t('.hours_update_note', time_ago: time_ago)
+
 -if @user_collections.present?
   table.admin-grid.datagrid.striped
     thead

--- a/config/locales/dashboard/dashboard-de.yml
+++ b/config/locales/dashboard/dashboard-de.yml
@@ -175,7 +175,7 @@ de:
       download_letter: Laden Sie einen Brief herunter
       end_date: Endtermin
       hours_details_message: "%{user_name} hat zwischen %{start_date} und %{end_date} %{time_duration} beigetragen"
+      hours_update_note: Beitragsstatistiken werden alle vierundzwanzig Stunden berechnet. Diese Statistiken spiegeln die Nutzung bis %{time_ago} wider.
       select_new_date: Wählen Sie einen neuen Datumsbereich
       start_date: Startdatum
       update: Aktualisieren
-      hours_update_note: "Beitragsstatistiken werden alle vierundzwanzig Stunden berechnet. Diese Statistiken spiegeln die Nutzung bis %{time_ago} wider."

--- a/config/locales/dashboard/dashboard-de.yml
+++ b/config/locales/dashboard/dashboard-de.yml
@@ -178,3 +178,4 @@ de:
       select_new_date: Wählen Sie einen neuen Datumsbereich
       start_date: Startdatum
       update: Aktualisieren
+      hours_update_note: "Beitragsstatistiken werden alle vierundzwanzig Stunden berechnet. Diese Statistiken spiegeln die Nutzung bis %{time_ago} wider."

--- a/config/locales/dashboard/dashboard-en.yml
+++ b/config/locales/dashboard/dashboard-en.yml
@@ -175,7 +175,7 @@ en:
       download_letter: Download a Letter
       end_date: End date
       hours_details_message: "%{user_name} has contributed %{time_duration} between %{start_date} and %{end_date}"
+      hours_update_note: Contribution statistics are calculated every twenty-four hours. These statistics reflect usage up to %{time_ago}.
       select_new_date: Select a new date range
       start_date: Start date
       update: Update
-      hours_update_note: "Contribution statistics are calculated every twenty-four hours. These statistics reflect usage up to %{time_ago}."

--- a/config/locales/dashboard/dashboard-en.yml
+++ b/config/locales/dashboard/dashboard-en.yml
@@ -178,3 +178,4 @@ en:
       select_new_date: Select a new date range
       start_date: Start date
       update: Update
+      hours_update_note: "Contribution statistics are calculated every twenty-four hours. These statistics reflect usage up to %{time_ago}."

--- a/config/locales/dashboard/dashboard-es.yml
+++ b/config/locales/dashboard/dashboard-es.yml
@@ -175,7 +175,7 @@ es:
       download_letter: Descargar una carta
       end_date: Fecha final
       hours_details_message: "%{user_name} ha contribuido %{time_duration} entre %{start_date} y %{end_date}"
+      hours_update_note: Las estadísticas de contribución se calculan cada veinticuatro horas. Estas estadísticas reflejan el uso hasta %{time_ago}.
       select_new_date: Seleccione un nuevo rango de fechas
       start_date: Fecha de inicio
       update: Actualizar
-      hours_update_note: "Las estadísticas de contribución se calculan cada veinticuatro horas. Estas estadísticas reflejan el uso hasta %{time_ago}."

--- a/config/locales/dashboard/dashboard-es.yml
+++ b/config/locales/dashboard/dashboard-es.yml
@@ -178,3 +178,4 @@ es:
       select_new_date: Seleccione un nuevo rango de fechas
       start_date: Fecha de inicio
       update: Actualizar
+      hours_update_note: "Las estadísticas de contribución se calculan cada veinticuatro horas. Estas estadísticas reflejan el uso hasta %{time_ago}."

--- a/config/locales/dashboard/dashboard-fr.yml
+++ b/config/locales/dashboard/dashboard-fr.yml
@@ -178,3 +178,4 @@ fr:
       select_new_date: Sélectionnez une nouvelle plage de dates
       start_date: Date de début
       update: Mise à jour
+      hours_update_note: "Les statistiques de contribution sont calculées toutes les vingt-quatre heures. Ces statistiques reflètent l'activité jusqu'à %{time_ago}."

--- a/config/locales/dashboard/dashboard-fr.yml
+++ b/config/locales/dashboard/dashboard-fr.yml
@@ -175,7 +175,7 @@ fr:
       download_letter: Télécharger une lettre
       end_date: Date de fin
       hours_details_message: "%{user_name} a contribué %{time_duration} entre le %{start_date} et %{end_date}"
+      hours_update_note: Les statistiques de contribution sont calculées toutes les vingt-quatre heures. Ces statistiques reflètent l'activité jusqu'à %{time_ago}.
       select_new_date: Sélectionnez une nouvelle plage de dates
       start_date: Date de début
       update: Mise à jour
-      hours_update_note: "Les statistiques de contribution sont calculées toutes les vingt-quatre heures. Ces statistiques reflètent l'activité jusqu'à %{time_ago}."

--- a/config/locales/dashboard/dashboard-pt.yml
+++ b/config/locales/dashboard/dashboard-pt.yml
@@ -178,3 +178,4 @@ pt:
       select_new_date: Selecione um novo período
       start_date: Data de início
       update: Atualizar
+      hours_update_note: "As estatísticas de contribuição são calculadas a cada vinte e quatro horas. Essas estatísticas refletem o uso até %{time_ago}."

--- a/config/locales/dashboard/dashboard-pt.yml
+++ b/config/locales/dashboard/dashboard-pt.yml
@@ -175,7 +175,7 @@ pt:
       download_letter: Baixe uma carta
       end_date: Data final
       hours_details_message: "%{user_name} contribuiu com %{time_duration} entre %{start_date} e %{end_date}"
+      hours_update_note: As estatísticas de contribuição são calculadas a cada vinte e quatro horas. Essas estatísticas refletem o uso até %{time_ago}.
       select_new_date: Selecione um novo período
       start_date: Data de início
       update: Atualizar
-      hours_update_note: "As estatísticas de contribuição são calculadas a cada vinte e quatro horas. Essas estatísticas refletem o uso até %{time_ago}."


### PR DESCRIPTION
Closes #4472 

## Summary
- add a new `hours_update_note` translation string in the dashboard locales
- display this note on the Your Hours dashboard page
- include the timestamp of the most recent statistics calculation

## Testing
- `bundle exec rspec spec/requests/dashboard_controller_spec.rb:130 -fd` *(fails: missing gems)*

------
https://chatgpt.com/codex/tasks/task_e_687e8f9180088328a31ef102984a11d4