### PR TITLE
4800 - Subjects elasticsearch architecture

### DIFF
--- a/app/chewy_indexes/articles_index.rb
+++ b/app/chewy_indexes/articles_index.rb
@@ -1,0 +1,24 @@
+class ArticlesIndex < Chewy::Index
+  include ChewyConcern
+
+  index_name formatted_index_name('article')
+  default_import_options batch_size: 1000
+
+  index_scope Article
+
+  field :db_id, type: 'integer', value: -> { id }
+  field :collection_id, type: 'integer'
+  field :docset_id, type: 'integer', value: -> { works.flat_map(&:document_sets).pluck(:id) }
+  field :category_ids, type: 'integer', value: -> { categories.map(&:id) }
+  field :owner_user_id, type: 'integer', value: -> { created_by_id }
+  field :is_public, type: 'boolean', value: -> {
+    !collection&.restricted ||
+      works.flat_map(&:document_sets).any? { |doc_set| ['public', 'read_only'].include?(doc_set.visibility) }
+  }
+
+  field :title, type: 'text', analyzer: 'general' do
+    field :no_underscores, type: 'text', analyzer: 'general_no_underscores'
+  end
+
+  field :content_english, type: 'text', analyzer: 'text_english', value: -> { source_text }
+end

--- a/app/jobs/elasticsearch/collection/sync_job.rb
+++ b/app/jobs/elasticsearch/collection/sync_job.rb
@@ -15,7 +15,8 @@ class Elasticsearch::Collection::SyncJob < ApplicationJob
       end
     end
 
-    WorksIndex.import collection.works
-    PagesIndex.import collection.pages
+    WorksIndex.import collection.works.includes({ collection: :owner }, :document_sets)
+    PagesIndex.import collection.pages.includes(work: [{ collection: :owner }, :document_sets])
+    ArticlesIndex.import collection.articles.includes(:collection, :categories, { works: :document_sets })
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -70,6 +70,54 @@ class Article < ApplicationRecord
   edtf_date_attribute :begun
   edtf_date_attribute :ended
 
+  update_index('articles', if: -> { ELASTIC_ENABLED && !destroyed? }) { self }
+  after_destroy :handle_index_deletion
+
+  def self.es_search(query:, user: nil, is_public: true)
+    blocked_collections = []
+    collection_collabs = []
+    docset_collabs = []
+
+    if user.present?
+      blocked_collections = user.blocked_collections.pluck(:id)
+      collection_collabs  = user.collection_collaborations.pluck(:id)
+      collection_collabs += user.owned_collections.pluck(:id)
+      docset_collabs      = user.document_set_collaborations.pluck(:id)
+    end
+
+    search_fields = [
+      'title^2',
+      'title.no_underscores^1.3',
+      'content_english'
+    ]
+
+    ArticlesIndex.query(
+      bool: {
+        must: {
+          simple_query_string: {
+            query: query,
+            fields: search_fields
+          }
+        },
+        filter: [
+          bool: {
+            must_not: [
+              { terms: { collection_id: blocked_collections } }
+            ],
+            # At least one of the following must be true
+            should: [
+              { term: { is_public: is_public } },
+              { term: { owner_user_id: user&.id || -1 } },
+              { terms: { collection_id: collection_collabs } },
+              { terms: { docset_id: docset_collabs } }
+            ],
+            minimum_should_match: 1
+          }
+        ]
+      }
+    )
+  end
+
   def self.sort_vertically(articles_scope, columns: LIST_NUM_COLUMNS)
     subquery_sql = articles_scope
       .select('articles.*, ROW_NUMBER() OVER (ORDER BY TRIM(articles.title) ASC) AS rn, COUNT(*) OVER () AS total_count')
@@ -234,5 +282,16 @@ class Article < ApplicationRecord
     ancestors = category.ancestors.reverse
 
     [category] + ancestors
+  end
+
+  def handle_index_deletion
+    return unless ELASTIC_ENABLED
+
+    Chewy.client.delete(
+      index: ArticlesIndex.index_name,
+      id: id
+    )
+  rescue StandardError => _e
+    # Make sure it does not fail
   end
 end

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -49,6 +49,7 @@ namespace :fromthepage do
         PagesIndex.delete
         WorksIndex.delete
         UsersIndex.delete
+        ArticlesIndex.delete
 
         client = Chewy.client
 
@@ -80,6 +81,7 @@ namespace :fromthepage do
         PagesIndex.create
         WorksIndex.create
         UsersIndex.create
+        ArticlesIndex.create
       end
 
       desc 'Reindex elements'
@@ -89,6 +91,7 @@ namespace :fromthepage do
         works_scope = Work.includes({ collection: :owner }, :document_sets)
         users_scope = User.all
         pages_scope = Page.includes(work: [{ collection: :owner }, :document_sets])
+        articles_scope = Article.includes(:collection, :categories, { works: :document_sets })
 
         if args[:hours_ago]
           hours_ago = args[:hours_ago].to_i
@@ -101,6 +104,7 @@ namespace :fromthepage do
           works_scope = works_scope.where('most_recent_deed_created_at >= ?', time_threshold)
           users_scope = users_scope.where('updated_at >= ?', time_threshold)
           pages_scope = pages_scope.where('updated_at >= ?', time_threshold)
+          # TODO: We may need updated_at timestamp on articles now
         end
 
         CollectionsIndex.import collections_scope
@@ -108,6 +112,7 @@ namespace :fromthepage do
         WorksIndex.import works_scope
         UsersIndex.import users_scope
         PagesIndex.import pages_scope
+        ArticlesIndex.import articles_scope
       end
 
       desc 'Update collection indices'
@@ -129,6 +134,7 @@ namespace :fromthepage do
         PagesIndex.purge
         WorksIndex.purge
         UsersIndex.purge
+        ArticlesIndex.purge
       end
 
       desc 'Gets Elasticsearch indices data'
@@ -153,6 +159,7 @@ namespace :fromthepage do
         all_indices.each { |idx| puts format_index_line(idx) }
       end
 
+      # TODO: Implement this
       desc 'Querries Elasticsearch via ID'
       task :query, [:id] => :environment do |_, args|
         id = args[:id]

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,0 +1,195 @@
+require 'spec_helper'
+
+# TODO: We want individual es_search specs for other models as well,
+# not just in multi_query_spec
+describe Article do
+  context 'es_search' do
+    let(:identifier) { 'pneumonoultramicroscopicsilicovolcanoconiosis' }
+
+    let!(:owner) { create(:unique_user, :owner) }
+    let!(:public_collection) { create(:collection, owner_user_id: owner.id) }
+    let!(:restricted_collection) { create(:collection, owner_user_id: owner.id, restricted: true) }
+
+    let!(:work_1) { create(:work, collection: public_collection) }
+    let!(:page_1) { create(:page, work: work_1) }
+
+    let!(:work_2) { create(:work, collection: restricted_collection) }
+    let!(:page_2) { create(:page, work: work_2) }
+
+    let!(:work_3) { create(:work, collection: restricted_collection) }
+    let!(:page_3) { create(:page, work: work_3) }
+
+    let!(:public_document_set) do
+      create(
+        :document_set,
+        :public,
+        collection_id: restricted_collection.id,
+        owner_user_id: owner.id,
+        works: [work_3]
+      )
+    end
+
+    # Belongs to public collection
+    let!(:article_1) do
+      create(
+        :article,
+        title: identifier,
+        collection: public_collection,
+        pages: [page_1],
+        created_by_id: owner.id
+      )
+    end
+
+    # Belongs to private collection
+    let!(:article_2) do
+      create(
+        :article,
+        title: identifier,
+        collection: restricted_collection,
+        pages: [page_2],
+        created_by_id: owner.id
+      )
+    end
+
+    # Belongs to private collection, but belongs to public document_set
+    let!(:article_3) do
+      create(
+        :article,
+        title: identifier,
+        collection: restricted_collection,
+        pages: [page_3],
+        created_by_id: owner.id
+      )
+    end
+
+    let!(:other_user) { create(:unique_user, :owner) }
+    let!(:other_public_collection) { create(:collection, owner_user_id: other_user.id) }
+    let!(:other_restricted_collection) { create(:collection, owner_user_id: other_user.id, restricted: true) }
+
+    let!(:work_4) { create(:work, collection: other_public_collection) }
+    let!(:page_4) { create(:page, work: work_4) }
+
+    let!(:work_5) { create(:work, collection: other_restricted_collection) }
+    let!(:page_5) { create(:page, work: work_5) }
+
+    # Belongs to other user public collection
+    let!(:article_4) do
+      create(
+        :article,
+        collection: other_public_collection,
+        pages: [page_4],
+        created_by_id: other_user.id,
+        source_text: identifier
+      )
+    end
+
+    # Belongs to other user private collection
+    let!(:article_5) do
+      create(
+        :article,
+        title: identifier,
+        collection: other_restricted_collection,
+        pages: [page_5],
+        created_by_id: other_user.id
+      )
+    end
+
+    let(:records) do
+      [
+        owner,
+        public_collection,
+        restricted_collection,
+        work_1,
+        page_1,
+        work_2,
+        page_2,
+        work_3,
+        page_3,
+        public_document_set,
+        article_1,
+        article_2,
+        article_3,
+        other_user,
+        other_public_collection,
+        other_restricted_collection,
+        work_4,
+        page_4,
+        work_5,
+        page_5,
+        article_4,
+        article_5
+      ]
+    end
+
+    before(:each) do
+      VCR.configure { |c| c.allow_http_connections_when_no_cassette = true }
+
+      stub_const('ELASTIC_ENABLED', true)
+
+      ArticlesIndex.purge
+      records.each(&:save!)
+    end
+
+    after(:each) do
+      VCR.configure { |c| c.allow_http_connections_when_no_cassette = true }
+
+      stub_const('ELASTIC_ENABLED', true)
+
+      records.reverse.each(&:destroy!)
+      ArticlesIndex.purge
+
+      VCR.configure { |c| c.allow_http_connections_when_no_cassette = false }
+    end
+
+    describe '#self.es_search' do
+      let(:user) { nil }
+
+      let(:es_search) { Article.es_search(query: identifier, user: user, is_public: true) }
+
+      context 'when not logged in' do
+        it 'returns correct article ids' do
+          expect(es_search.pluck("_id").map(&:to_i)).to match_array(
+            [
+              article_1.id,
+              article_3.id,
+              article_4.id
+            ]
+          )
+        end
+      end
+
+      context 'when logged in as owner' do
+        let(:user) { owner }
+
+        it 'returns correct article ids' do
+          expect(es_search.pluck("_id").map(&:to_i)).to match_array(
+            [
+              article_1.id,
+              article_2.id,
+              article_3.id,
+              article_4.id
+            ]
+          )
+        end
+      end
+
+      context 'when logged in as other_user and is blocked on public_collection' do
+        let(:user) { other_user }
+
+        before do
+          public_collection.blocked_users << other_user
+        end
+
+        it 'returns correct article ids' do
+          expect(es_search.pluck("_id").map(&:to_i)).to match_array(
+            [
+              article_3.id,
+              article_4.id,
+              article_5.id
+            ]
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Setup
Inside rails console:
```
ArticlesIndex.create
ArticlesIndex.import Article.includes(:collection, :categories, { works: :document_sets })
```

# Testing
To simplify things I have added `self.es_search` functions inside necessary models that uses es_search so this is not necessarily limited to articles.
Inside rails console:
### Standard query
```
Article.es_search(query: 'Your query string')
```
This will return articles belonging to public collections or belonging to works that belongs to public docset.

### Logged in user query (optional user param)
```
Article.es_search(query: 'Your query string', user: current_user)
```
This will return:
1. Articles belonging to public collections or belonging to works that belongs to public docset.
2. Articles that is owned by current_user even if it is private
3. Articles that belongs to collection that current_user is blocked will not be returned

# Deployment
We can either run the same rails console command as above in setup, OR run reindex rake. I'd rather we run the console version as it will only deal with articles.