### PR TITLE
Ensure Handsontable edits are saved on form submit

### DIFF
--- a/app/views/shared/_handsontable.html.erb
+++ b/app/views/shared/_handsontable.html.erb
@@ -182,6 +182,17 @@
     }
   });
 
+  var form = container.closest('form');
+  if (form) {
+    form.addEventListener('submit', function() {
+      var editor = hot.getActiveEditor();
+      if (editor && editor.isOpened()) {
+        editor.finishEditing();
+      }
+      document.getElementById('<%= "fields-#{transcription_field.id}" %>').value = JSON.stringify(hot.getData());
+    });
+  }
+
   window.addEventListener('load', function() {
     window.onscroll = function (e) {
       freezeTableColumn();


### PR DESCRIPTION
## Summary
- finalize active Handsontable edits before form submission so hidden JSON field captures final cell value

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 2.7.3)*

------
https://chatgpt.com/codex/tasks/task_e_68924ee3d48c8322a7176e53db9ad86c