### PR TITLE
Add hours spent stats to admin dashboard

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -35,6 +35,7 @@ class AdminController < ApplicationController
     @contribution_counts = {}
     @activity_project_counts = {}
     @unique_contributor_counts = {}
+    @hours_spent_counts = {}
     @week_intervals=[ 1, 2, 4, 12, 26, 52, 104, 156, 208 ]
     @week_intervals.each do |weeks_ago|
       start_date = Date.yesterday - weeks_ago.weeks
@@ -43,6 +44,8 @@ class AdminController < ApplicationController
       @contribution_counts[weeks_ago] = contributor_deeds.where('created_at between ? and ?', start_date, end_date).count
       @activity_project_counts[weeks_ago] = contributor_deeds.where('created_at between ? and ?', start_date, end_date).distinct.count(:collection_id)
       @unique_contributor_counts[weeks_ago] = contributor_deeds.where('created_at between ? and ?', start_date, end_date).distinct.count(:user_id)
+      minutes_spent = AhoyActivitySummary.where('date between ? and ?', start_date, end_date).sum(:minutes)
+      @hours_spent_counts[weeks_ago] = minutes_spent.to_f / 60
     end
 
     @version = ActiveRecord::Migrator.current_version

--- a/app/views/admin/index.html.slim
+++ b/app/views/admin/index.html.slim
@@ -36,7 +36,7 @@ table.admin-grid.datagrid.striped
     tr
       td Hours Spent
       -@week_intervals.each do |week_interval|
-        td.aright = number_with_precision(@hours_spent_counts[week_interval], precision: 2)
+        td.aright = number_with_precision(@hours_spent_counts[week_interval], precision: 0)
 
 .section.admin-counters
   =link_to admin_collection_list_path do

--- a/app/views/admin/index.html.slim
+++ b/app/views/admin/index.html.slim
@@ -33,6 +33,10 @@ table.admin-grid.datagrid.striped
       td Unique Active Contributors
       -@week_intervals.each do |week_interval|
         td.aright =@unique_contributor_counts[week_interval]
+    tr
+      td Hours Spent
+      -@week_intervals.each do |week_interval|
+        td.aright = number_with_precision(@hours_spent_counts[week_interval], precision: 2)
 
 .section.admin-counters
   =link_to admin_collection_list_path do


### PR DESCRIPTION
## Summary
- sum Ahoy activity minutes for each week interval and expose the totals as hours on the admin dashboard
- render a new "Hours Spent" row in the admin weekly usage table with precision formatting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d53b6577f88322b7090dfdf5442b51