### PR TITLE
4939 - SolidQueue Worker Service

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -47,7 +47,16 @@ namespace :deploy do
 
   after :publishing, :restart
 
-  after :restart, :clear_cache do
+  after :restart, :restart_solid_queue
+
+  desc 'Restart Solid Queue service'
+  task :restart_solid_queue do
+    on roles(:app) do
+      execute :sudo, :systemctl, 'restart solid_queue'
+    end
+  end
+
+  after :restart_solid_queue, :clear_cache do
     on roles(:web), in: :groups, limit: 3, wait: 10 do
       # Here we can do anything such as:
       # within release_path do


### PR DESCRIPTION
This is to ensure we start a worker every time we redeploy.

This is an outline `solid_queue.service` config file, I'll let Ander Kiereg check this one:

```
[Unit]
Description=Solid Queue worker for FromThePage
After=network.target

[Service]
Type=simple
EnvironmentFile=#path to env files
WorkingDirectory=/home/fromthepage/deployment/current
ExecStart=/bin/bash -lc 'bundle exec rails solid_queue:start'
User=fromthepage
Restart=always
RestartSec=5
StandardOutput=#path to solid_queue logs. This probably should be a linked file instead of actual file to `current` dir as we are `current` on every deploy.
StandardError=syslog
SyslogIdentifier=solid_queue

[Install]
WantedBy=multi-user.target
```

@saracarl In the meantime I started a solid_queue worker in production. We can find the worker's PID at fromthepage.com/solid_queue at `Workers` tab. We can kill it once this one is resolved.