### PR TITLE
Fixes #4973 by treating blank lines in spreadsheet cells as double-lb

### DIFF
--- a/app/models/xml_source_processor.rb
+++ b/app/models/xml_source_processor.rb
@@ -113,7 +113,7 @@ end
     xml_string = clean_script_tags(xml_string)
     xml_string = process_square_braces(xml_string) unless subjects_disabled
     xml_string = process_linewise_markup(xml_string)
-    xml_string = process_line_breaks(xml_string)
+    xml_string = process_line_breaks(xml_string, !page.collection.field_based?)
     xml_string = valid_xml_from_source(xml_string)
     xml_string = update_links_and_xml(xml_string, preview_mode, text_type)
     xml_string = postprocess_xml_markup(xml_string)
@@ -337,9 +337,13 @@ end
   end
 
   # transformations converting source mode transcription to xml
-  def process_line_breaks(text)
-    text="<p>#{text}</p>"
-    text = text.gsub(/\s*\n\s*\n\s*/, '</p><p>')
+  def process_line_breaks(text, add_paragraph_tags = true)
+    if add_paragraph_tags
+      text="<p>#{text}</p>"
+      text = text.gsub(/\s*\n\s*\n\s*/, '</p><p>')
+    else
+      text = text.gsub(/\s*\n\s*\n\s*/, '<lb/><lb/>')
+    end
     text = text.gsub(/([[:word:]]+)-\r\n\s*/, '\1<lb break="no" />')
     text = text.gsub(/\r\n\s*/, '<lb/>')
     text = text.gsub(/([[:word:]]+)-\n\s*/, '\1<lb break="no" />')

--- a/app/views/transcription_field/_field_layout.html.slim
+++ b/app/views/transcription_field/_field_layout.html.slim
@@ -14,7 +14,7 @@
               -preview_cells=@field_preview[field.id]
             -else
               -preview_cells=nil
-            =render({ :partial => '/shared/handsontable', :locals => {:transcription_field => field, :preview_cells => preview_cells} })
+            =render({ partial: '/shared/handsontable', locals: {transcription_field: field, preview_cells: preview_cells} })
         -else
           -span_width = !field.percentage.blank? ? field.percentage : @width
           .field-wrapper(style="width: #{span_width}%")

--- a/app/views/transcription_field/_field_layout.html.slim
+++ b/app/views/transcription_field/_field_layout.html.slim
@@ -10,7 +10,11 @@
         -if field.input_type == 'spreadsheet'
           -span_width = !field.percentage.blank? ? field.percentage : @width
           .field-wrapper.spreadsheet(style="width: #{span_width}%")
-            =render({ :partial => '/shared/handsontable', :locals => {:transcription_field => field, :preview_cells => @field_preview[field.id]} })
+            -if @field_preview
+              -preview_cells=@field_preview[field.id]
+            -else
+              -preview_cells=nil
+            =render({ :partial => '/shared/handsontable', :locals => {:transcription_field => field, :preview_cells => preview_cells} })
         -else
           -span_width = !field.percentage.blank? ? field.percentage : @width
           .field-wrapper(style="width: #{span_width}%")

--- a/spec/tasks/flag_abuse_spec.rb
+++ b/spec/tasks/flag_abuse_spec.rb
@@ -3,7 +3,8 @@ require 'rake'
 
 describe 'Flag abuse rake tasks' do
   before(:all) do
-    Rails.application.load_tasks if Rake::Task.tasks.empty?
+    Rake.application = Rake::Application.new
+    Rails.application.load_tasks
   end
 
   before(:each) do


### PR DESCRIPTION
Fixes #4973.

To reproduce: transcribe a page in a spreadsheet-based project.
In the spreadsheet cell, use `ctrl-return` to create a cell with a blank line like so:
```
First line

Second line
```

Upon saving the page, the parser will fail, either with a 500 error or a warning about unbalanced tags ("found `p`", etc.)