### PR TITLE
Disable bento chat on article edit pages

### DIFF
--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -4,6 +4,7 @@ class ArticleController < ApplicationController
 
   skip_before_action :verify_authenticity_token, only: [:relationship_graph]
   before_action :authorized?, except: [:list, :show, :tooltip, :graph, :relationship_graph]
+  before_action :disable_bento, only: [:edit, :update]
 
   def tooltip
     render partial: 'tooltip'
@@ -364,5 +365,9 @@ class ArticleController < ApplicationController
 
   def article_params
     params.require(:article).permit(:title, :uri, :short_summary, :source_text, :latitude, :longitude, :birth_date, :death_date, :race_description, :sex, :bibliography, :begun, :ended, category_ids: [])
+  end
+
+  def disable_bento
+    @disable_bento = true
   end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -147,7 +147,7 @@ html lang="en-US"
 
     =yield :javascript
 
-    -if defined?(BENTO_ENABLED) && BENTO_ENABLED
+    -if defined?(BENTO_ENABLED) && BENTO_ENABLED && !@disable_bento
         =render :partial => '/shared/bento'
         -if (user_signed_in? && current_user.owner?) || controller_name=='static'
           =render :partial => '/shared/bento_chat'


### PR DESCRIPTION
## Summary
- set a controller flag to disable Bento on article edit views
- skip rendering the Bento scripts when the flag is present so the editor textarea works normally

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fbacb34cb483289b49b1aedc7da3b2