### PR TITLE
Revert "Update annotations"

### DIFF
--- a/app/models/bulk_export.rb
+++ b/app/models/bulk_export.rb
@@ -13,8 +13,6 @@
 #  organization                       :string(255)      default("by_work")
 #  owner_detailed_activity            :boolean
 #  owner_mailing_list                 :boolean
-#  page_details_csv_collection        :boolean          default(FALSE)
-#  page_details_csv_work              :boolean          default(FALSE)
 #  plaintext_emended_page             :boolean
 #  plaintext_emended_work             :boolean
 #  plaintext_searchable_page          :boolean

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -20,7 +20,6 @@
 #  source_translation      :text(16777215)
 #  status                  :string(255)      default("new"), not null
 #  title                   :string(255)
-#  transcription_json      :text(4294967295)
 #  translation_status      :string(255)      default("new"), not null
 #  xml_text                :text(16777215)
 #  xml_translation         :text(16777215)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,43 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
-  create_table "active_storage_attachments", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
-    t.datetime "created_at", null: false
-    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
-  end
-
-  create_table "active_storage_blobs", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.string "service_name", null: false
-    t.bigint "byte_size", null: false
-    t.string "checksum"
-    t.datetime "created_at", null: false
-    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
-  end
-
-  create_table "active_storage_variant_records", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.bigint "blob_id", null: false
-    t.string "variation_digest", null: false
-    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
-  end
+ActiveRecord::Schema[7.2].define(version: 2025_10_23_165053) do
 
   create_table "ahoy_activity_summaries", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.datetime "date", precision: nil
+    t.datetime "date"
     t.integer "user_id"
     t.integer "collection_id"
     t.string "activity"
     t.integer "minutes"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["date", "collection_id", "user_id", "activity"], name: "ahoy_activity_day_user_collection", unique: true
   end
 
@@ -55,7 +28,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "user_id"
     t.string "name"
     t.text "properties"
-    t.datetime "time", precision: nil
+    t.timestamp "time"
     t.index ["name", "time"], name: "index_ahoy_events_on_name_and_time"
     t.index ["user_id", "name"], name: "index_ahoy_events_on_user_id_and_name"
     t.index ["visit_id", "name"], name: "index_ahoy_events_on_visit_id_and_name"
@@ -65,29 +38,29 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "source_article_id"
     t.integer "target_article_id"
     t.string "display_text"
-    t.datetime "created_on", precision: nil
+    t.datetime "created_on"
     t.index ["source_article_id"], name: "index_article_article_links_on_source_article_id"
     t.index ["target_article_id"], name: "index_article_article_links_on_target_article_id"
   end
 
   create_table "article_versions", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.string "title"
-    t.text "source_text", size: :medium
-    t.text "xml_text", size: :medium
+    t.text "source_text"
+    t.text "xml_text"
     t.integer "user_id"
     t.integer "article_id"
     t.integer "version", default: 0
-    t.datetime "created_on", precision: nil
+    t.datetime "created_on"
     t.index ["article_id"], name: "index_article_versions_on_article_id"
     t.index ["user_id"], name: "index_article_versions_on_user_id"
   end
 
   create_table "articles", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.string "title"
-    t.text "source_text", size: :medium
-    t.datetime "created_on", precision: nil
+    t.text "source_text"
+    t.datetime "created_on"
     t.integer "lock_version", default: 0
-    t.text "xml_text", size: :medium
+    t.text "xml_text"
     t.string "graph_image"
     t.integer "collection_id"
     t.decimal "latitude", precision: 7, scale: 5
@@ -129,8 +102,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.boolean "subject_csv_collection"
     t.boolean "table_csv_collection"
     t.boolean "table_csv_work"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "work_metadata_csv", default: false
     t.integer "work_id"
     t.boolean "facing_edition_work"
@@ -142,16 +115,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.boolean "text_only_pdf_work"
     t.string "organization", default: "by_work"
     t.boolean "use_uploaded_filename", default: false
-    t.boolean "plaintext_verbatim_zero_index_page", default: false
     t.boolean "owner_mailing_list"
     t.boolean "owner_detailed_activity"
     t.boolean "collection_activity"
     t.boolean "collection_contributors"
     t.string "report_arguments"
-    t.boolean "notes_csv"
+    t.boolean "plaintext_verbatim_zero_index_page", default: false
     t.boolean "admin_searches"
-    t.boolean "page_details_csv_work", default: false
-    t.boolean "page_details_csv_collection", default: false
+    t.boolean "notes_csv"
     t.index ["collection_id"], name: "index_bulk_exports_on_collection_id"
     t.index ["document_set_id"], name: "index_bulk_exports_on_document_set_id"
     t.index ["user_id"], name: "index_bulk_exports_on_user_id"
@@ -162,7 +133,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.string "title"
     t.integer "parent_id"
     t.integer "collection_id"
-    t.datetime "created_on", precision: nil
+    t.datetime "created_on"
     t.boolean "gis_enabled", default: false, null: false
     t.boolean "bio_fields_enabled", default: false
     t.boolean "org_fields_enabled"
@@ -175,31 +146,31 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.boolean "ocr_correction", default: false
     t.string "collection_param", null: false
     t.text "cdm_urls"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_cdm_bulk_imports_on_user_id"
   end
 
   create_table "clientperf_results", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.integer "clientperf_uri_id"
     t.integer "milliseconds"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["clientperf_uri_id"], name: "index_clientperf_results_on_clientperf_uri_id"
   end
 
   create_table "clientperf_uris", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.string "uri"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["uri"], name: "index_clientperf_uris_on_uri"
   end
 
   create_table "collection_blocks", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.integer "collection_id", null: false
     t.integer "user_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["collection_id", "user_id"], name: "index_collection_blocks_on_collection_id_and_user_id", unique: true
     t.index ["user_id"], name: "fk_rails_c117458532"
   end
@@ -212,15 +183,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
   create_table "collection_owners", id: false, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "collection_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "collection_reviewers", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "collection_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["collection_id"], name: "index_collection_reviewers_on_collection_id"
     t.index ["user_id"], name: "index_collection_reviewers_on_user_id"
   end
@@ -228,9 +199,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
   create_table "collections", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.string "title"
     t.integer "owner_user_id"
-    t.datetime "created_on", precision: nil
-    t.text "intro_block", size: :medium
-    t.text "footer_block", size: :medium
+    t.datetime "created_on"
+    t.text "intro_block"
+    t.string "footer_block", limit: 2000
     t.boolean "restricted", default: false
     t.string "picture"
     t.boolean "supports_document_sets", default: false
@@ -243,13 +214,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.boolean "field_based", default: false
     t.boolean "voice_recognition", default: false
     t.string "language"
-    t.string "text_language"
     t.string "license_key"
+    t.string "text_language"
     t.integer "pct_completed"
     t.string "default_orientation"
     t.boolean "is_active", default: true
-    t.integer "works_count", default: 0
     t.integer "next_untranscribed_page_id"
+    t.integer "works_count", default: 0
     t.boolean "api_access", default: false
     t.boolean "facets_enabled", default: false
     t.boolean "user_download", default: false
@@ -260,12 +231,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.string "messageboard_slug"
     t.bigint "thredded_messageboard_group_id"
     t.boolean "messageboards_enabled"
-    t.datetime "most_recent_deed_created_at", precision: nil
+    t.datetime "most_recent_deed_created_at"
     t.boolean "alphabetize_works", default: true
-    t.datetime "featured_at", precision: nil
-    t.text "legend"
+    t.datetime "featured_at"
     t.index ["owner_user_id"], name: "index_collections_on_owner_user_id"
-    t.index ["restricted"], name: "index_collections_on_restricted"
     t.index ["slug"], name: "index_collections_on_slug", unique: true
     t.index ["thredded_messageboard_group_id"], name: "index_collections_on_thredded_messageboard_group_id"
   end
@@ -273,19 +242,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
   create_table "collections_tags", id: false, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.integer "collection_id"
     t.integer "tag_id"
-  end
-
-  create_table "comments", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.integer "parent_id"
-    t.integer "user_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.integer "commentable_id", default: 0, null: false
-    t.string "commentable_type", default: "", null: false
-    t.integer "depth"
-    t.string "title"
-    t.text "body", size: :medium
-    t.string "comment_type", limit: 10, default: "annotation"
-    t.string "comment_status", limit: 10
   end
 
   create_table "deeds", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
@@ -296,8 +252,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "article_id"
     t.integer "user_id"
     t.integer "note_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "visit_id"
     t.string "prerender", limit: 8191
     t.string "prerender_mailer", limit: 8191
@@ -325,15 +281,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.string "title"
     t.text "description"
     t.string "picture"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "slug"
     t.integer "pct_completed"
     t.string "default_orientation"
-    t.integer "works_count", default: 0
     t.integer "next_untranscribed_page_id"
+    t.integer "works_count", default: 0
     t.integer "visibility", default: 0, null: false
-    t.datetime "featured_at", precision: nil
+    t.datetime "featured_at"
     t.index ["collection_id"], name: "index_document_sets_on_collection_id"
     t.index ["owner_user_id"], name: "index_document_sets_on_owner_user_id"
     t.index ["slug"], name: "index_document_sets_on_slug", unique: true
@@ -342,8 +298,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
   create_table "document_sets_works", id: false, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.integer "document_set_id", null: false
     t.integer "work_id", null: false
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
     t.index ["work_id", "document_set_id"], name: "index_document_sets_works_on_work_id_and_document_set_id", unique: true
   end
 
@@ -351,8 +305,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "user_id"
     t.integer "collection_id"
     t.string "file"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "status", default: "new"
     t.boolean "preserve_titles", default: false
     t.boolean "ocr", default: false
@@ -364,8 +318,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.string "key"
     t.integer "collection_id", null: false
     t.boolean "prefer_html"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["collection_id"], name: "index_editor_buttons_on_collection_id"
   end
 
@@ -377,8 +331,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.string "engine"
     t.string "status"
     t.text "params"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["collection_id"], name: "index_external_api_requests_on_collection_id"
     t.index ["page_id"], name: "index_external_api_requests_on_page_id"
     t.index ["user_id"], name: "index_external_api_requests_on_user_id"
@@ -390,8 +344,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.string "input_type"
     t.integer "order"
     t.integer "metadata_coverage_id", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["metadata_coverage_id"], name: "index_facet_configs_on_metadata_coverage_id"
   end
 
@@ -406,15 +360,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.text "comment"
     t.integer "reporter_user_id"
     t.integer "auditor_user_id"
-    t.datetime "content_at", precision: nil
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "content_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["article_version_id"], name: "index_flags_on_article_version_id"
     t.index ["auditor_user_id"], name: "index_flags_on_auditor_user_id"
     t.index ["author_user_id"], name: "index_flags_on_author_user_id"
     t.index ["note_id"], name: "index_flags_on_note_id"
     t.index ["page_version_id"], name: "index_flags_on_page_version_id"
     t.index ["reporter_user_id"], name: "index_flags_on_reporter_user_id"
+    t.index ["status"], name: "index_flags_on_status"
   end
 
   create_table "friendly_id_slugs", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
@@ -422,25 +377,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "sluggable_id", null: false
     t.string "sluggable_type", limit: 50
     t.string "scope"
-    t.datetime "created_at", precision: nil
+    t.datetime "created_at"
     t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
     t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
     t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
     t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
-  end
-
-  create_table "honeypot_visits", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.integer "visit_id"
-    t.string "ip_address", null: false
-    t.string "ip_subnet", null: false
-    t.string "browser"
-    t.text "user_agent"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["browser"], name: "index_honeypot_visits_on_browser"
-    t.index ["ip_address"], name: "index_honeypot_visits_on_ip_address"
-    t.index ["ip_subnet", "created_at"], name: "index_honeypot_visits_on_ip_subnet_and_created_at"
-    t.index ["visit_id"], name: "index_honeypot_visits_on_visit_id"
   end
 
   create_table "ia_leaves", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
@@ -451,8 +392,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "leaf_number"
     t.string "page_number"
     t.string "page_type"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "ocr_text"
     t.index ["page_id"], name: "index_ia_leaves_on_page_id"
   end
@@ -474,8 +415,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.string "sponsor"
     t.string "image_count"
     t.integer "title_leaf"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "image_format", default: "jp2"
     t.string "archive_format", default: "zip"
     t.string "scandata_file"
@@ -488,8 +429,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.string "key"
     t.integer "count", default: 0
     t.integer "collection_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "metadata_description_versions", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
@@ -497,8 +438,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "user_id", null: false
     t.integer "work_id", null: false
     t.integer "version_number"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_metadata_description_versions_on_user_id"
     t.index ["work_id"], name: "index_metadata_description_versions_on_work_id"
   end
@@ -512,8 +453,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "page_id"
     t.integer "parent_id"
     t.integer "depth"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["collection_id"], name: "fk_rails_7d330fa613"
     t.index ["page_id"], name: "index_notes_on_page_id"
     t.index ["work_id"], name: "fk_rails_9fa473ac93"
@@ -526,81 +467,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.boolean "owner_stats", default: false
     t.boolean "user_activity", default: true
     t.integer "user_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "add_as_reviewer", default: true
-  end
-
-  create_table "oai_repositories", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.string "url"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-  end
-
-  create_table "oai_sets", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.string "set_spec"
-    t.string "repository_url"
-    t.integer "user_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-  end
-
-  create_table "omeka_collections", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.integer "omeka_id"
-    t.integer "collection_id"
-    t.string "title"
-    t.string "description"
-    t.integer "omeka_site_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-  end
-
-  create_table "omeka_files", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.integer "omeka_id"
-    t.integer "omeka_item_id"
-    t.string "mime_type"
-    t.string "fullsize_url"
-    t.string "thumbnail_url"
-    t.string "original_filename"
-    t.integer "omeka_order"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.integer "page_id"
-    t.index ["omeka_id"], name: "index_omeka_files_on_omeka_id"
-  end
-
-  create_table "omeka_items", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.string "title"
-    t.string "subject"
-    t.string "description"
-    t.string "rights"
-    t.string "creator"
-    t.string "format"
-    t.string "coverage"
-    t.integer "omeka_site_id"
-    t.integer "omeka_id"
-    t.string "omeka_url"
-    t.integer "omeka_collection_id"
-    t.integer "user_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.integer "work_id"
-  end
-
-  create_table "omeka_sites", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.string "title"
-    t.string "api_url"
-    t.string "api_key"
-    t.integer "user_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
   end
 
   create_table "page_article_links", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.integer "page_id"
     t.integer "article_id"
     t.string "display_text"
-    t.datetime "created_on", precision: nil
+    t.datetime "created_on"
     t.string "text_type", default: "transcription"
     t.integer "work_id"
     t.index ["article_id"], name: "index_page_article_links_on_article_id"
@@ -613,9 +489,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.string "view"
     t.string "tag"
     t.string "description"
-    t.text "html", size: :medium
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.text "html"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["controller", "view"], name: "index_page_blocks_on_controller_and_view"
   end
 
@@ -627,7 +503,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "page_id"
     t.integer "work_version", default: 0
     t.integer "page_version", default: 0
-    t.datetime "created_on", precision: nil
+    t.datetime "created_on"
     t.text "source_translation", collation: "utf8mb4_unicode_ci"
     t.text "xml_translation", collation: "utf8mb4_unicode_ci"
     t.string "status"
@@ -643,7 +519,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "base_height"
     t.integer "shrink_factor"
     t.integer "work_id"
-    t.datetime "created_on", precision: nil
+    t.datetime "created_on"
     t.integer "position"
     t.integer "lock_version", default: 0
     t.text "xml_text", size: :medium, collation: "utf8mb4_unicode_ci"
@@ -654,14 +530,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.text "search_text", collation: "utf8mb4_unicode_ci"
     t.string "translation_status", default: "new", null: false
     t.text "metadata"
-    t.datetime "edit_started_at", precision: nil
+    t.timestamp "edit_started_at"
     t.integer "edit_started_by_user_id"
     t.integer "line_count"
     t.float "approval_delta"
     t.integer "last_editor_user_id"
-    t.datetime "last_note_updated_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.text "transcription_json", size: :long, collation: "utf8mb4_bin"
+    t.datetime "last_note_updated_at"
+    t.datetime "updated_at"
     t.index ["edit_started_by_user_id"], name: "index_pages_on_edit_started_by_user_id"
     t.index ["search_text"], name: "pages_search_text_index", type: :fulltext
     t.index ["status", "work_id", "edit_started_at"], name: "index_pages_on_status_and_work_id_and_edit_started_at"
@@ -676,11 +551,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.index ["section_id", "page_id"], name: "index_pages_sections_on_section_id_and_page_id"
   end
 
-  create_table "plugin_schema_info", id: false, charset: "utf8", collation: "utf8_general_ci", options: "ENGINE=MyISAM", force: :cascade do |t|
-    t.string "plugin_name"
-    t.integer "version"
-  end
-
   create_table "privacy_preferences", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.boolean "recorded", default: false, null: false
@@ -693,8 +563,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "user_id", null: false
     t.integer "collection_id", null: false
     t.text "sample_set", size: :medium
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["collection_id"], name: "index_quality_samplings_on_collection_id"
     t.index ["user_id"], name: "index_quality_samplings_on_user_id"
   end
@@ -706,8 +576,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.string "sc_canvas_id"
     t.string "sc_canvas_label"
     t.string "sc_service_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "height"
     t.integer "width"
     t.string "sc_resource_id"
@@ -719,8 +589,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
 
   create_table "sc_collections", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.integer "collection_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "at_id"
     t.integer "parent_id"
     t.string "label"
@@ -732,12 +602,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "work_id"
     t.integer "sc_collection_id"
     t.string "sc_id"
-    t.text "label"
+    t.text "label", size: :tiny
     t.text "metadata"
     t.string "first_sequence_id"
     t.string "first_sequence_label"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "at_id"
     t.integer "collection_id"
     t.string "version", default: "2"
@@ -746,8 +616,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
   end
 
   create_table "search_attempts", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "query"
     t.integer "hits", default: 0
     t.integer "clicks", default: 0
@@ -773,21 +643,21 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "depth"
     t.integer "position"
     t.integer "work_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["work_id"], name: "index_sections_on_work_id"
   end
 
   create_table "sessions", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.string "session_id", default: "", null: false
-    t.text "data", size: :medium
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["session_id"], name: "index_sessions_on_session_id"
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
-  create_table "solid_queue_blocked_executions", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "solid_queue_blocked_executions", charset: "utf8mb3", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.string "queue_name", null: false
     t.integer "priority", default: 0, null: false
@@ -799,7 +669,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
   end
 
-  create_table "solid_queue_claimed_executions", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "solid_queue_claimed_executions", charset: "utf8mb3", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.bigint "process_id"
     t.datetime "created_at", null: false
@@ -807,14 +677,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
   end
 
-  create_table "solid_queue_failed_executions", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "solid_queue_failed_executions", charset: "utf8mb3", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.text "error"
     t.datetime "created_at", null: false
     t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
   end
 
-  create_table "solid_queue_jobs", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "solid_queue_jobs", charset: "utf8mb3", force: :cascade do |t|
     t.string "queue_name", null: false
     t.string "class_name", null: false
     t.text "arguments"
@@ -832,13 +702,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
   end
 
-  create_table "solid_queue_pauses", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "solid_queue_pauses", charset: "utf8mb3", force: :cascade do |t|
     t.string "queue_name", null: false
     t.datetime "created_at", null: false
     t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
   end
 
-  create_table "solid_queue_processes", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "solid_queue_processes", charset: "utf8mb3", force: :cascade do |t|
     t.string "kind", null: false
     t.datetime "last_heartbeat_at", null: false
     t.bigint "supervisor_id"
@@ -852,7 +722,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
   end
 
-  create_table "solid_queue_ready_executions", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "solid_queue_ready_executions", charset: "utf8mb3", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.string "queue_name", null: false
     t.integer "priority", default: 0, null: false
@@ -862,7 +732,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
   end
 
-  create_table "solid_queue_recurring_executions", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "solid_queue_recurring_executions", charset: "utf8mb3", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.string "task_key", null: false
     t.datetime "run_at", null: false
@@ -871,7 +741,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
   end
 
-  create_table "solid_queue_recurring_tasks", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "solid_queue_recurring_tasks", charset: "utf8mb3", force: :cascade do |t|
     t.string "key", null: false
     t.string "schedule", null: false
     t.string "command", limit: 2048
@@ -887,7 +757,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
   end
 
-  create_table "solid_queue_scheduled_executions", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "solid_queue_scheduled_executions", charset: "utf8mb3", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.string "queue_name", null: false
     t.integer "priority", default: 0, null: false
@@ -897,7 +767,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
   end
 
-  create_table "solid_queue_semaphores", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "solid_queue_semaphores", charset: "utf8mb3", force: :cascade do |t|
     t.string "key", null: false
     t.integer "value", default: 1, null: false
     t.datetime "expires_at", null: false
@@ -914,8 +784,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.string "label"
     t.string "input_type"
     t.text "options"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["transcription_field_id"], name: "index_spreadsheet_columns_on_transcription_field_id"
   end
 
@@ -926,8 +796,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.string "header"
     t.text "content"
     t.integer "row"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "transcription_field_id"
     t.index ["page_id"], name: "index_table_cells_on_page_id"
     t.index ["section_id"], name: "index_table_cells_on_section_id"
@@ -940,16 +810,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.boolean "canonical"
     t.string "ai_text"
     t.string "message_key"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "tex_figures", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.integer "page_id"
     t.integer "position"
     t.text "source"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["page_id"], name: "index_tex_figures_on_page_id"
   end
 
@@ -957,8 +827,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.bigint "messageboard_id", null: false
     t.text "name", null: false
     t.text "description"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "slug", null: false
     t.index ["messageboard_id", "slug"], name: "index_thredded_categories_on_messageboard_id_and_slug", unique: true, length: { slug: 191 }
     t.index ["messageboard_id"], name: "index_thredded_categories_on_messageboard_id"
@@ -968,8 +838,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
   create_table "thredded_messageboard_groups", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.string "name"
     t.integer "position", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "thredded_messageboard_notifications_for_followed_topics", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
@@ -983,7 +853,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
   create_table "thredded_messageboard_users", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.bigint "thredded_user_detail_id", null: false
     t.bigint "thredded_messageboard_id", null: false
-    t.datetime "last_seen_at", precision: nil, null: false
+    t.datetime "last_seen_at", null: false
     t.index ["thredded_messageboard_id", "last_seen_at"], name: "index_thredded_messageboard_users_for_recently_active"
     t.index ["thredded_messageboard_id", "thredded_user_detail_id"], name: "index_thredded_messageboard_users_primary", unique: true
     t.index ["thredded_user_detail_id"], name: "fk_rails_06e42c62f5"
@@ -998,8 +868,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "position", null: false
     t.bigint "last_topic_id"
     t.bigint "messageboard_group_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "locked", default: false, null: false
     t.index ["messageboard_group_id"], name: "index_thredded_messageboards_on_messageboard_group_id"
     t.index ["slug"], name: "index_thredded_messageboards_on_slug", unique: true, length: 191
@@ -1028,7 +898,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "moderator_id"
     t.integer "moderation_state", null: false
     t.integer "previous_moderation_state", null: false
-    t.timestamp "created_at", default: -> { "current_timestamp() ON UPDATE current_timestamp()" }, null: false
+    t.timestamp "created_at", default: -> { "current_timestamp()" }, null: false
     t.index ["messageboard_id", "created_at"], name: "index_thredded_moderation_records_for_display"
   end
 
@@ -1039,8 +909,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.bigint "postable_id", null: false
     t.bigint "messageboard_id", null: false
     t.integer "moderation_state", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["content"], name: "thredded_posts_content_fts", type: :fulltext
     t.index ["messageboard_id"], name: "index_thredded_posts_on_messageboard_id"
     t.index ["moderation_state", "updated_at"], name: "index_thredded_posts_for_display"
@@ -1053,8 +923,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "user_id"
     t.text "content"
     t.bigint "postable_id", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["postable_id", "created_at"], name: "index_thredded_private_posts_on_postable_id_and_created_at"
   end
 
@@ -1065,9 +935,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.text "slug", null: false
     t.integer "posts_count", default: 0
     t.string "hash_id", limit: 20, null: false
-    t.datetime "last_post_at", precision: nil
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "last_post_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["hash_id"], name: "index_thredded_private_topics_on_hash_id"
     t.index ["last_post_at"], name: "index_thredded_private_topics_on_last_post_at"
     t.index ["slug"], name: "index_thredded_private_topics_on_slug", unique: true, length: 191
@@ -1076,8 +946,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
   create_table "thredded_private_users", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.bigint "private_topic_id"
     t.integer "user_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["private_topic_id"], name: "index_thredded_private_users_on_private_topic_id"
     t.index ["user_id"], name: "index_thredded_private_users_on_user_id"
   end
@@ -1100,9 +970,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.boolean "locked", default: false, null: false
     t.string "hash_id", limit: 20, null: false
     t.integer "moderation_state", null: false
-    t.datetime "last_post_at", precision: nil
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "last_post_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["hash_id"], name: "index_thredded_topics_on_hash_id"
     t.index ["last_post_at"], name: "index_thredded_topics_on_last_post_at"
     t.index ["messageboard_id"], name: "index_thredded_topics_on_messageboard_id"
@@ -1114,14 +984,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
 
   create_table "thredded_user_details", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.integer "user_id", null: false
-    t.datetime "latest_activity_at", precision: nil
+    t.datetime "latest_activity_at"
     t.integer "posts_count", default: 0
     t.integer "topics_count", default: 0
-    t.datetime "last_seen_at", precision: nil
+    t.datetime "last_seen_at"
     t.integer "moderation_state", default: 0, null: false
     t.timestamp "moderation_state_changed_at"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["latest_activity_at"], name: "index_thredded_user_details_on_latest_activity_at"
     t.index ["moderation_state", "moderation_state_changed_at"], name: "index_thredded_user_details_for_moderations"
     t.index ["user_id"], name: "index_thredded_user_details_on_user_id", unique: true
@@ -1132,15 +1002,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.bigint "messageboard_id", null: false
     t.boolean "follow_topics_on_mention", default: true, null: false
     t.boolean "auto_follow_topics", default: false, null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_id", "messageboard_id"], name: "thredded_user_messageboard_preferences_user_id_messageboard_id", unique: true
   end
 
   create_table "thredded_user_post_notifications", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.bigint "post_id", null: false
-    t.datetime "notified_at", precision: nil, null: false
+    t.datetime "notified_at", null: false
     t.index ["post_id"], name: "index_thredded_user_post_notifications_on_post_id"
     t.index ["user_id", "post_id"], name: "index_thredded_user_post_notifications_on_user_id_and_post_id", unique: true
   end
@@ -1149,8 +1019,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "user_id", null: false
     t.boolean "follow_topics_on_mention", default: true, null: false
     t.boolean "auto_follow_topics", default: false, null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_thredded_user_preferences_on_user_id", unique: true
   end
 
@@ -1160,14 +1030,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "unread_posts_count", default: 0, null: false
     t.integer "read_posts_count", default: 0, null: false
     t.integer "integer", default: 0, null: false
-    t.timestamp "read_at", default: -> { "current_timestamp() ON UPDATE current_timestamp()" }, null: false
+    t.timestamp "read_at", default: -> { "current_timestamp()" }, null: false
     t.index ["user_id", "postable_id"], name: "thredded_user_private_topic_read_states_user_postable", unique: true
   end
 
   create_table "thredded_user_topic_follows", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.bigint "topic_id", null: false
-    t.datetime "created_at", precision: nil, null: false
+    t.datetime "created_at", null: false
     t.integer "reason", limit: 1
     t.index ["user_id", "topic_id"], name: "thredded_user_topic_follows_user_topic", unique: true
   end
@@ -1179,7 +1049,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "unread_posts_count", default: 0, null: false
     t.integer "read_posts_count", default: 0, null: false
     t.integer "integer", default: 0, null: false
-    t.timestamp "read_at", default: -> { "current_timestamp() ON UPDATE current_timestamp()" }, null: false
+    t.timestamp "read_at", default: -> { "current_timestamp()" }, null: false
     t.index ["messageboard_id"], name: "index_thredded_user_topic_read_states_on_messageboard_id"
     t.index ["user_id", "messageboard_id"], name: "thredded_user_topic_read_states_user_messageboard"
     t.index ["user_id", "postable_id"], name: "thredded_user_topic_read_states_user_postable", unique: true
@@ -1215,29 +1085,29 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.boolean "admin", default: false
     t.string "encrypted_password", default: "", null: false
     t.string "password_salt", default: "", null: false
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string "remember_token"
-    t.datetime "remember_token_expires_at", precision: nil
+    t.datetime "remember_token_expires_at"
     t.string "location"
     t.string "website"
     t.text "about"
     t.string "reset_password_token"
-    t.datetime "reset_password_sent_at", precision: nil
-    t.datetime "remember_created_at", precision: nil
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
     t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at", precision: nil
-    t.datetime "last_sign_in_at", precision: nil
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
     t.string "account_type"
-    t.datetime "paid_date", precision: nil
+    t.datetime "paid_date"
     t.boolean "guest"
     t.string "slug"
     t.boolean "deleted", default: false
     t.string "provider"
     t.string "uid"
-    t.datetime "start_date", precision: nil
+    t.datetime "start_date"
     t.string "orcid"
     t.string "dictation_language", default: "en-US"
     t.boolean "activity_email"
@@ -1246,9 +1116,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.string "preferred_locale"
     t.string "api_key"
     t.string "picture"
-    t.text "help"
     t.text "footer_block", size: :medium
-    t.index ["deleted"], name: "index_users_on_deleted"
+    t.text "help"
     t.index ["login"], name: "index_users_on_login"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["slug"], name: "index_users_on_slug", unique: true
@@ -1280,7 +1149,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.string "utm_term"
     t.string "utm_content"
     t.string "utm_campaign"
-    t.datetime "started_at", precision: nil
+    t.timestamp "started_at"
     t.index ["user_id"], name: "index_visits_on_user_id"
     t.index ["visit_token"], name: "index_visits_on_visit_token", unique: true
   end
@@ -1300,8 +1169,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.date "d1"
     t.date "d2"
     t.integer "work_id", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["work_id"], name: "index_work_facets_on_work_id"
   end
 
@@ -1310,8 +1179,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "transcribed_pages"
     t.integer "annotated_pages"
     t.integer "total_pages"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "blank_pages", default: 0
     t.integer "incomplete_pages", default: 0
     t.integer "corrected_pages"
@@ -1325,23 +1194,23 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.integer "line_count"
     t.integer "transcribed_percentage"
     t.integer "needs_review_percentage"
-    t.datetime "last_edit_at", precision: nil
+    t.datetime "last_edit_at"
     t.index ["work_id", "line_count"], name: "index_work_statistics_on_work_id_and_line_count"
   end
 
   create_table "works", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.string "title"
-    t.text "description", size: :medium
-    t.datetime "created_on", precision: nil
+    t.string "description", limit: 4000
+    t.datetime "created_on"
     t.integer "owner_user_id"
     t.boolean "restrict_scribes", default: false
     t.integer "transcription_version", default: 0
-    t.text "physical_description", size: :medium
-    t.text "document_history", size: :medium
-    t.text "permission_description", size: :medium
+    t.text "physical_description"
+    t.text "document_history"
+    t.text "permission_description"
     t.string "location_of_composition"
     t.string "author"
-    t.text "transcription_conventions", size: :medium
+    t.text "transcription_conventions"
     t.integer "collection_id"
     t.boolean "scribes_can_edit_titles", default: false
     t.boolean "supports_translation", default: false
@@ -1354,6 +1223,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.string "identifier"
     t.integer "next_untranscribed_page_id"
     t.text "original_metadata"
+    t.string "uploaded_filename"
     t.string "genre"
     t.string "source_location"
     t.string "source_collection_name"
@@ -1361,21 +1231,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
     t.boolean "in_scope", default: true
     t.text "editorial_notes"
     t.string "document_date"
-    t.string "uploaded_filename"
     t.text "metadata_description"
     t.integer "metadata_description_version_id"
     t.string "description_status", default: "undescribed"
     t.text "searchable_metadata"
     t.string "recipient"
-    t.datetime "most_recent_deed_created_at", precision: nil
+    t.datetime "most_recent_deed_created_at"
     t.index ["collection_id"], name: "index_works_on_collection_id"
     t.index ["metadata_description_version_id"], name: "index_works_on_metadata_description_version_id"
     t.index ["owner_user_id"], name: "index_works_on_owner_user_id"
     t.index ["slug"], name: "index_works_on_slug", unique: true
   end
 
-  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "bulk_exports", "collections"
   add_foreign_key "bulk_exports", "document_sets"
   add_foreign_key "bulk_exports", "users"
@@ -1389,14 +1256,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_120653) do
   add_foreign_key "external_api_requests", "users"
   add_foreign_key "external_api_requests", "works"
   add_foreign_key "facet_configs", "metadata_coverages"
-  add_foreign_key "honeypot_visits", "visits"
   add_foreign_key "metadata_description_versions", "users"
   add_foreign_key "metadata_description_versions", "works"
   add_foreign_key "notes", "collections", on_delete: :cascade
   add_foreign_key "notes", "pages", on_delete: :cascade
   add_foreign_key "notes", "works", on_delete: :cascade
   add_foreign_key "page_article_links", "works"
-  add_foreign_key "privacy_preferences", "users", on_delete: :cascade
   add_foreign_key "quality_samplings", "collections"
   add_foreign_key "quality_samplings", "users"
   add_foreign_key "spreadsheet_columns", "transcription_fields"


### PR DESCRIPTION
Reverts benwbrum/fromthepage#5028

@benwbrum I missed it initially, but for some reason the `transcription_json` column is considered `text` instead of json column in db/schema.rb. It clearly should be json right? Is this an artifact of difference in db versions? In either case we should consider reverting...