### PR TITLE
5136 - Missing owner es search bug

### DIFF
--- a/app/views/elastic/_search_result.html.slim
+++ b/app/views/elastic/_search_result.html.slim
@@ -1,11 +1,11 @@
 // Customize the rendering of each type here
--if result.is_a?(Collection)
+-if result.is_a?(Collection) && result.owner.present?
   .collection-work.search_result
     h2 =link_to result[:title], collection_path(result.owner.slug, result)
     p =to_snippet(result[:intro_block])
     =render partial: 'elastic/breadcrumbs', locals: { doc: result }
 
--elsif result.is_a?(DocumentSet)
+-elsif result.is_a?(DocumentSet) && result.owner.present?
   .collection-work.search_result
     h2 =link_to result[:title], collection_path(result.owner, result)
     p =to_snippet(result[:description])
@@ -14,7 +14,7 @@
 -elsif result.is_a?(Page) && result.collection.present?
   / Collection work class provides consistent styling with other elements
   .collection-work.search_result
-    =render({ :partial => 'elastic/page_partial', :locals => { :page => result , :collection => result.collection} })
+    =render partial: 'elastic/page_partial', locals: { page: result , collection: result.collection }
 
 -elsif result.is_a?(User)
   .collection-work.search_result
@@ -22,4 +22,4 @@
     p =to_snippet(result[:about])
 
 -elsif result.is_a?(Work) && result.collection.present?
-  =render({ :partial => 'elastic/work_partial', :locals => { :work => result , :collection => result.collection} })
+  =render partial: 'elastic/work_partial', locals: { work: result , collection: result.collection }


### PR DESCRIPTION
It is worth noting this is an artifact of https://github.com/benwbrum/fromthepage/issues/5137

We should be syncing es constantly on relevant record updates. I believe this includes user deletion. But the syncs are failing since the solid_queue worker is running in dev mode.