### PR TITLE
Fix broken AI transcriptions again

### DIFF
--- a/lib/tasks/migrate_ai_transcriptions.rake
+++ b/lib/tasks/migrate_ai_transcriptions.rake
@@ -1,5 +1,4 @@
 namespace :fromthepage do
-
   desc 'Cleanup bad migration'
   task cleanup_ai_migration_folders: :environment do
     # first rename all of the folders in public/text that end with _processed back to original name
@@ -12,7 +11,7 @@ namespace :fromthepage do
       puts "Renaming #{folder_path} back to #{original_path}..."
       File.rename(folder_path, original_path)
     end
-    puts "rename completed."
+    puts 'rename completed.'
   end
 
   desc 'Remove bad AI transcription records'
@@ -26,7 +25,7 @@ namespace :fromthepage do
         transcription.destroy!
       end
     end
-    puts "Bad AI transcriptions removed."
+    puts 'Bad AI transcriptions removed.'
   end
 
 
@@ -46,7 +45,7 @@ namespace :fromthepage do
 
       puts "Processing folder #{folder}..."
 
-      Dir.children(folder_path).map{|filename| filename.split('_').first.to_i }.sort.uniq.each do |page_id|
+      Dir.children(folder_path).map { |filename| filename.split('_').first.to_i }.sort.uniq.each do |page_id|
         filename = "#{page_id}_ai_plaintext.txt"
         ai_plaintext_path = folder_path.join(filename)
         next unless File.exist?(ai_plaintext_path)
@@ -76,7 +75,6 @@ namespace :fromthepage do
           )
         rescue => e
           puts "Error creating AiTranscription for page #{page.id}: #{e.message}"
-          binding.pry
         end
       end
 

--- a/lib/tasks/migrate_ai_transcriptions.rake
+++ b/lib/tasks/migrate_ai_transcriptions.rake
@@ -60,7 +60,7 @@ namespace :fromthepage do
           prompt = File.read(alto_path)
         else
           type = 'ai_plaintext'
-          model = 'gemini-2.5-pro'
+          model = 'gemini-3-pro-preview (migrated)'
           prompt = nil
         end
 
@@ -69,7 +69,7 @@ namespace :fromthepage do
         begin
           AiTranscription.create!(
             page_id: page.id,
-            source_text: source_text.gsub('🤔', '?'),
+            source_text: source_text,
             model: model,
             prompt: prompt
           )

--- a/lib/tasks/migrate_ai_transcriptions.rake
+++ b/lib/tasks/migrate_ai_transcriptions.rake
@@ -1,4 +1,35 @@
 namespace :fromthepage do
+
+  desc 'Cleanup bad migration'
+  task cleanup_ai_migration_folders: :environment do
+    # first rename all of the folders in public/text that end with _processed back to original name
+    root_path = Rails.root.join('public', 'text')
+    Dir.each_child(root_path) do |folder|
+      next unless folder.end_with?('_processed')
+      original_folder = folder.sub('_processed', '')
+      folder_path = root_path.join(folder)
+      original_path = root_path.join(original_folder)
+      puts "Renaming #{folder_path} back to #{original_path}..."
+      File.rename(folder_path, original_path)
+    end
+    puts "rename completed."
+  end
+
+  desc 'Remove bad AI transcription records'
+  task remove_bad_ai_transcriptions: :environment do
+    AiTranscription.find_each do |transcription|
+      page = transcription.page
+      folder = Rails.root.join('public', 'text', page.work.id.to_s)
+      ai_plaintext_path = folder.join("#{page.id}_ai_plaintext.txt")
+      if File.exist?(ai_plaintext_path)
+        puts "Deleting AiTranscription #{transcription.id} (#{transcription.model}) for page #{page.id}..."
+        transcription.destroy!
+      end
+    end
+    puts "Bad AI transcriptions removed."
+  end
+
+
   desc 'Migrate AI transcription for pages'
   task migrate_ai_transcription: :environment do
     root_path = Rails.root.join('public', 'text')
@@ -15,16 +46,12 @@ namespace :fromthepage do
 
       puts "Processing folder #{folder}..."
 
-      Dir.each_child(folder_path) do |filename|
-        ai_plaintext_file = Dir.children(folder_path).find { |f| f.end_with?('_ai_plaintext.txt') }
-        next unless ai_plaintext_file
+      Dir.children(folder_path).map{|filename| filename.split('_').first.to_i }.sort.uniq.each do |page_id|
+        filename = "#{page_id}_ai_plaintext.txt"
+        ai_plaintext_path = folder_path.join(filename)
+        next unless File.exist?(ai_plaintext_path)
+        alto_path = ai_plaintext_path.sub('ai_plaintext.txt', 'alto.xml')
 
-        ai_plaintext_path = folder_path.join(ai_plaintext_file)
-
-        alto_file = Dir.children(folder_path).find { |f| f.end_with?('_alto.xml') }
-        alto_path = alto_file ? folder_path.join(alto_file) : nil
-
-        page_id = filename.split('_').first.to_i
         page = Page.find_by(id: page_id)
         next unless page.present?
 
@@ -40,12 +67,17 @@ namespace :fromthepage do
 
         source_text = File.read(ai_plaintext_path)
 
-        AiTranscription.create!(
-          page_id: page.id,
-          source_text: source_text,
-          model: model,
-          prompt: prompt
-        )
+        begin
+          AiTranscription.create!(
+            page_id: page.id,
+            source_text: source_text.gsub('🤔', '?'),
+            model: model,
+            prompt: prompt
+          )
+        rescue => e
+          puts "Error creating AiTranscription for page #{page.id}: #{e.message}"
+          binding.pry
+        end
       end
 
       File.rename(folder_path, processed_path)


### PR DESCRIPTION
The previous migration code was not aware that multiple plaintext and alto files are stored in a folder for a work, so it was grabbing a file from the folder and using it for all pages in the system. This should fix that problem by following our naming conventions to find the files corresponding to the page_id and create a record from them.

This also contains convenience scripts to clear out old `ai_transcription` records and rename the folders, so that we can clean up the bad migration before re-running this.