### PR TITLE
Use POST for OmniAuth request phase

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -96,8 +96,7 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   def set_saml
-    institution = saml_provider_param
-    redirect_to user_omniauth_authorize_path(institution)  # go to users/auth/saml/instution_name
+    @institution = saml_provider_param
   end
 
   def choose_saml

--- a/app/views/devise/registrations/set_saml.html.slim
+++ b/app/views/devise/registrations/set_saml.html.slim
@@ -1,0 +1,9 @@
+- content_for :page_title, t('devise.sign_in')
+
+section.signon
+  h1= t('devise.registrations.choose_saml.sign_in_with_institution')
+  = form_tag(user_omniauth_authorize_path(@institution), method: :post, id: 'saml-provider-form') do
+    = submit_tag t('devise.sign_in'), class: 'strong signin'
+
+javascript:
+  document.getElementById('saml-provider-form').submit();

--- a/app/views/devise/shared/_links.html.slim
+++ b/app/views/devise/shared/_links.html.slim
@@ -10,6 +10,6 @@ ul.signon_links
 
   -if devise_mapping.omniauthable?
     -if ENABLE_GOOGLEOAUTH
-      li = link_to t('.sign_in_with_google'), user_omniauth_authorize_path(:google_oauth2)
+      li = button_to t('.sign_in_with_google'), user_omniauth_authorize_path(:google_oauth2), method: :post
     -if ENABLE_SAML
       p =button_to(t('.sign_in_with_institution'), registrations_choose_provider_path, class: 'strong signin')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Fromthepage::Application.routes.draw do
           as: 'user_omniauth_callback'
 
     match '/users/auth/saml/:identity_provider_id',
-          via: [:get, :post],
+          via: [:post],
           to: 'users/omniauth_callbacks#passthru',
           as: 'user_omniauth_authorize'
   end


### PR DESCRIPTION
## Summary
- switch Google OmniAuth entry point to submit via POST
- render SAML provider selection through an auto-submitted POST form
- limit the SAML OmniAuth authorize route to POST-only requests

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945a8d70cc88328882e0dfa7f6c33a4)