### PR TITLE
Add Ruby script to zip aperture card subfolders on Windows

### DIFF
--- a/doc/aperture_card_subfoldering.md
+++ b/doc/aperture_card_subfoldering.md
@@ -1,0 +1,75 @@
+# Subdivide aperture card image folders on Windows 11
+
+This project includes a Ruby script to split each parent folder of images into range-based subfolders of fixed size.
+
+## Script location
+
+`script/subdivide_aperture_card_folders.rb`
+
+## What it does
+
+Given a root directory like:
+
+- `D:\ApertureCards\IALVIP_Series1_Box1`
+- `D:\ApertureCards\IALVIP_Series1_Box2`
+
+It will process each immediate child folder (`IALVIP_Series1_Box1`, etc.), find image files directly inside that folder, sort them by filename, and move them into subfolders of 100 files each (by default).
+
+Example output subfolders inside `IALVIP_Series1_Box1`:
+
+- `IALVIP_Series1_Box1_000001_to_000100`
+- `IALVIP_Series1_Box1_000101_to_000200`
+- ...
+
+If filenames end in numeric indexes (like `..._000009.jpg`), the script uses those index values for the range names.
+
+## Requirements
+
+1. Ruby installed on Windows 11.
+2. Your folders available on a local drive (for example `D:`).
+
+## Install Ruby on Windows 11
+
+If Ruby is not installed, use [RubyInstaller for Windows](https://rubyinstaller.org/):
+
+1. Download and install Ruby+Devkit.
+2. During install, allow it to add Ruby to your PATH.
+3. Open a new PowerShell window and verify:
+
+```powershell
+ruby -v
+```
+
+## Run the script
+
+Open PowerShell in the repository folder and run:
+
+```powershell
+ruby script/subdivide_aperture_card_folders.rb --root "D:/ApertureCards" --dry-run
+```
+
+Review the planned folder creation and moves.
+
+If everything looks correct, run without `--dry-run`:
+
+```powershell
+ruby script/subdivide_aperture_card_folders.rb --root "D:/ApertureCards"
+```
+
+## Optional flags
+
+- `--files-per-folder 100` (default is 100)
+- `--extensions .jpg,.jpeg` (default includes `.jpg` and `.jpeg`)
+- `--dry-run` (preview only)
+
+Example with explicit options:
+
+```powershell
+ruby script/subdivide_aperture_card_folders.rb --root "D:/ApertureCards" --files-per-folder 100 --extensions .jpg,.jpeg
+```
+
+## Safety notes
+
+- Start with `--dry-run` first.
+- Keep a backup before large file operations.
+- The script only processes files directly inside each parent folder (not nested subfolders).

--- a/doc/aperture_card_zipping.md
+++ b/doc/aperture_card_zipping.md
@@ -1,0 +1,60 @@
+# Zip aperture card subfolders on Windows 11
+
+Use this script after you have already split each box folder into subfolders (for example `..._000001_to_000100`).
+
+## Script location
+
+`script/zip_aperture_card_subfolders.rb`
+
+## What it does
+
+Given a root folder like:
+
+- `D:\ApertureCards\IALVIP_Series1_Box1`
+- `D:\ApertureCards\IALVIP_Series1_Box2`
+
+The script will:
+
+1. Enter each box folder under `--root`.
+2. Find each immediate subfolder in that box.
+3. Create a zip for each subfolder.
+4. Write zips to `C:\Users\benwb\Documents\ApertureCards\<box-folder>\` by default.
+
+Example output zip path:
+
+- `C:\Users\benwb\Documents\ApertureCards\IALVIP_Series1_Box1\IALVIP_Series1_Box1_000001_to_000100.zip`
+
+## Requirements
+
+1. Ruby installed on Windows 11.
+2. PowerShell (included with Windows 11).
+
+## Run (preview first)
+
+```powershell
+ruby script/zip_aperture_card_subfolders.rb --root "D:/ApertureCards" --dry-run
+```
+
+## Run for real
+
+```powershell
+ruby script/zip_aperture_card_subfolders.rb --root "D:/ApertureCards"
+```
+
+## Optional flags
+
+- `--output-root "C:/Users/benwb/Documents/ApertureCards"` (default shown)
+- `--overwrite` to replace existing zips
+- `--dry-run` for preview only
+
+Example:
+
+```powershell
+ruby script/zip_aperture_card_subfolders.rb --root "D:/ApertureCards" --output-root "C:/Users/benwb/Documents/ApertureCards" --overwrite
+```
+
+## Safety notes
+
+- Use `--dry-run` first.
+- Keep backup copies before large batch jobs.
+- The script zips immediate subfolders only (not deeper nested folders).

--- a/script/subdivide_aperture_card_folders.rb
+++ b/script/subdivide_aperture_card_folders.rb
@@ -1,0 +1,137 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'optparse'
+
+options = {
+  files_per_folder: 100,
+  dry_run: false,
+  extensions: %w[.jpg .jpeg]
+}
+
+OptionParser.new do |opts|
+  opts.banner = <<~BANNER
+    Usage: ruby script/subdivide_aperture_card_folders.rb --root "D:/ApertureCards"
+
+    Moves image files in each immediate child directory of --root into subfolders of --files-per-folder.
+    Each subfolder is named as: PARENT_000001_to_000100 (using filename index when available).
+  BANNER
+
+  opts.on('--root ROOT_PATH', 'Root directory containing parent folders (required).') do |value|
+    options[:root] = value
+  end
+
+  opts.on('--files-per-folder N', Integer, 'Number of files per subfolder (default: 100).') do |value|
+    options[:files_per_folder] = value
+  end
+
+  opts.on('--extensions x,y,z', Array, 'Comma-separated file extensions to include (default: .jpg,.jpeg).') do |value|
+    options[:extensions] = value.map { |ext| ext.start_with?('.') ? ext.downcase : ".#{ext.downcase}" }
+  end
+
+  opts.on('--dry-run', 'Print planned moves without changing files.') do
+    options[:dry_run] = true
+  end
+
+  opts.on('-h', '--help', 'Show this help message.') do
+    puts opts
+    exit
+  end
+end.parse!
+
+abort('ERROR: --root is required. Use --help for usage.') unless options[:root]
+abort('ERROR: --files-per-folder must be greater than 0.') unless options[:files_per_folder].positive?
+
+root = File.expand_path(options[:root])
+abort("ERROR: Root path does not exist: #{root}") unless Dir.exist?(root)
+
+# Returns the trailing numeric index from a filename (without extension), if present.
+def extract_index(filename)
+  base = File.basename(filename, File.extname(filename))
+  match = base.match(/(\d+)$/)
+  match && match[1]
+end
+
+# Returns a range token using filename indices when present.
+def range_token(files, start_seq)
+  first_idx = extract_index(files.first)
+  last_idx = extract_index(files.last)
+
+  if first_idx && last_idx
+    width = [first_idx.length, last_idx.length].max
+    [first_idx.rjust(width, '0'), last_idx.rjust(width, '0')]
+  else
+    width = 6
+    start_num = start_seq
+    end_num = start_seq + files.length - 1
+    [start_num.to_s.rjust(width, '0'), end_num.to_s.rjust(width, '0')]
+  end
+end
+
+parent_dirs = Dir.children(root)
+                 .map { |entry| File.join(root, entry) }
+                 .select { |path| File.directory?(path) }
+                 .sort
+
+if parent_dirs.empty?
+  puts "No directories found in #{root}. Nothing to do."
+  exit
+end
+
+puts "Root: #{root}"
+puts "Parent folders found: #{parent_dirs.length}"
+puts "Files per subfolder: #{options[:files_per_folder]}"
+puts "Dry run: #{options[:dry_run]}"
+puts
+
+moved_count = 0
+created_count = 0
+
+parent_dirs.each do |parent_dir|
+  parent_name = File.basename(parent_dir)
+  files = Dir.children(parent_dir)
+             .select do |entry|
+               full_path = File.join(parent_dir, entry)
+               File.file?(full_path) && options[:extensions].include?(File.extname(entry).downcase)
+             end
+             .sort
+
+  if files.empty?
+    puts "[SKIP] #{parent_name}: no matching files at top level."
+    next
+  end
+
+  puts "[PROCESS] #{parent_name}: #{files.length} file(s)"
+
+  files.each_slice(options[:files_per_folder]).with_index do |slice, group_index|
+    start_seq = group_index * options[:files_per_folder] + 1
+    first_token, last_token = range_token(slice, start_seq)
+    child_name = "#{parent_name}_#{first_token}_to_#{last_token}"
+    child_dir = File.join(parent_dir, child_name)
+
+    unless Dir.exist?(child_dir)
+      puts "  Create: #{child_name}"
+      FileUtils.mkdir_p(child_dir) unless options[:dry_run]
+      created_count += 1
+    end
+
+    slice.each do |file_name|
+      from = File.join(parent_dir, file_name)
+      to = File.join(child_dir, file_name)
+
+      if File.exist?(to)
+        puts "  [SKIP] Destination exists: #{to}"
+        next
+      end
+
+      puts "  Move: #{file_name} -> #{child_name}/"
+      FileUtils.mv(from, to) unless options[:dry_run]
+      moved_count += 1
+    end
+  end
+end
+
+puts
+puts "Done. Subfolders created: #{created_count}. Files moved: #{moved_count}."
+puts 'Dry run only; no changes made.' if options[:dry_run]

--- a/script/zip_aperture_card_subfolders.rb
+++ b/script/zip_aperture_card_subfolders.rb
@@ -1,0 +1,119 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'optparse'
+require 'rbconfig'
+
+options = {
+  output_root: 'C:/Users/benwb/Documents/ApertureCards',
+  dry_run: false,
+  overwrite: false
+}
+
+OptionParser.new do |opts|
+  opts.banner = <<~BANNER
+    Usage: ruby script/zip_aperture_card_subfolders.rb --root "D:/ApertureCards"
+
+    For each box folder under --root, zip each immediate child subfolder
+    and write zip files into --output-root/<box_folder>/.
+  BANNER
+
+  opts.on('--root ROOT_PATH', 'Root directory containing box folders (required).') do |value|
+    options[:root] = value
+  end
+
+  opts.on('--output-root OUTPUT_PATH', 'Destination for zip files (default: C:/Users/benwb/Documents/ApertureCards).') do |value|
+    options[:output_root] = value
+  end
+
+  opts.on('--overwrite', 'Overwrite existing zip files.') do
+    options[:overwrite] = true
+  end
+
+  opts.on('--dry-run', 'Print planned actions without creating zip files.') do
+    options[:dry_run] = true
+  end
+
+  opts.on('-h', '--help', 'Show this help message.') do
+    puts opts
+    exit
+  end
+end.parse!
+
+abort('ERROR: --root is required. Use --help for usage.') unless options[:root]
+
+unless RbConfig::CONFIG['host_os'].downcase.include?('mswin') || RbConfig::CONFIG['host_os'].downcase.include?('mingw')
+  abort('ERROR: This script is intended to run on Windows (uses PowerShell Compress-Archive).')
+end
+
+root = File.expand_path(options[:root])
+output_root = File.expand_path(options[:output_root])
+
+abort("ERROR: Root path does not exist: #{root}") unless Dir.exist?(root)
+
+box_dirs = Dir.children(root)
+              .map { |entry| File.join(root, entry) }
+              .select { |path| File.directory?(path) }
+              .sort
+
+if box_dirs.empty?
+  puts "No box folders found in #{root}. Nothing to do."
+  exit
+end
+
+puts "Root: #{root}"
+puts "Output root: #{output_root}"
+puts "Box folders found: #{box_dirs.length}"
+puts "Dry run: #{options[:dry_run]}"
+puts "Overwrite: #{options[:overwrite]}"
+puts
+
+zip_count = 0
+skip_count = 0
+
+box_dirs.each do |box_dir|
+  box_name = File.basename(box_dir)
+  subfolders = Dir.children(box_dir)
+                  .map { |entry| File.join(box_dir, entry) }
+                  .select { |path| File.directory?(path) }
+                  .sort
+
+  if subfolders.empty?
+    puts "[SKIP] #{box_name}: no subfolders found."
+    next
+  end
+
+  box_output_dir = File.join(output_root, box_name)
+  FileUtils.mkdir_p(box_output_dir) unless options[:dry_run]
+
+  puts "[PROCESS] #{box_name}: #{subfolders.length} subfolder(s)"
+
+  subfolders.each do |subfolder_path|
+    subfolder_name = File.basename(subfolder_path)
+    zip_path = File.join(box_output_dir, "#{subfolder_name}.zip")
+
+    if File.exist?(zip_path) && !options[:overwrite]
+      puts "  [SKIP] Zip exists: #{zip_path} (use --overwrite to replace)"
+      skip_count += 1
+      next
+    end
+
+    puts "  Zip: #{subfolder_name} -> #{zip_path}"
+    next if options[:dry_run]
+
+    escaped_subfolder = subfolder_path.gsub("'", "''")
+    escaped_zip = zip_path.gsub("'", "''")
+    force_part = options[:overwrite] ? ' -Force' : ''
+    ps_command = "Compress-Archive -LiteralPath '#{escaped_subfolder}' -DestinationPath '#{escaped_zip}' -CompressionLevel Optimal#{force_part}"
+
+    success = system('powershell', '-NoProfile', '-Command', ps_command)
+    abort("ERROR: Failed to zip folder: #{subfolder_path}") unless success
+
+    zip_count += 1
+  end
+end
+
+puts
+puts "Done. Zips created: #{zip_count}. Skipped existing: #{skip_count}."
+puts 'Dry run only; no zip files were created.' if options[:dry_run]


### PR DESCRIPTION
### Motivation
- Provide a Windows-friendly tool to package each subfolder produced by the subdivide script into per-subfolder zip files for easier transfer and archival. 
- Write the resulting zips to the local Windows path `C:\Users\benwb\Documents\ApertureCards` by default while allowing a configurable `--output-root` and safe preview/overwrite controls. 
- Use native PowerShell `Compress-Archive` so the zipping behavior is consistent on Windows hosts. 

### Description
- Add `script/zip_aperture_card_subfolders.rb`, a CLI Ruby utility which scans each immediate box folder under `--root`, navigates each box, finds immediate child subfolders, and creates a `SUBFOLDER.zip` for each one in `--output-root/<box-folder>/`. 
- The script uses `OptionParser` and supports `--dry-run`, `--output-root`, and `--overwrite`, validates that `--root` exists and that the host is Windows via `RbConfig`, and creates destination directories with `FileUtils.mkdir_p`. 
- Subfolder paths and zip targets are safely escaped for PowerShell, and the script invokes `Compress-Archive` via `system('powershell', '-NoProfile', '-Command', ps_command)`, aborting on failures and reporting counts of created and skipped zips. 
- Add `doc/aperture_card_zipping.md` with Windows 11 usage examples, flags, and safety notes. 

### Testing
- Ran `ruby -c script/zip_aperture_card_subfolders.rb` to validate Ruby syntax and it succeeded. 
- Ran `ruby script/zip_aperture_card_subfolders.rb --help` to inspect usage output and it displayed the expected options and help text. 
- Also verified `ruby -c script/subdivide_aperture_card_folders.rb` and the existing subdivide script help previously reported OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69987ac3cb188328947fe6d680d4d8f7)