### PR TITLE
feat: add AI draft push option to CONTENTdm export credentials form

### DIFF
--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -189,7 +189,15 @@ class ExportController < ApplicationController
   end
 
   def edit_contentdm_credentials
-    # display the edit form
+    if ContentdmTranslator.collection_is_cdm?(@collection)
+      begin
+        field_config = ContentdmTranslator.fetch_cdm_field_config(@collection)
+        @cdm_fulltext_fields = field_config.select { |e| e['type'] == 'FTS' }.map { |e| [e['name'], e['nick']] }
+        @cdm_metadata_fields = field_config.map { |e| [e['name'], e['nick']] }
+      rescue => e
+        Rails.logger.error("Failed to fetch CONTENTdm field config: #{e.message}")
+      end
+    end
   end
 
   # TODO: Add specs for this

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -208,10 +208,18 @@ class ExportController < ApplicationController
     contentdm_password = params[:contentdm_password]
     error_message, _fts_field = ContentdmTranslator.fts_field_for_collection(@collection)
 
-    # persist license key so the user doesn't have to retype it
+    # persist license key and export settings so the user doesn't have to retype them
     if error_message.blank? || !error_message.match(/license.*invalid/)
       @collection.license_key = license_key
       @collection.save!
+
+      cdm_setting = @collection.cdm_export_setting || @collection.build_cdm_export_setting
+      cdm_setting.transcript_source    = params[:transcript_source].presence || CdmExportSetting::HUMAN_ONLY
+      cdm_setting.fulltext_field       = params[:cdm_fulltext_field].presence
+      cdm_setting.include_ai_provenance = params[:include_ai_provenance] == '1'
+      cdm_setting.ai_provenance_field  = params[:cdm_ai_provenance_field].presence
+      cdm_setting.prepend_ai_warning   = params[:prepend_ai_warning] == '1'
+      cdm_setting.save!
     end
 
     # redirect to or render edit screen with error

--- a/app/models/cdm_export_setting.rb
+++ b/app/models/cdm_export_setting.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: cdm_export_settings
+#
+#  id                    :bigint           not null, primary key
+#  ai_provenance_field   :string(255)
+#  fulltext_field        :string(255)
+#  include_ai_provenance :boolean          default(FALSE), not null
+#  prepend_ai_warning    :boolean          default(FALSE), not null
+#  transcript_source     :string(255)      default("human_only"), not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  collection_id         :integer          not null
+#
+# Indexes
+#
+#  index_cdm_export_settings_on_collection_id  (collection_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (collection_id => collections.id)
+#
+class CdmExportSetting < ApplicationRecord
+  belongs_to :collection
+
+  HUMAN_ONLY    = 'human_only'
+  HUMAN_AND_AI  = 'human_and_ai'
+
+  validates :transcript_source, inclusion: { in: [HUMAN_ONLY, HUMAN_AND_AI] }
+end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -14,11 +14,11 @@
 #  facets_enabled                 :boolean          default(FALSE)
 #  featured_at                    :datetime
 #  field_based                    :boolean          default(FALSE)
-#  footer_block                   :text(16777215)
+#  footer_block                   :string(2000)
 #  help                           :text(65535)
 #  hide_completed                 :boolean          default(TRUE)
 #  hide_notes                     :boolean          default(FALSE)
-#  intro_block                    :text(16777215)
+#  intro_block                    :text(65535)
 #  is_active                      :boolean          default(TRUE)
 #  language                       :string(255)
 #  legend                         :text(65535)
@@ -47,7 +47,6 @@
 # Indexes
 #
 #  index_collections_on_owner_user_id                   (owner_user_id)
-#  index_collections_on_restricted                      (restricted)
 #  index_collections_on_slug                            (slug) UNIQUE
 #  index_collections_on_thredded_messageboard_group_id  (thredded_messageboard_group_id)
 #
@@ -82,6 +81,7 @@ class Collection < ApplicationRecord
   has_many :bulk_exports, dependent: :destroy
   has_many :editor_buttons, dependent: :destroy
   has_one :quality_sampling, dependent: :destroy
+  has_one :cdm_export_setting, dependent: :destroy
   belongs_to :messageboard_group, class_name: 'Thredded::MessageboardGroup', foreign_key: 'thredded_messageboard_group_id', optional: true
 
   belongs_to :next_untranscribed_page, foreign_key: 'next_untranscribed_page_id', class_name: 'Page', optional: true

--- a/app/views/export/edit_contentdm_credentials.html.slim
+++ b/app/views/export/edit_contentdm_credentials.html.slim
@@ -5,7 +5,6 @@
       span.flash_message
         =svg_symbol flash_icon[type], class: 'icon'
         span =message
-      a.flash_close &times;
 
 
   h1 =t('.contentdm_credentials')
@@ -24,5 +23,67 @@
       tr
         th =f.label :contentdm_password, t('.contentdm_password')
         td.w100 =password_field_tag :contentdm_password
+
+    fieldset style="margin-top: 1.5em; border: 1px solid #ccc; padding: 1em;"
+      legend Transcript Export Options
+
+      .form-group style="margin-bottom: 1em;"
+        p style="margin-bottom: 0.5em; font-weight: bold;" Transcript Source:
+        label style="display: block; margin-bottom: 0.4em;"
+          =radio_button_tag :transcript_source, 'human_only', true, id: 'source_human_only'
+          | &nbsp;Only Send Human Edited Transcripts
+        label style="display: block;"
+          =radio_button_tag :transcript_source, 'human_and_ai', false, id: 'source_human_and_ai'
+          | &nbsp;Send Human Transcripts where available, otherwise send AI drafts
+
+      .form-group style="margin-bottom: 1em;"
+        =label_tag :cdm_fulltext_field, 'Full Text Search Field for Transcripts:'
+        br
+        =select_tag :cdm_fulltext_field, options_for_select(@cdm_fulltext_fields.presence || [['-- connect to load fields --', '']]), style: "min-width: 300px; margin-top: 0.25em;"
+
+      #ai-export-options style="display: none; border-top: 1px solid #ddd; padding-top: 1em; margin-top: 0.5em;"
+        .form-group style="margin-bottom: 0.75em;"
+          label style="display: block; margin-bottom: 0.4em;"
+            =check_box_tag :include_ai_provenance, '1', false, id: 'include_ai_provenance'
+            | &nbsp;Include AI provenance (model &amp; date)
+          #ai-provenance-field-group style="display: none; margin-top: 0.5em; margin-left: 1.5em;"
+            =label_tag :cdm_ai_provenance_field, 'AI Provenance Field:'
+            br
+            =select_tag :cdm_ai_provenance_field, options_for_select(@cdm_metadata_fields.presence || [['-- connect to load fields --', '']]), style: "min-width: 300px; margin-top: 0.25em;"
+
+        .form-group
+          label style="display: block;"
+            =check_box_tag :prepend_ai_warning
+            | &nbsp;Append &ldquo;Warning: This transcript is AI-generated.&rdquo; to the top of the transcript.
+
     .toolbar
       .toolbar_group.aright =f.button t('.connect')
+
+  javascript:
+    (function () {
+      var radioButtons = document.querySelectorAll('input[name="transcript_source"]');
+      var aiOptions = document.getElementById('ai-export-options');
+      var provenanceCheckbox = document.getElementById('include_ai_provenance');
+      var provenanceFieldGroup = document.getElementById('ai-provenance-field-group');
+
+      function toggleAiOptions() {
+        var selected = document.querySelector('input[name="transcript_source"]:checked');
+        if (aiOptions) {
+          aiOptions.style.display = (selected && selected.value === 'human_and_ai') ? 'block' : 'none';
+        }
+      }
+
+      function toggleProvenanceField() {
+        if (provenanceFieldGroup) {
+          provenanceFieldGroup.style.display = provenanceCheckbox.checked ? 'block' : 'none';
+        }
+      }
+
+      radioButtons.forEach(function (radio) {
+        radio.addEventListener('change', toggleAiOptions);
+      });
+
+      if (provenanceCheckbox) {
+        provenanceCheckbox.addEventListener('change', toggleProvenanceField);
+      }
+    })();

--- a/app/views/export/edit_contentdm_credentials.html.slim
+++ b/app/views/export/edit_contentdm_credentials.html.slim
@@ -54,7 +54,7 @@
         .form-group
           label style="display: block;"
             =check_box_tag :prepend_ai_warning
-            | &nbsp;Append &ldquo;Warning: This transcript is AI-generated.&rdquo; to the top of the transcript.
+            | &nbsp;Prepend &ldquo;Warning: This transcript is AI-generated.&rdquo; to the top of the transcript.
 
     .toolbar
       .toolbar_group.aright =f.button t('.connect')

--- a/db/migrate/20260507000000_create_cdm_export_settings.rb
+++ b/db/migrate/20260507000000_create_cdm_export_settings.rb
@@ -1,4 +1,4 @@
-class CreateCdmExportSettings < ActiveRecord::Migration[7.0]
+class CreateCdmExportSettings < ActiveRecord::Migration[7.2]
   def change
     create_table :cdm_export_settings do |t|
       t.integer :collection_id, null: false

--- a/db/migrate/20260507000000_create_cdm_export_settings.rb
+++ b/db/migrate/20260507000000_create_cdm_export_settings.rb
@@ -1,0 +1,16 @@
+class CreateCdmExportSettings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cdm_export_settings do |t|
+      t.integer :collection_id, null: false
+      t.string  :transcript_source,     default: 'human_only', null: false
+      t.string  :fulltext_field
+      t.boolean :include_ai_provenance, default: false, null: false
+      t.string  :ai_provenance_field
+      t.boolean :prepend_ai_warning,    default: false, null: false
+      t.timestamps
+    end
+
+    add_index :cdm_export_settings, :collection_id, unique: true
+    add_foreign_key :cdm_export_settings, :collections
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
-  create_table "active_storage_attachments", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+ActiveRecord::Schema[7.2].define(version: 2026_05_07_000000) do
+  create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
     t.bigint "record_id", null: false
@@ -21,7 +21,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "active_storage_blobs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -33,35 +33,35 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "active_storage_variant_records", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "active_storage_variant_records", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "ahoy_activity_summaries", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "ahoy_activity_summaries", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "date", precision: nil
     t.integer "user_id"
     t.integer "collection_id"
     t.string "activity"
     t.integer "minutes"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["date", "collection_id", "user_id", "activity"], name: "ahoy_activity_day_user_collection", unique: true
   end
 
-  create_table "ahoy_events", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "ahoy_events", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "visit_id"
     t.integer "user_id"
     t.string "name"
     t.text "properties"
-    t.datetime "time", precision: nil
+    t.timestamp "time"
     t.index ["name", "time"], name: "index_ahoy_events_on_name_and_time"
     t.index ["user_id", "name"], name: "index_ahoy_events_on_user_id_and_name"
     t.index ["visit_id", "name"], name: "index_ahoy_events_on_visit_id_and_name"
   end
 
-  create_table "ai_transcriptions", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "ai_transcriptions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "page_id", null: false
     t.text "source_text", size: :long
     t.text "prompt", size: :long
@@ -85,8 +85,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
 
   create_table "article_versions", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.string "title"
-    t.text "source_text", size: :medium
-    t.text "xml_text", size: :medium
+    t.text "source_text"
+    t.text "xml_text"
     t.integer "user_id"
     t.integer "article_id"
     t.integer "version", default: 0
@@ -97,10 +97,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
 
   create_table "articles", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.string "title"
-    t.text "source_text", size: :medium
+    t.text "source_text"
     t.datetime "created_on", precision: nil
     t.integer "lock_version", default: 0
-    t.text "xml_text", size: :medium
+    t.text "xml_text"
     t.string "graph_image"
     t.integer "collection_id"
     t.decimal "latitude", precision: 7, scale: 5
@@ -126,7 +126,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["article_id", "category_id"], name: "index_articles_categories_on_article_id_and_category_id"
   end
 
-  create_table "bulk_exports", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "bulk_exports", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "collection_id"
     t.string "status"
@@ -155,14 +155,14 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.boolean "text_only_pdf_work"
     t.string "organization", default: "by_work"
     t.boolean "use_uploaded_filename", default: false
-    t.boolean "plaintext_verbatim_zero_index_page", default: false
     t.boolean "owner_mailing_list"
     t.boolean "owner_detailed_activity"
     t.boolean "collection_activity"
     t.boolean "collection_contributors"
     t.string "report_arguments"
-    t.boolean "notes_csv"
+    t.boolean "plaintext_verbatim_zero_index_page", default: false
     t.boolean "admin_searches"
+    t.boolean "notes_csv"
     t.boolean "page_details_csv_work", default: false
     t.boolean "page_details_csv_collection", default: false
     t.index ["collection_id"], name: "index_bulk_exports_on_collection_id"
@@ -183,7 +183,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["parent_id"], name: "index_categories_on_parent_id"
   end
 
-  create_table "cdm_bulk_imports", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "cdm_bulk_imports", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.boolean "ocr_correction", default: false
     t.string "collection_param", null: false
@@ -194,22 +194,34 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["user_id"], name: "index_cdm_bulk_imports_on_user_id"
   end
 
+  create_table "cdm_export_settings", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "collection_id", null: false
+    t.string "transcript_source", default: "human_only", null: false
+    t.string "fulltext_field"
+    t.boolean "include_ai_provenance", default: false, null: false
+    t.string "ai_provenance_field"
+    t.boolean "prepend_ai_warning", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["collection_id"], name: "index_cdm_export_settings_on_collection_id", unique: true
+  end
+
   create_table "clientperf_results", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.integer "clientperf_uri_id"
     t.integer "milliseconds"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["clientperf_uri_id"], name: "index_clientperf_results_on_clientperf_uri_id"
   end
 
   create_table "clientperf_uris", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.string "uri"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["uri"], name: "index_clientperf_uris_on_uri"
   end
 
-  create_table "collection_blocks", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "collection_blocks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "collection_id", null: false
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
@@ -218,7 +230,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["user_id"], name: "fk_rails_c117458532"
   end
 
-  create_table "collection_collaborators", id: false, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "collection_collaborators", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "collection_id"
   end
@@ -226,11 +238,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
   create_table "collection_owners", id: false, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "collection_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "collection_reviewers", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "collection_reviewers", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "collection_id"
     t.datetime "created_at", precision: nil, null: false
@@ -243,8 +255,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.string "title"
     t.integer "owner_user_id"
     t.datetime "created_on", precision: nil
-    t.text "intro_block", size: :medium
-    t.text "footer_block", size: :medium
+    t.string "review_type", default: "optional"
+    t.text "intro_block"
+    t.string "footer_block", limit: 2000
     t.boolean "restricted", default: false
     t.string "picture"
     t.boolean "supports_document_sets", default: false
@@ -257,17 +270,16 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.boolean "field_based", default: false
     t.boolean "voice_recognition", default: false
     t.string "language"
-    t.string "text_language"
     t.string "license_key"
+    t.string "text_language"
     t.integer "pct_completed"
     t.string "default_orientation"
     t.boolean "is_active", default: true
-    t.integer "works_count", default: 0
     t.integer "next_untranscribed_page_id"
+    t.integer "works_count", default: 0
     t.boolean "api_access", default: false
     t.boolean "facets_enabled", default: false
     t.boolean "user_download", default: false
-    t.string "review_type", default: "optional"
     t.string "data_entry_type", default: "text"
     t.text "description_instructions"
     t.boolean "enable_spellcheck", default: false
@@ -281,27 +293,13 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.string "default_overview_orientation"
     t.boolean "hide_notes", default: false
     t.index ["owner_user_id"], name: "index_collections_on_owner_user_id"
-    t.index ["restricted"], name: "index_collections_on_restricted"
     t.index ["slug"], name: "index_collections_on_slug", unique: true
     t.index ["thredded_messageboard_group_id"], name: "index_collections_on_thredded_messageboard_group_id"
   end
 
-  create_table "collections_tags", id: false, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "collections_tags", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "collection_id"
     t.integer "tag_id"
-  end
-
-  create_table "comments", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.integer "parent_id"
-    t.integer "user_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.integer "commentable_id", default: 0, null: false
-    t.string "commentable_type", default: "", null: false
-    t.integer "depth"
-    t.string "title"
-    t.text "body", size: :medium
-    t.string "comment_type", limit: 10, default: "annotation"
-    t.string "comment_status", limit: 10
   end
 
   create_table "deeds", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
@@ -312,8 +310,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.integer "article_id"
     t.integer "user_id"
     t.integer "note_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "visit_id"
     t.string "prerender", limit: 8191
     t.string "prerender_mailer", limit: 8191
@@ -330,45 +328,43 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["work_id", "deed_type", "user_id", "created_at"], name: "index_deeds_on_work_id_and_deed_type_and_user_id_and_created_at"
   end
 
-  create_table "document_set_collaborators", id: false, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "document_set_collaborators", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "document_set_id"
   end
 
-  create_table "document_sets", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "document_sets", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "owner_user_id"
     t.integer "collection_id"
     t.string "title"
     t.text "description"
     t.string "picture"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.integer "visibility"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "slug"
     t.integer "pct_completed"
     t.string "default_orientation"
-    t.integer "works_count", default: 0
     t.integer "next_untranscribed_page_id"
-    t.integer "visibility", default: 0, null: false
+    t.integer "works_count", default: 0
     t.datetime "featured_at", precision: nil
     t.index ["collection_id"], name: "index_document_sets_on_collection_id"
     t.index ["owner_user_id"], name: "index_document_sets_on_owner_user_id"
     t.index ["slug"], name: "index_document_sets_on_slug", unique: true
   end
 
-  create_table "document_sets_works", id: false, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "document_sets_works", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "document_set_id", null: false
     t.integer "work_id", null: false
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
     t.index ["work_id", "document_set_id"], name: "index_document_sets_works_on_work_id_and_document_set_id", unique: true
   end
 
-  create_table "document_uploads", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "document_uploads", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "collection_id"
     t.string "file"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "status", default: "new"
     t.boolean "preserve_titles", default: false
     t.boolean "ocr", default: false
@@ -379,7 +375,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["user_id"], name: "index_document_uploads_on_user_id"
   end
 
-  create_table "editor_buttons", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "editor_buttons", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "key"
     t.integer "collection_id", null: false
     t.boolean "prefer_html"
@@ -388,7 +384,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["collection_id"], name: "index_editor_buttons_on_collection_id"
   end
 
-  create_table "external_api_requests", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "external_api_requests", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "collection_id", null: false
     t.integer "work_id"
@@ -404,7 +400,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["work_id"], name: "index_external_api_requests_on_work_id"
   end
 
-  create_table "facet_configs", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "facet_configs", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "label"
     t.string "input_type"
     t.integer "order"
@@ -414,7 +410,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["metadata_coverage_id"], name: "index_facet_configs_on_metadata_coverage_id"
   end
 
-  create_table "flags", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "flags", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "author_user_id"
     t.integer "page_version_id"
     t.integer "article_version_id"
@@ -426,17 +422,18 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.integer "reporter_user_id"
     t.integer "auditor_user_id"
     t.datetime "content_at", precision: nil
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["article_version_id"], name: "index_flags_on_article_version_id"
     t.index ["auditor_user_id"], name: "index_flags_on_auditor_user_id"
     t.index ["author_user_id"], name: "index_flags_on_author_user_id"
     t.index ["note_id"], name: "index_flags_on_note_id"
     t.index ["page_version_id"], name: "index_flags_on_page_version_id"
     t.index ["reporter_user_id"], name: "index_flags_on_reporter_user_id"
+    t.index ["status"], name: "index_flags_on_status"
   end
 
-  create_table "friendly_id_slugs", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "friendly_id_slugs", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "slug", null: false
     t.integer "sluggable_id", null: false
     t.string "sluggable_type", limit: 50
@@ -448,20 +445,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
   end
 
-  create_table "honeypot_visits", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.integer "visit_id"
-    t.string "ip_address", null: false
-    t.string "ip_subnet", null: false
-    t.string "browser"
-    t.text "user_agent"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["browser"], name: "index_honeypot_visits_on_browser"
-    t.index ["ip_address"], name: "index_honeypot_visits_on_ip_address"
-    t.index ["ip_subnet", "created_at"], name: "index_honeypot_visits_on_ip_subnet_and_created_at"
-    t.index ["visit_id"], name: "index_honeypot_visits_on_visit_id"
-  end
-
   create_table "ia_leaves", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.integer "ia_work_id"
     t.integer "page_id"
@@ -470,8 +453,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.integer "leaf_number"
     t.string "page_number"
     t.string "page_type"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "ocr_text"
     t.index ["page_id"], name: "index_ia_leaves_on_page_id"
   end
@@ -493,8 +476,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.string "sponsor"
     t.string "image_count"
     t.integer "title_leaf"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "image_format", default: "jp2"
     t.string "archive_format", default: "zip"
     t.string "scandata_file"
@@ -503,7 +486,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.boolean "use_ocr", default: false
   end
 
-  create_table "metadata_coverages", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "metadata_coverages", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "key"
     t.integer "count", default: 0
     t.integer "collection_id"
@@ -511,7 +494,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "metadata_description_versions", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "metadata_description_versions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "metadata_description"
     t.integer "user_id", null: false
     t.integer "work_id", null: false
@@ -531,88 +514,23 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.integer "page_id"
     t.integer "parent_id"
     t.integer "depth"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["collection_id"], name: "fk_rails_7d330fa613"
     t.index ["page_id"], name: "index_notes_on_page_id"
     t.index ["work_id"], name: "fk_rails_9fa473ac93"
   end
 
-  create_table "notifications", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "notifications", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.boolean "add_as_owner", default: true
     t.boolean "add_as_collaborator", default: true
     t.boolean "note_added", default: true
     t.boolean "owner_stats", default: false
     t.boolean "user_activity", default: true
     t.integer "user_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "add_as_reviewer", default: true
-  end
-
-  create_table "oai_repositories", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.string "url"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-  end
-
-  create_table "oai_sets", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.string "set_spec"
-    t.string "repository_url"
-    t.integer "user_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-  end
-
-  create_table "omeka_collections", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.integer "omeka_id"
-    t.integer "collection_id"
-    t.string "title"
-    t.string "description"
-    t.integer "omeka_site_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-  end
-
-  create_table "omeka_files", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.integer "omeka_id"
-    t.integer "omeka_item_id"
-    t.string "mime_type"
-    t.string "fullsize_url"
-    t.string "thumbnail_url"
-    t.string "original_filename"
-    t.integer "omeka_order"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.integer "page_id"
-    t.index ["omeka_id"], name: "index_omeka_files_on_omeka_id"
-  end
-
-  create_table "omeka_items", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.string "title"
-    t.string "subject"
-    t.string "description"
-    t.string "rights"
-    t.string "creator"
-    t.string "format"
-    t.string "coverage"
-    t.integer "omeka_site_id"
-    t.integer "omeka_id"
-    t.string "omeka_url"
-    t.integer "omeka_collection_id"
-    t.integer "user_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.integer "work_id"
-  end
-
-  create_table "omeka_sites", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.string "title"
-    t.string "api_url"
-    t.string "api_key"
-    t.integer "user_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
   end
 
   create_table "page_article_links", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
@@ -632,9 +550,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.string "view"
     t.string "tag"
     t.string "description"
-    t.text "html", size: :medium
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.text "html"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["controller", "view"], name: "index_page_blocks_on_controller_and_view"
   end
 
@@ -667,15 +585,15 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.datetime "created_on", precision: nil
     t.integer "position"
     t.integer "lock_version", default: 0
+    t.string "status", default: "new", null: false
+    t.string "translation_status", default: "new", null: false
     t.text "xml_text", size: :medium, collation: "utf8mb4_unicode_ci"
     t.integer "page_version_id"
-    t.string "status", default: "new", null: false
     t.text "source_translation", size: :medium, collation: "utf8mb4_unicode_ci"
     t.text "xml_translation", size: :medium, collation: "utf8mb4_unicode_ci"
-    t.text "search_text", size: :medium, collation: "utf8mb4_unicode_ci"
-    t.string "translation_status", default: "new", null: false
+    t.text "search_text", collation: "utf8mb4_unicode_ci"
     t.text "metadata"
-    t.datetime "edit_started_at", precision: nil
+    t.timestamp "edit_started_at"
     t.integer "edit_started_by_user_id"
     t.integer "line_count"
     t.float "approval_delta"
@@ -690,19 +608,14 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["work_id"], name: "index_pages_on_work_id"
   end
 
-  create_table "pages_sections", id: false, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "pages_sections", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "page_id", null: false
     t.integer "section_id", null: false
     t.index ["page_id", "section_id"], name: "index_pages_sections_on_page_id_and_section_id"
     t.index ["section_id", "page_id"], name: "index_pages_sections_on_section_id_and_page_id"
   end
 
-  create_table "plugin_schema_info", id: false, charset: "utf8", collation: "utf8_general_ci", options: "ENGINE=MyISAM", force: :cascade do |t|
-    t.string "plugin_name"
-    t.integer "version"
-  end
-
-  create_table "privacy_preferences", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "privacy_preferences", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.boolean "recorded", default: false, null: false
     t.boolean "analytics", default: false, null: false
@@ -710,7 +623,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["user_id"], name: "index_privacy_preferences_on_user_id", unique: true
   end
 
-  create_table "quality_samplings", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "quality_samplings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "collection_id", null: false
     t.text "sample_set", size: :medium
@@ -720,15 +633,15 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["user_id"], name: "index_quality_samplings_on_user_id"
   end
 
-  create_table "sc_canvases", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "sc_canvases", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "sc_id"
     t.integer "sc_manifest_id"
     t.integer "page_id"
     t.string "sc_canvas_id"
     t.string "sc_canvas_label"
     t.string "sc_service_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "height"
     t.integer "width"
     t.string "sc_resource_id"
@@ -738,10 +651,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["sc_manifest_id"], name: "index_sc_canvases_on_sc_manifest_id"
   end
 
-  create_table "sc_collections", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "sc_collections", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "collection_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "at_id"
     t.integer "parent_id"
     t.string "label"
@@ -749,16 +662,16 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["collection_id"], name: "index_sc_collections_on_collection_id"
   end
 
-  create_table "sc_manifests", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "sc_manifests", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "work_id"
     t.integer "sc_collection_id"
     t.string "sc_id"
-    t.text "label"
+    t.text "label", size: :tiny
     t.text "metadata"
     t.string "first_sequence_id"
     t.string "first_sequence_label"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "at_id"
     t.integer "collection_id"
     t.string "version", default: "2"
@@ -766,7 +679,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["work_id"], name: "index_sc_manifests_on_work_id"
   end
 
-  create_table "search_attempts", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "search_attempts", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "query"
@@ -789,21 +702,21 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["work_id"], name: "index_search_attempts_on_work_id"
   end
 
-  create_table "sections", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "sections", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "title"
     t.integer "depth"
     t.integer "position"
     t.integer "work_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["work_id"], name: "index_sections_on_work_id"
   end
 
   create_table "sessions", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
-    t.string "session_id", default: "", null: false
-    t.text "data", size: :medium
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["session_id"], name: "index_sessions_on_session_id"
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
@@ -929,7 +842,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
-  create_table "spreadsheet_columns", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "spreadsheet_columns", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "transcription_field_id", null: false
     t.integer "position"
     t.string "label"
@@ -940,7 +853,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["transcription_field_id"], name: "index_spreadsheet_columns_on_transcription_field_id"
   end
 
-  create_table "suspicious_behaviors", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "suspicious_behaviors", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "page_id"
     t.integer "collection_id"
@@ -957,15 +870,15 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["user_id"], name: "index_suspicious_behaviors_on_user_id"
   end
 
-  create_table "table_cells", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "table_cells", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "work_id"
     t.integer "page_id"
     t.integer "section_id"
     t.string "header"
     t.text "content"
     t.integer "row"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "transcription_field_id"
     t.index ["page_id"], name: "index_table_cells_on_page_id"
     t.index ["section_id"], name: "index_table_cells_on_section_id"
@@ -973,7 +886,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["work_id"], name: "index_table_cells_on_work_id"
   end
 
-  create_table "tags", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "tags", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "tag_type"
     t.boolean "canonical"
     t.string "ai_text"
@@ -982,16 +895,16 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "tex_figures", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "tex_figures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "page_id"
     t.integer "position"
     t.text "source"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["page_id"], name: "index_tex_figures_on_page_id"
   end
 
-  create_table "thredded_categories", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_categories", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "messageboard_id", null: false
     t.text "name", null: false
     t.text "description"
@@ -1003,14 +916,14 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["name"], name: "thredded_categories_name_ci", length: 191
   end
 
-  create_table "thredded_messageboard_groups", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_messageboard_groups", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.integer "position", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "thredded_messageboard_notifications_for_followed_topics", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_messageboard_notifications_for_followed_topics", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.bigint "messageboard_id", null: false
     t.string "notifier_key", limit: 90, null: false
@@ -1018,7 +931,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["user_id", "messageboard_id", "notifier_key"], name: "thredded_messageboard_notifications_for_followed_topics_unique", unique: true
   end
 
-  create_table "thredded_messageboard_users", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_messageboard_users", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "thredded_user_detail_id", null: false
     t.bigint "thredded_messageboard_id", null: false
     t.datetime "last_seen_at", precision: nil, null: false
@@ -1027,7 +940,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["thredded_user_detail_id"], name: "fk_rails_06e42c62f5"
   end
 
-  create_table "thredded_messageboards", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_messageboards", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "name", null: false
     t.text "slug"
     t.text "description"
@@ -1043,21 +956,21 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["slug"], name: "index_thredded_messageboards_on_slug", unique: true, length: 191
   end
 
-  create_table "thredded_notifications_for_followed_topics", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_notifications_for_followed_topics", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "notifier_key", limit: 90, null: false
     t.boolean "enabled", default: true, null: false
     t.index ["user_id", "notifier_key"], name: "thredded_notifications_for_followed_topics_unique", unique: true
   end
 
-  create_table "thredded_notifications_for_private_topics", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_notifications_for_private_topics", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "notifier_key", limit: 90, null: false
     t.boolean "enabled", default: true, null: false
     t.index ["user_id", "notifier_key"], name: "thredded_notifications_for_private_topics_unique", unique: true
   end
 
-  create_table "thredded_post_moderation_records", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_post_moderation_records", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "post_id"
     t.bigint "messageboard_id"
     t.text "post_content"
@@ -1070,7 +983,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["messageboard_id", "created_at"], name: "index_thredded_moderation_records_for_display"
   end
 
-  create_table "thredded_posts", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_posts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.text "content"
     t.string "source", limit: 191, default: "web"
@@ -1087,7 +1000,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["user_id"], name: "index_thredded_posts_on_user_id"
   end
 
-  create_table "thredded_private_posts", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_private_posts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.text "content"
     t.bigint "postable_id", null: false
@@ -1096,7 +1009,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["postable_id", "created_at"], name: "index_thredded_private_posts_on_postable_id_and_created_at"
   end
 
-  create_table "thredded_private_topics", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_private_topics", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "last_user_id"
     t.text "title", null: false
@@ -1111,7 +1024,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["slug"], name: "index_thredded_private_topics_on_slug", unique: true, length: 191
   end
 
-  create_table "thredded_private_users", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_private_users", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "private_topic_id"
     t.integer "user_id"
     t.datetime "created_at", precision: nil, null: false
@@ -1120,14 +1033,14 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["user_id"], name: "index_thredded_private_users_on_user_id"
   end
 
-  create_table "thredded_topic_categories", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_topic_categories", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "topic_id", null: false
     t.bigint "category_id", null: false
     t.index ["category_id"], name: "index_thredded_topic_categories_on_category_id"
     t.index ["topic_id"], name: "index_thredded_topic_categories_on_topic_id"
   end
 
-  create_table "thredded_topics", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_topics", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "last_user_id"
     t.text "title", null: false
@@ -1150,7 +1063,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["user_id"], name: "index_thredded_topics_on_user_id"
   end
 
-  create_table "thredded_user_details", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_user_details", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "latest_activity_at", precision: nil
     t.integer "posts_count", default: 0
@@ -1165,7 +1078,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["user_id"], name: "index_thredded_user_details_on_user_id", unique: true
   end
 
-  create_table "thredded_user_messageboard_preferences", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_user_messageboard_preferences", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.bigint "messageboard_id", null: false
     t.boolean "follow_topics_on_mention", default: true, null: false
@@ -1175,7 +1088,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["user_id", "messageboard_id"], name: "thredded_user_messageboard_preferences_user_id_messageboard_id", unique: true
   end
 
-  create_table "thredded_user_post_notifications", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_user_post_notifications", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.bigint "post_id", null: false
     t.datetime "notified_at", precision: nil, null: false
@@ -1183,7 +1096,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["user_id", "post_id"], name: "index_thredded_user_post_notifications_on_user_id_and_post_id", unique: true
   end
 
-  create_table "thredded_user_preferences", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_user_preferences", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.boolean "follow_topics_on_mention", default: true, null: false
     t.boolean "auto_follow_topics", default: false, null: false
@@ -1192,7 +1105,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["user_id"], name: "index_thredded_user_preferences_on_user_id", unique: true
   end
 
-  create_table "thredded_user_private_topic_read_states", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_user_private_topic_read_states", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.bigint "postable_id", null: false
     t.integer "unread_posts_count", default: 0, null: false
@@ -1202,7 +1115,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["user_id", "postable_id"], name: "thredded_user_private_topic_read_states_user_postable", unique: true
   end
 
-  create_table "thredded_user_topic_follows", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_user_topic_follows", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.bigint "topic_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -1210,7 +1123,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.index ["user_id", "topic_id"], name: "thredded_user_topic_follows_user_topic", unique: true
   end
 
-  create_table "thredded_user_topic_read_states", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "thredded_user_topic_read_states", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "messageboard_id", null: false
     t.integer "user_id", null: false
     t.bigint "postable_id", null: false
@@ -1228,7 +1141,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.integer "work_id"
   end
 
-  create_table "transcription_fields", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "transcription_fields", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "label"
     t.integer "collection_id"
     t.string "input_type"
@@ -1284,16 +1197,15 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.string "preferred_locale"
     t.string "api_key"
     t.string "picture"
-    t.text "help"
     t.text "footer_block", size: :medium
+    t.text "help"
     t.boolean "document_sets_on_owner_page", default: false
-    t.index ["deleted"], name: "index_users_on_deleted"
     t.index ["login"], name: "index_users_on_login"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["slug"], name: "index_users_on_slug", unique: true
   end
 
-  create_table "visits", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "visits", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "visit_token"
     t.string "visitor_token"
     t.string "ip"
@@ -1319,12 +1231,12 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.string "utm_term"
     t.string "utm_content"
     t.string "utm_campaign"
-    t.datetime "started_at", precision: nil
+    t.timestamp "started_at"
     t.index ["user_id"], name: "index_visits_on_user_id"
     t.index ["visit_token"], name: "index_visits_on_visit_token", unique: true
   end
 
-  create_table "work_facets", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+  create_table "work_facets", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "s0", limit: 512
     t.string "s1", limit: 512
     t.string "s2", limit: 512
@@ -1349,8 +1261,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.integer "transcribed_pages"
     t.integer "annotated_pages"
     t.integer "total_pages"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "blank_pages", default: 0
     t.integer "incomplete_pages", default: 0
     t.integer "corrected_pages"
@@ -1370,17 +1282,17 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
 
   create_table "works", id: :integer, charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.string "title"
-    t.text "description", size: :medium
+    t.string "description", limit: 4000
     t.datetime "created_on", precision: nil
     t.integer "owner_user_id"
     t.boolean "restrict_scribes", default: false
     t.integer "transcription_version", default: 0
-    t.text "physical_description", size: :medium
-    t.text "document_history", size: :medium
-    t.text "permission_description", size: :medium
+    t.text "physical_description"
+    t.text "document_history"
+    t.text "permission_description"
     t.string "location_of_composition"
     t.string "author"
-    t.text "transcription_conventions", size: :medium
+    t.text "transcription_conventions"
     t.integer "collection_id"
     t.boolean "scribes_can_edit_titles", default: false
     t.boolean "supports_translation", default: false
@@ -1393,6 +1305,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.string "identifier"
     t.integer "next_untranscribed_page_id"
     t.text "original_metadata"
+    t.string "uploaded_filename"
     t.string "genre"
     t.string "source_location"
     t.string "source_collection_name"
@@ -1400,7 +1313,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
     t.boolean "in_scope", default: true
     t.text "editorial_notes"
     t.string "document_date"
-    t.string "uploaded_filename"
     t.text "metadata_description"
     t.integer "metadata_description_version_id"
     t.string "description_status", default: "undescribed"
@@ -1421,6 +1333,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
   add_foreign_key "bulk_exports", "users"
   add_foreign_key "bulk_exports", "works"
   add_foreign_key "cdm_bulk_imports", "users"
+  add_foreign_key "cdm_export_settings", "collections"
   add_foreign_key "collection_blocks", "collections"
   add_foreign_key "collection_blocks", "users"
   add_foreign_key "collections", "thredded_messageboard_groups"
@@ -1429,7 +1342,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_12_193204) do
   add_foreign_key "external_api_requests", "users"
   add_foreign_key "external_api_requests", "works"
   add_foreign_key "facet_configs", "metadata_coverages"
-  add_foreign_key "honeypot_visits", "visits"
   add_foreign_key "metadata_description_versions", "users"
   add_foreign_key "metadata_description_versions", "works"
   add_foreign_key "notes", "collections", on_delete: :cascade

--- a/lib/contentdm_translator.rb
+++ b/lib/contentdm_translator.rb
@@ -183,7 +183,7 @@ module ContentdmTranslator
       ]
 
       if ai_transcription && cdm_setting&.include_ai_provenance && cdm_setting&.ai_provenance_field.present?
-        provenance = "#{ai_transcription.model} #{ai_transcription.created_at.strftime('%Y-%m-%d')}"
+        provenance = ai_provenance(ai_transcription)
         metadata_entries << { field: cdm_setting.ai_provenance_field, value: provenance }
       end
 
@@ -206,15 +206,19 @@ module ContentdmTranslator
   end
 
   def self.transcript_for_page(page, cdm_setting)
-    if cdm_setting&.transcript_source == CdmExportSetting::HUMAN_AND_AI && page.verbatim_transcription_plaintext.blank?
-      ai = page.ai_transcription
-      if ai&.source_text.present?
-        text = ai.source_text
-        text = "Warning: This transcript is AI-generated.\n#{text}" if cdm_setting.prepend_ai_warning
-        return [text, ai]
+      if cdm_setting&.transcript_source == CdmExportSetting::HUMAN_AND_AI && page.verbatim_transcription_plaintext.blank?
+        ai = page.ai_transcription
+        if ai&.source_text.present?
+          text = ai.source_text
+          text = "Warning: This transcript is AI-generated (#{ai_provenance(ai)}).\n#{text}" if cdm_setting.prepend_ai_warning
+          return [text, ai]
+        end
       end
-    end
-    [page.verbatim_transcription_plaintext, nil]
+      [page.verbatim_transcription_plaintext, nil]
+  end
+
+  def self.ai_provenance(ai_transcription)
+    "#{ai_transcription.model} #{ai_transcription.created_at.strftime('%Y-%m-%d')}"
   end
 
   def self.log_file(collection)

--- a/lib/contentdm_translator.rb
+++ b/lib/contentdm_translator.rb
@@ -157,10 +157,16 @@ module ContentdmTranslator
   end
 
   def self.export_work_to_cdm(work, username, password, license)
-    error, fieldname = fts_field_for_collection(work.collection)
-    if error
-      puts "Error retrieving Full-Text Search field: #{error}\n"
-      exit
+    collection = work.collection
+    cdm_setting = collection.cdm_export_setting
+
+    fieldname = cdm_setting&.fulltext_field.presence
+    unless fieldname
+      error, fieldname = fts_field_for_collection(collection)
+      if error
+        puts "Error retrieving Full-Text Search field: #{error}\n"
+        exit
+      end
     end
 
     soap_client = Savon.client(log: true, filters: [:password], wsdl: 'https://worldcat.org/webservices/contentdm/catcher?wsdl', follow_redirects: true)
@@ -168,14 +174,20 @@ module ContentdmTranslator
       canvas_at_id = page.sc_canvas.sc_canvas_id
       manifest_at_id = work.sc_manifest.at_id
       puts "\nUpdating #{cdm_collection(manifest_at_id)}\trecord #{cdm_record(canvas_at_id)}\tfrom #{page.title}\t#{page.id}\t#{work.title} at #{Time.current.strftime('%Y-%m-%d %I:%M %p')}.  CONTENTdm response:"
-      metadata_wrapper = {
-        'metadataList' => {
-          'metadata' => [
-            { field: 'dmrecord', value: cdm_record(canvas_at_id) },
-            { field: fieldname, value: page.verbatim_transcription_plaintext }
-          ]
-        }
-      }
+
+      transcript_text, ai_transcription = transcript_for_page(page, cdm_setting)
+
+      metadata_entries = [
+        { field: 'dmrecord', value: cdm_record(canvas_at_id) },
+        { field: fieldname, value: transcript_text }
+      ]
+
+      if ai_transcription && cdm_setting&.include_ai_provenance && cdm_setting&.ai_provenance_field.present?
+        provenance = "#{ai_transcription.model} #{ai_transcription.created_at.strftime('%Y-%m-%d')}"
+        metadata_entries << { field: cdm_setting.ai_provenance_field, value: provenance }
+      end
+
+      metadata_wrapper = { 'metadataList' => { 'metadata' => metadata_entries } }
 
       message = {
         cdmurl: "http://#{cdm_server(manifest_at_id)}:8888",
@@ -191,6 +203,18 @@ module ContentdmTranslator
 
       puts resp.to_hash[:process_conten_tdm_response][:return]
     end
+  end
+
+  def self.transcript_for_page(page, cdm_setting)
+    if cdm_setting&.transcript_source == CdmExportSetting::HUMAN_AND_AI && page.verbatim_transcription_plaintext.blank?
+      ai = page.ai_transcription
+      if ai&.source_text.present?
+        text = ai.source_text
+        text = "Warning: This transcript is AI-generated.\n#{text}" if cdm_setting.prepend_ai_warning
+        return [text, ai]
+      end
+    end
+    [page.verbatim_transcription_plaintext, nil]
   end
 
   def self.log_file(collection)

--- a/lib/tasks/cdm_transcript_export.rake
+++ b/lib/tasks/cdm_transcript_export.rake
@@ -8,8 +8,10 @@ namespace :fromthepage do
     password = ENV['contentdm_password']
     license = ENV['contentdm_license']
 
+    include_ai_drafts = collection.cdm_export_setting&.transcript_source == CdmExportSetting::HUMAN_AND_AI
+
     collection.works.joins(:sc_manifest, :work_statistic).each do |work|
-      if work.work_statistic.complete >= 99
+      if include_ai_drafts || work.work_statistic.complete >= 99
         print "\tBeginning export of work #{work.id}, '#{work.title}' \n"
         ContentdmTranslator.export_work_to_cdm_with_retry(work, username, password, license)
         print "Finished export of work #{work.id}, '#{work.title}' \n"

--- a/spec/factories/cdm_export_setting.rb
+++ b/spec/factories/cdm_export_setting.rb
@@ -1,0 +1,23 @@
+FactoryBot.define do
+  factory :cdm_export_setting do
+    collection
+    transcript_source { CdmExportSetting::HUMAN_ONLY }
+    fulltext_field    { 'transc' }
+    include_ai_provenance { false }
+    ai_provenance_field   { nil }
+    prepend_ai_warning    { false }
+
+    trait :human_and_ai do
+      transcript_source { CdmExportSetting::HUMAN_AND_AI }
+    end
+
+    trait :with_provenance do
+      include_ai_provenance { true }
+      ai_provenance_field   { 'descri' }
+    end
+
+    trait :with_warning do
+      prepend_ai_warning { true }
+    end
+  end
+end

--- a/spec/models/contentdm_translator_spec.rb
+++ b/spec/models/contentdm_translator_spec.rb
@@ -2,6 +2,84 @@ require 'spec_helper'
 require 'contentdm_translator'
 
 RSpec.describe ContentdmTranslator do
+  describe '.transcript_for_page' do
+    let(:page)        { create(:page) }
+    let(:cdm_setting) { build(:cdm_export_setting) }
+
+    context 'when cdm_setting is nil' do
+      it 'returns the human transcript and no AI object' do
+        allow(page).to receive(:verbatim_transcription_plaintext).and_return('human text')
+        text, ai = ContentdmTranslator.transcript_for_page(page, nil)
+        expect(text).to eq('human text')
+        expect(ai).to be_nil
+      end
+    end
+
+    context 'when transcript_source is human_only' do
+      it 'returns the human transcript regardless of AI drafts' do
+        allow(page).to receive(:verbatim_transcription_plaintext).and_return('human text')
+        text, ai = ContentdmTranslator.transcript_for_page(page, cdm_setting)
+        expect(text).to eq('human text')
+        expect(ai).to be_nil
+      end
+    end
+
+    context 'when transcript_source is human_and_ai' do
+      before { cdm_setting.transcript_source = CdmExportSetting::HUMAN_AND_AI }
+
+      context 'when a human transcript exists' do
+        it 'returns the human transcript and no AI object' do
+          allow(page).to receive(:verbatim_transcription_plaintext).and_return('human text')
+          text, ai = ContentdmTranslator.transcript_for_page(page, cdm_setting)
+          expect(text).to eq('human text')
+          expect(ai).to be_nil
+        end
+      end
+
+      context 'when no human transcript exists' do
+        before { allow(page).to receive(:verbatim_transcription_plaintext).and_return(nil) }
+
+        context 'and an AI draft exists' do
+          let(:ai_transcription) { create(:ai_transcription, page: page, source_text: 'AI draft text', status: :finished) }
+          before { allow(page).to receive(:ai_transcription).and_return(ai_transcription) }
+
+          it 'returns the AI draft text and the AI object' do
+            text, ai = ContentdmTranslator.transcript_for_page(page, cdm_setting)
+            expect(text).to eq('AI draft text')
+            expect(ai).to eq(ai_transcription)
+          end
+
+          context 'and prepend_ai_warning is true' do
+            before { cdm_setting.prepend_ai_warning = true }
+
+            it 'prepends the warning line to the AI text' do
+              text, _ai = ContentdmTranslator.transcript_for_page(page, cdm_setting)
+              expect(text).to eq("Warning: This transcript is AI-generated.\nAI draft text")
+            end
+          end
+
+          context 'and prepend_ai_warning is false' do
+            it 'does not add a warning prefix' do
+              text, _ai = ContentdmTranslator.transcript_for_page(page, cdm_setting)
+              expect(text).not_to include('Warning:')
+            end
+          end
+        end
+
+        context 'and no AI draft exists' do
+          before { allow(page).to receive(:ai_transcription).and_return(nil) }
+
+          it 'returns nil transcript and no AI object' do
+            text, ai = ContentdmTranslator.transcript_for_page(page, cdm_setting)
+            expect(text).to be_nil
+            expect(ai).to be_nil
+          end
+        end
+      end
+    end
+  end
+
+
   describe '#cdm_url_to_iiif' do
     let(:item_url) { 'https://digital.archives.alabama.gov/digital/collection/supreme_court/id/7076' }
     let(:collection_url) { 'https://digital.archives.alabama.gov/digital/collection/supreme_court' }

--- a/spec/models/contentdm_translator_spec.rb
+++ b/spec/models/contentdm_translator_spec.rb
@@ -2,6 +2,44 @@ require 'spec_helper'
 require 'contentdm_translator'
 
 RSpec.describe ContentdmTranslator do
+  describe '#transcript_for_page' do
+    let(:created_at) { Time.zone.parse('2026-05-01 12:00:00') }
+    let(:ai_transcription) do
+      instance_double(AiTranscription, source_text: 'AI draft text', model: 'gemini-2.5-pro', created_at: created_at)
+    end
+
+    it 'returns human transcription when transcript source is human only' do
+      page = instance_double(Page, verbatim_transcription_plaintext: 'Human text', ai_transcription: ai_transcription)
+      cdm_setting = instance_double(CdmExportSetting, transcript_source: CdmExportSetting::HUMAN_ONLY, prepend_ai_warning: false)
+
+      transcript_text, ai = ContentdmTranslator.transcript_for_page(page, cdm_setting)
+
+      expect(transcript_text).to eq('Human text')
+      expect(ai).to be_nil
+    end
+
+    it 'falls back to AI transcription when human text is blank and AI fallback is enabled' do
+      page = instance_double(Page, verbatim_transcription_plaintext: '', ai_transcription: ai_transcription)
+      cdm_setting = instance_double(CdmExportSetting, transcript_source: CdmExportSetting::HUMAN_AND_AI, prepend_ai_warning: false)
+
+      transcript_text, ai = ContentdmTranslator.transcript_for_page(page, cdm_setting)
+
+      expect(transcript_text).to eq('AI draft text')
+      expect(ai).to eq(ai_transcription)
+    end
+
+    it 'prepends a warning that includes model and run date when requested' do
+      page = instance_double(Page, verbatim_transcription_plaintext: nil, ai_transcription: ai_transcription)
+      cdm_setting = instance_double(CdmExportSetting, transcript_source: CdmExportSetting::HUMAN_AND_AI, prepend_ai_warning: true)
+
+      transcript_text, ai = ContentdmTranslator.transcript_for_page(page, cdm_setting)
+
+      expect(transcript_text).to start_with('Warning: This transcript is AI-generated (gemini-2.5-pro 2026-05-01).')
+      expect(transcript_text).to end_with("\nAI draft text")
+      expect(ai).to eq(ai_transcription)
+    end
+  end
+
   describe '#cdm_url_to_iiif' do
     let(:item_url) { 'https://digital.archives.alabama.gov/digital/collection/supreme_court/id/7076' }
     let(:collection_url) { 'https://digital.archives.alabama.gov/digital/collection/supreme_court' }

--- a/spec/tasks/cdm_transcript_export_spec.rb
+++ b/spec/tasks/cdm_transcript_export_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+require 'rake'
+
+describe 'fromthepage:cdm_transcript_export' do
+  before(:all) do
+    Rake.application = Rake::Application.new
+    Rails.application.load_tasks
+  end
+
+  let(:owner)      { create(:unique_user, :owner) }
+  let(:collection) { create(:collection, owner_user_id: owner.id, works: []) }
+
+  let(:complete_work) do
+    create(:work, collection: collection).tap do |w|
+      create(:sc_manifest, work: w)
+      w.work_statistic.update!(complete: 100)
+    end
+  end
+
+  let(:incomplete_work) do
+    create(:work, collection: collection).tap do |w|
+      create(:sc_manifest, work: w)
+      w.work_statistic.update!(complete: 50)
+    end
+  end
+
+  before do
+    complete_work
+    incomplete_work
+    allow(ContentdmTranslator).to receive(:export_work_to_cdm_with_retry)
+    allow(SystemMailer).to receive_message_chain(:cdm_sync_finished, :deliver!)
+  end
+
+  def capture_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+  ensure
+    $stdout = original
+  end
+
+  def run_task
+    Rake::Task['fromthepage:cdm_transcript_export'].reenable
+    capture_stdout { Rake::Task['fromthepage:cdm_transcript_export'].invoke(collection.id) }
+  end
+
+  context 'with human_only setting (default)' do
+    before { create(:cdm_export_setting, collection: collection) }
+
+    it 'exports complete works' do
+      run_task
+      expect(ContentdmTranslator).to have_received(:export_work_to_cdm_with_retry).with(complete_work, any_args)
+    end
+
+    it 'skips incomplete works' do
+      run_task
+      expect(ContentdmTranslator).not_to have_received(:export_work_to_cdm_with_retry).with(incomplete_work, any_args)
+    end
+  end
+
+  context 'with human_and_ai setting' do
+    before { create(:cdm_export_setting, :human_and_ai, collection: collection) }
+
+    it 'exports complete works' do
+      run_task
+      expect(ContentdmTranslator).to have_received(:export_work_to_cdm_with_retry).with(complete_work, any_args)
+    end
+
+    it 'also exports incomplete works' do
+      run_task
+      expect(ContentdmTranslator).to have_received(:export_work_to_cdm_with_retry).with(incomplete_work, any_args)
+    end
+  end
+
+  context 'with no cdm_export_setting record' do
+    it 'exports only complete works' do
+      run_task
+      expect(ContentdmTranslator).to have_received(:export_work_to_cdm_with_retry).with(complete_work, any_args)
+      expect(ContentdmTranslator).not_to have_received(:export_work_to_cdm_with_retry).with(incomplete_work, any_args)
+    end
+  end
+end


### PR DESCRIPTION
Adds UI for collection owners to choose between exporting only human-edited transcripts or falling back to AI drafts when no human transcript exists. Includes options for AI provenance metadata and a warning prefix. Populates the full-text search and metadata field dropdowns from the CONTENTdm REST API.