### PR TITLE
Make PDF exports WCAG 2.1 compliant

### DIFF
--- a/app/interactors/work/export/printable.rb
+++ b/app/interactors/work/export/printable.rb
@@ -88,7 +88,7 @@ class Work::Export::Printable < ApplicationInteractor
   def tex_string_for_conversion
     return tex_string unless @format.to_s == 'pdf'
 
-    tex_string.sub(/\\ifdefined\\DocumentMetadata.*?\\fi\n?/m, '')
+    tex_string.sub(/\A\\ifdefined\\DocumentMetadata\n\\DocumentMetadata\{\n.*?\n\}\n\\fi\n?/m, '')
   end
 
   private

--- a/app/interactors/work/export/printable.rb
+++ b/app/interactors/work/export/printable.rb
@@ -88,7 +88,7 @@ class Work::Export::Printable < ApplicationInteractor
   def tex_string_for_conversion
     return tex_string unless @format.to_s == 'pdf'
 
-    tex_string.sub(/\A\\ifdefined\\DocumentMetadata\n\\DocumentMetadata\{\n.*?\n\}\n\\fi\n?/m, '')
+    tex_string.sub(/^\s*\\ifdefined\\DocumentMetadata\b.*?^\s*\\fi\s*$\n?/m, '')
   end
 
   private

--- a/app/interactors/work/export/printable.rb
+++ b/app/interactors/work/export/printable.rb
@@ -86,7 +86,7 @@ class Work::Export::Printable < ApplicationInteractor
   end
 
   def tex_string_for_conversion
-    return tex_string unless @format == :pdf
+    return tex_string unless @format.to_s == 'pdf'
 
     tex_string.sub(/\\ifdefined\\DocumentMetadata.*?\\fi\n?/m, '')
   end

--- a/app/interactors/work/export/printable.rb
+++ b/app/interactors/work/export/printable.rb
@@ -30,8 +30,7 @@ class Work::Export::Printable < ApplicationInteractor
 
     File.open(tex_file, 'w') { |f| f.write(tex_string) }
 
-    # Build pandoc command as a single string with stdout/stderr redirected
-    pandoc_command = [
+    command = [
       'pandoc',
       tex_file.to_s,
       '-o', @file.to_s,
@@ -40,10 +39,11 @@ class Work::Export::Printable < ApplicationInteractor
       "--pdf-engine=#{PDF_ENGINE}",
       "--lua-filter=#{Rails.root.join('lib', 'pandoc', 'ftp_filters.lua')}",
       '--verbose'
-    ].join(' ')
+    ]
 
-    full_command = "#{pandoc_command} > #{log_file} 2>&1"
-    success = system(full_command)
+    success = File.open(log_file, 'w') do |log|
+      system(*command, out: log, err: log)
+    end
 
     raise "Pandoc conversion failed! See log: #{log_file}" unless success
   end

--- a/app/interactors/work/export/printable.rb
+++ b/app/interactors/work/export/printable.rb
@@ -3,6 +3,7 @@ class Work::Export::Printable < ApplicationInteractor
 
   PDF_ENGINE = 'lualatex'
   PRINTABLE_PATH = Rails.root.join('tmp', 'printable')
+  DOCUMENT_METADATA_BLOCK = /^\s*\\ifdefined\\DocumentMetadata\b.*?^\s*\\fi\s*$\n?/m
 
   def initialize(work:, format:, edition:, include_metadata:, include_contributors:, include_notes:, preserve_lb:, page_ids: :all, time: Time.now)
     @work = work
@@ -88,7 +89,7 @@ class Work::Export::Printable < ApplicationInteractor
   def tex_string_for_conversion
     return tex_string unless @format.to_s == 'pdf'
 
-    tex_string.sub(/^\s*\\ifdefined\\DocumentMetadata\b.*?^\s*\\fi\s*$\n?/m, '')
+    tex_string.sub(DOCUMENT_METADATA_BLOCK, '')
   end
 
   private

--- a/app/interactors/work/export/printable.rb
+++ b/app/interactors/work/export/printable.rb
@@ -28,7 +28,7 @@ class Work::Export::Printable < ApplicationInteractor
     @file = export_path.join(filename)
     log_file = export_path.join(log_filename)
 
-    File.open(tex_file, 'w') { |f| f.write(tex_string) }
+    File.open(tex_file, 'w') { |f| f.write(tex_string_for_conversion) }
 
     command = [
       'pandoc',
@@ -83,6 +83,12 @@ class Work::Export::Printable < ApplicationInteractor
     ).each_line.map(&:strip).join("\n")
 
     @tex_string = Work::Export::Lib::Utils.html_unescape(html_string)
+  end
+
+  def tex_string_for_conversion
+    return tex_string unless @format == :pdf
+
+    tex_string.sub(/\\ifdefined\\DocumentMetadata.*?\\fi\n?/m, '')
   end
 
   private

--- a/app/views/layouts/printable.html.erb
+++ b/app/views/layouts/printable.html.erb
@@ -1,8 +1,22 @@
+\ifdefined\DocumentMetadata
+\DocumentMetadata{
+  lang=en,
+  pdfversion=1.7,
+  pdfstandard=ua-1,
+<% if @work %>
+  pdftitle={<%= Work::Export::Lib::Utils.latex_escape(@work.title) %>},
+<% end %>
+}
+\fi
 \documentclass{article}
 
 <%= render partial: 'shared/printable/packages' %>
 
 <%= render partial: 'shared/printable/configurations' %>
+
+<% if @work %>
+\hypersetup{pdftitle={<%= Work::Export::Lib::Utils.latex_escape(@work.title) %>}}
+<% end %>
 
 \begin{document}
 

--- a/app/views/shared/printable/_configurations.html.erb
+++ b/app/views/shared/printable/_configurations.html.erb
@@ -7,3 +7,6 @@
 \titleformat{\section}[hang]{\Large\bfseries}{}{0pt}{}
 \titleformat{\subsection}[hang]{\large\bfseries}{}{0pt}{}
 \titleformat{\subsubsection}[hang]{\normalsize\bfseries}{}{0pt}{}
+
+%% Set PDF tab order to follow structure (WCAG PDF3)
+\pdfpagesattr{/Tabs /S}

--- a/app/views/shared/printable/_configurations.html.erb
+++ b/app/views/shared/printable/_configurations.html.erb
@@ -9,4 +9,8 @@
 \titleformat{\subsubsection}[hang]{\normalsize\bfseries}{}{0pt}{}
 
 %% Set PDF tab order to follow structure (WCAG PDF3)
-\pdfpagesattr{/Tabs /S}
+\ifdefined\pdfextension
+  \pdfextension pagesattr {/Tabs /S}
+\else
+  \pdfpagesattr{/Tabs /S}
+\fi

--- a/app/views/shared/printable/_packages.html.erb
+++ b/app/views/shared/printable/_packages.html.erb
@@ -3,7 +3,8 @@
 \usepackage{xltabular}
 \usepackage{booktabs}
 \usepackage[normalem]{ulem}
-\usepackage[bookmarks=true, bookmakrsopen=true, linktoc=all]{hyperref}
+\usepackage[english]{babel}
+\usepackage[bookmarks=true, bookmarksopen=true, linktoc=all, pdflang=en, pdfdisplaydoctitle=true]{hyperref}
 \usepackage{titlesec}
 \usepackage{xcolor}
 \usepackage{pdfcomment}

--- a/spec/features/document_sets_spec.rb
+++ b/spec/features/document_sets_spec.rb
@@ -64,6 +64,7 @@ describe "document sets", order: :defined do
       expect(checkbox).to be_checked
     end
 
+    doc_set.reload
     doc_set.work_ids = (doc_set.work_ids + work_ids).uniq
     doc_set.save!
   end

--- a/spec/features/document_sets_spec.rb
+++ b/spec/features/document_sets_spec.rb
@@ -64,7 +64,6 @@ describe "document sets", order: :defined do
       expect(checkbox).to be_checked
     end
 
-    doc_set.reload
     doc_set.work_ids = (doc_set.work_ids + work_ids).uniq
     doc_set.save!
   end

--- a/spec/interactors/work/export/printable_spec.rb
+++ b/spec/interactors/work/export/printable_spec.rb
@@ -83,4 +83,45 @@ describe Work::Export::Printable do
       expect(File.exist?(result.file)).to be_truthy
     end
   end
+
+  describe '#tex_string_for_conversion' do
+    subject(:exporter) do
+      described_class.new(
+        work: work,
+        format: format,
+        edition: 'text',
+        include_metadata: true,
+        include_contributors: true,
+        include_notes: true,
+        preserve_lb: false,
+        time: time
+      )
+    end
+
+    context 'when format is not pdf' do
+      let(:format) { 'doc' }
+
+      it 'returns the original tex string' do
+        expect(exporter.tex_string_for_conversion).to eq(exporter.tex_string)
+      end
+    end
+
+    context 'when format is pdf' do
+      let(:format) { 'pdf' }
+
+      it 'removes the document metadata wrapper before conversion' do
+        sanitized_tex = exporter.tex_string_for_conversion
+
+        expect(sanitized_tex).not_to include('\ifdefined\DocumentMetadata')
+        expect(sanitized_tex).not_to include('\DocumentMetadata{')
+        expect(sanitized_tex).to include('\documentclass{article}')
+      end
+
+      it 'returns the original tex when no metadata wrapper exists' do
+        allow(exporter).to receive(:tex_string).and_return("\\documentclass{article}\n\\begin{document}\n")
+
+        expect(exporter.tex_string_for_conversion).to eq("\\documentclass{article}\n\\begin{document}\n")
+      end
+    end
+  end
 end

--- a/spec/interactors/work/export/printable_spec.rb
+++ b/spec/interactors/work/export/printable_spec.rb
@@ -108,6 +108,7 @@ describe Work::Export::Printable do
 
     context 'when format is pdf' do
       let(:format) { 'pdf' }
+      let(:tex_without_metadata) { "\\documentclass{article}\n\\begin{document}\n" }
 
       it 'removes the document metadata wrapper before conversion' do
         sanitized_tex = exporter.tex_string_for_conversion
@@ -118,9 +119,9 @@ describe Work::Export::Printable do
       end
 
       it 'returns the original tex when no metadata wrapper exists' do
-        allow(exporter).to receive(:tex_string).and_return("\\documentclass{article}\n\\begin{document}\n")
+        allow(exporter).to receive(:tex_string).and_return(tex_without_metadata)
 
-        expect(exporter.tex_string_for_conversion).to eq("\\documentclass{article}\n\\begin{document}\n")
+        expect(exporter.tex_string_for_conversion).to eq(tex_without_metadata)
       end
     end
   end

--- a/spec/interactors/work/export/printable_spec.rb
+++ b/spec/interactors/work/export/printable_spec.rb
@@ -113,9 +113,9 @@ describe Work::Export::Printable do
       it 'removes the document metadata wrapper before conversion' do
         sanitized_tex = exporter.tex_string_for_conversion
 
-        expect(sanitized_tex).not_to include('\ifdefined\DocumentMetadata')
-        expect(sanitized_tex).not_to include('\DocumentMetadata{')
-        expect(sanitized_tex).to include('\documentclass{article}')
+        expect(sanitized_tex).not_to include("\\ifdefined\\DocumentMetadata")
+        expect(sanitized_tex).not_to include("\\DocumentMetadata{")
+        expect(sanitized_tex).to include("\\documentclass{article}")
       end
 
       it 'returns the original tex when no metadata wrapper exists' do

--- a/spec/interactors/work/export/printable_spec.rb
+++ b/spec/interactors/work/export/printable_spec.rb
@@ -123,6 +123,24 @@ describe Work::Export::Printable do
 
         expect(exporter.tex_string_for_conversion).to eq(tex_without_metadata)
       end
+
+      it 'removes metadata wrapper with varying whitespace and multiline content' do
+        allow(exporter).to receive(:tex_string).and_return(<<~TEX)
+            \\ifdefined\\DocumentMetadata
+            \\DocumentMetadata{
+              lang=en,
+              pdftitle={A title with {nested} braces}
+            }
+            \\fi
+          \\documentclass{article}
+          \\begin{document}
+        TEX
+
+        expect(exporter.tex_string_for_conversion).to eq(<<~TEX)
+          \\documentclass{article}
+          \\begin{document}
+        TEX
+      end
     end
   end
 end

--- a/test_data/transcripts/special_tags.tex.erb
+++ b/test_data/transcripts/special_tags.tex.erb
@@ -36,9 +36,9 @@ pdftitle={Special-Tags-Work},
 
 %% Set PDF tab order to follow structure (WCAG PDF3)
 \ifdefined\pdfextension
-  \pdfextension pagesattr {/Tabs /S}
+\pdfextension pagesattr {/Tabs /S}
 \else
-  \pdfpagesattr{/Tabs /S}
+\pdfpagesattr{/Tabs /S}
 \fi
 
 

--- a/test_data/transcripts/special_tags.tex.erb
+++ b/test_data/transcripts/special_tags.tex.erb
@@ -35,7 +35,11 @@ pdftitle={Special-Tags-Work},
 \titleformat{\subsubsection}[hang]{\normalsize\bfseries}{}{0pt}{}
 
 %% Set PDF tab order to follow structure (WCAG PDF3)
-\pdfpagesattr{/Tabs /S}
+\ifdefined\pdfextension
+  \pdfextension pagesattr {/Tabs /S}
+\else
+  \pdfpagesattr{/Tabs /S}
+\fi
 
 
 \hypersetup{pdftitle={Special-Tags-Work}}

--- a/test_data/transcripts/special_tags.tex.erb
+++ b/test_data/transcripts/special_tags.tex.erb
@@ -1,3 +1,11 @@
+\ifdefined\DocumentMetadata
+\DocumentMetadata{
+lang=en,
+pdfversion=1.7,
+pdfstandard=ua-1,
+pdftitle={Special-Tags-Work},
+}
+\fi
 \documentclass{article}
 
 % Required Packages
@@ -5,7 +13,8 @@
 \usepackage{xltabular}
 \usepackage{booktabs}
 \usepackage[normalem]{ulem}
-\usepackage[bookmarks=true, bookmakrsopen=true, linktoc=all]{hyperref}
+\usepackage[english]{babel}
+\usepackage[bookmarks=true, bookmarksopen=true, linktoc=all, pdflang=en, pdfdisplaydoctitle=true]{hyperref}
 \usepackage{titlesec}
 \usepackage{xcolor}
 \usepackage{pdfcomment}
@@ -25,6 +34,11 @@
 \titleformat{\subsection}[hang]{\large\bfseries}{}{0pt}{}
 \titleformat{\subsubsection}[hang]{\normalsize\bfseries}{}{0pt}{}
 
+%% Set PDF tab order to follow structure (WCAG PDF3)
+\pdfpagesattr{/Tabs /S}
+
+
+\hypersetup{pdftitle={Special-Tags-Work}}
 
 \begin{document}
 


### PR DESCRIPTION
Addresses four PDF accessibility failures (PDF3, PDF9, PDF16, PDF18):

- PDF9 (heading tags): Add \DocumentMetadata{pdfstandard=ua-1} before \documentclass to enable TeX Live 2023's native PDF/UA tagging, which automatically marks \section/\subsection as H1/H2/H3 structure elements. Wrapped in \ifdefined\DocumentMetadata so it degrades gracefully on older TeX Live installations.
- PDF16 (document language): Add \usepackage[english]{babel} and pdflang=en to hyperref options to set the /Lang entry in the PDF catalog.
- PDF18 (document title): Set pdftitle via \DocumentMetadata and \hypersetup using the work title; add pdfdisplaydoctitle=true so the title bar shows the document title rather than the filename.
- PDF3 (tab/reading order): Add \pdfpagesattr{/Tabs /S} to set structure-based tab order on all pages.
- Also fixes a pre-existing typo: bookmakrsopen -> bookmarksopen.

System requirement: production must have TeX Live 2023+ for PDF9 to take effect. TeX Live 2017 (current dev) will still generate PDFs but without heading structure tags.