### PR TITLE
Revert "5533 - PDF export fails on [unclear]Leun[\unclear] (#5534)"

### DIFF
--- a/app/interactors/work/export/lib/utils.rb
+++ b/app/interactors/work/export/lib/utils.rb
@@ -22,11 +22,6 @@ class Work::Export::Lib::Utils
   # Zero-width and invisible Unicode characters that LaTeX cannot handle
   LATEX_INVISIBLE_CHARS = /[\u{2060}\u{200B}\u{200C}\u{200D}\u{FEFF}]/
 
-  # Manually catch unsupported control_sequence that got through our parser
-  UNSUPPORTED_LATEX_COMMANDS = [
-    'unclear'
-  ]
-
   def self.latex_escape(text)
     return '' if text.blank?
 
@@ -56,29 +51,12 @@ class Work::Export::Lib::Utils
     end
   end
 
-  # NOTE: This is not ideal, but it is a real limitation we have. Our parser
-  # recursively parses, which means we have to let `control_sequence`-like strings
-  # through. Only way to catch these is manually disallowing specific strings.
-  def self.sanitize_unsupported_latex_commands(text)
-    UNSUPPORTED_LATEX_COMMANDS.each do |command|
-      text.gsub!(
-        /\\#{Regexp.escape(command)}\b/,
-        '\\textbackslash{}' + command
-      )
-    end
-
-    text
-  end
-
   def self.xml_to_latex(page:, xml_text:, preserve_lb: true, flatten_links: false)
     doc = REXML::Document.new(xml_text)
     page_doc = doc.root
 
     tex_string = page_doc.elements.map { |element| process_element(page, element, preserve_lb, flatten_links) }.join
     tex_string.sub(/(#{Regexp.escape(LINEBREAK_ELEMENT)}){2}\z/, '')
-    tex_string = sanitize_unsupported_latex_commands(tex_string)
-
-    tex_string
   end
 
   def self.process_element(page, element, preserve_lb, flatten_links)

--- a/spec/interactors/work/export/printable_spec.rb
+++ b/spec/interactors/work/export/printable_spec.rb
@@ -18,6 +18,10 @@ describe Work::Export::Printable do
   end
 
   let!(:page) do
+    create(:page, title: 'Special Tags Page', work: work, source_text: source_text, xml_text: xml_text, search_text: 'Search text',
+      status: :transcribed)
+  end
+  let!(:page) do
     page = create(:page, title: 'Special Tags Page', work: work, search_text: 'Search text', status: :transcribed)
     page.update!(source_text: source_text)
 

--- a/test_data/transcripts/special_tags.tex.erb
+++ b/test_data/transcripts/special_tags.tex.erb
@@ -95,7 +95,7 @@ Col 1 & Col 2 & Col 3 \\
 \\{}
 \sout{\textit{[to be?]}}\\{}
 \\{}
-thither \textsuperscript{\underline{for}}\sout{an many}\textsuperscript{\sout{\textit{[[unclear][\textbackslash{}unclear]]}} many}years\\{}
+thither \textsuperscript{\underline{for}}\sout{an many}\textsuperscript{\sout{\textit{[[unclear]]}} many}years\\{}
 \\{}
 Strike \sout{through} or \sout{s} or \sout{str} for struck through text\\{}
 \\{}
@@ -122,8 +122,6 @@ Catchword \{catchword\} for catchwords\\{}
 \textit{\{page break 1\}}\\{}
 \\{}
 $(\psi_1, \psi_2,  \psi_3) = \vec{\psi}(\vec{x},t) = V^{-1/2}\sum_k \sqrt{\frac{\hbar}{2k}} (\vec{a_k} e^{i \vec{k}\dot\vec{x} - ikt} + c.c.)$
-\\{}
-\\{}
 
 
 \{\{startnewpage\}\}

--- a/test_data/transcripts/special_tags.txt
+++ b/test_data/transcripts/special_tags.txt
@@ -29,7 +29,7 @@ Stamp <stamp>stamp here</stamp> for stamps on envelops
 
 <hi rend="str"><unclear>to be?</unclear></hi>
 
-thither <add>for</add> <hi rend="str">an many</hi> <hi rend="sup"><hi rend="str"><unclear>[unclear][\unclear]</unclear></hi> many</hi>years
+thither <add>for</add> <hi rend="str">an many</hi> <hi rend="sup"><hi rend="str"><unclear>[unclear]</unclear></hi> many</hi>years
 
 Strike <strike>through</strike> or <s>s</s> or <hi rend="str">str</hi> for struck through text
 

--- a/test_data/transcripts/special_tags.xml
+++ b/test_data/transcripts/special_tags.xml
@@ -79,7 +79,7 @@
 		<hi rend='str'>an many</hi>
 		<hi rend='sup'>
 			<hi rend='str'>
-				<unclear>[unclear][\unclear]</unclear>
+				<unclear>[unclear]</unclear>
 			</hi> many
 		</hi>years
 	</p>


### PR DESCRIPTION
This reverts commit 521af12520d4a223ec217fd911d1446a4f010458.