### PR TITLE
5500 error redirecting to assign categories for huge number of subjects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'acts_as_tree'
 gem 'interactor-rails', '~> 2.0'
 gem 'friendly_id'
 gem 'thredded', '~> 1.1'
+gem 'solid_cache'
 gem 'solid_queue', '~> 1.2'
 gem 'mission_control-jobs'
 gem 'aws-sdk-s3', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -808,6 +808,10 @@ GEM
     snaky_hash (2.0.3)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
+    solid_cache (1.0.10)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
+      railties (>= 7.2)
     solid_queue (1.2.4)
       activejob (>= 7.1)
       activerecord (>= 7.1)
@@ -1030,6 +1034,7 @@ DEPENDENCIES
   simplecov-lcov
   slack-notifier
   slim
+  solid_cache
   solid_queue (~> 1.2)
   sprockets (~> 4.2)
   sprockets-rails (>= 3.4)

--- a/app/controllers/transcribe_controller.rb
+++ b/app/controllers/transcribe_controller.rb
@@ -180,8 +180,23 @@ class TranscribeController  < ApplicationController
 
           next_page_id = @page.last? || save_button_clicked ? @page.id : @page.lower_item.id
           flash[:notice] = t('.saved_and_next_notice') if next_page_id != @page.id
+
+          cache_key = [
+            'assign_categories',
+            'save_transcription',
+            current_user.id,
+            @page.id,
+            SecureRandom.hex(8)
+          ].join(':')
+
+          Rails.cache.write(
+            cache_key,
+            old_article_ids,
+            expires_in: 30.minutes
+          )
+
           redirect_to action: 'assign_categories', page_id: @page.id,
-                      collection_id: @collection, next_page_id: next_page_id, old_article_ids: old_article_ids
+                      collection_id: @collection, next_page_id: next_page_id, article_ids_cache_key: cache_key
           return
         end
       else
@@ -229,7 +244,8 @@ class TranscribeController  < ApplicationController
     # no reason to check articles if subjects disabled
     unless @page.collection.subjects_disabled
       @unassigned_articles = []
-      @new_article_ids = @page.articles.where.not(id: params[:old_article_ids]).pluck(:id)
+      old_article_ids = Rails.cache.read(params[:article_ids_cache_key]) || []
+      @new_article_ids = @page.articles.where.not(id: old_article_ids).pluck(:id)
 
       # Separate translationa and transcription links
       left, right = @page.page_article_links.partition { |x| x.text_type == 'translation' }
@@ -321,8 +337,22 @@ class TranscribeController  < ApplicationController
           end
         end
 
+        cache_key = [
+          'assign_categories',
+          'save_translation',
+          current_user.id,
+          @page.id,
+          SecureRandom.hex(8)
+        ].join(':')
+
+        Rails.cache.write(
+          cache_key,
+          old_article_ids,
+          expires_in: 30.minutes
+        )
+
         redirect_to action: 'assign_categories', page_id: @page.id,
-                    collection_id: @collection, text_type: 'translation', old_article_ids: old_article_ids
+                    collection_id: @collection, text_type: 'translation', article_ids_cache_key: cache_key
         return
       else
         log_translation_error(message)

--- a/config/cache.yml
+++ b/config/cache.yml
@@ -1,0 +1,16 @@
+default: &default
+  store_options:
+    # Cap age of oldest cache entry to fulfill retention policies
+    # max_age: <%= 60.days.to_i %>
+    max_size: <%= 256.megabytes %>
+    namespace: <%= Rails.env %>
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  database: cache
+  <<: *default

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
+    config.cache_store = :solid_cache_store
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,7 +57,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :solid_cache_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = "http://assets.example.com"

--- a/db/migrate/20260526185917_add_solid_cache_schema_migration.rb
+++ b/db/migrate/20260526185917_add_solid_cache_schema_migration.rb
@@ -1,0 +1,18 @@
+class AddSolidCacheSchemaMigration < ActiveRecord::Migration[7.2]
+  def up
+    create_table 'solid_cache_entries', force: :cascade do |t|
+      t.binary 'key', limit: 1024, null: false
+      t.binary 'value', limit: 536870912, null: false
+      t.datetime 'created_at', null: false
+      t.integer 'key_hash', limit: 8, null: false
+      t.integer 'byte_size', limit: 4, null: false
+      t.index ['byte_size'], name: 'index_solid_cache_entries_on_byte_size'
+      t.index ['key_hash', 'byte_size'], name: 'index_solid_cache_entries_on_key_hash_and_byte_size'
+      t.index ['key_hash'], name: 'index_solid_cache_entries_on_key_hash', unique: true
+    end
+  end
+
+  def down
+    drop_table 'solid_cache_entries'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_21_000000) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_26_185917) do
   create_table "active_storage_attachments", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -805,6 +805,17 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_21_000000) do
     t.datetime "updated_at", precision: nil
     t.index ["session_id"], name: "index_sessions_on_session_id"
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
+  end
+
+  create_table "solid_cache_entries", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.binary "key", limit: 1024, null: false
+    t.binary "value", size: :long, null: false
+    t.datetime "created_at", null: false
+    t.bigint "key_hash", null: false
+    t.integer "byte_size", null: false
+    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
+    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
   end
 
   create_table "solid_queue_blocked_executions", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|


### PR DESCRIPTION
The initial idea is to use `session` to store the article_ids. But I think this is going to be flaky and unreliable, since there is still a 4kb limit to what we can store in a session key.

I added support for solid_cache, a db-backed caching. I know we are having storage issues recently but this should not take much, especially since we can also add `expiration` to what we cache.

So far this will only be explicitly used for assign_categories. We should be fine, I added 30m expiration to each key.

@benwbrum @saracarl 

Specific test cases to cover these will follow, preferably here https://github.com/benwbrum/fromthepage/pull/4978 after I catch it up to this PR.