### PR TITLE
Add rake task to delete legacy page images migrated to ActiveStorage

### DIFF
--- a/lib/tasks/active_storage_migration.rake
+++ b/lib/tasks/active_storage_migration.rake
@@ -137,9 +137,9 @@ namespace :fromthepage do
 
     pages = if collection
               collection.pages
-            else
+    else
               Page.joins(:work).where(works: { owner_user_id: user.id })
-            end
+    end
     pages = pages.where.not(base_image: [nil, ''])
 
     deleted_files = 0

--- a/lib/tasks/active_storage_migration.rake
+++ b/lib/tasks/active_storage_migration.rake
@@ -166,7 +166,6 @@ namespace :fromthepage do
 
         deleted_files += 1
         deleted_bytes += bytes
-        puts "Deleted #{path}"
       end
     end
 

--- a/lib/tasks/active_storage_migration.rake
+++ b/lib/tasks/active_storage_migration.rake
@@ -116,3 +116,63 @@ namespace :fromthepage do
     )
   end
 end
+
+namespace :fromthepage do
+  desc 'Delete legacy page images migrated to ActiveStorage for a user or collection slug'
+  task :delete_migrated_page_images, [:slug] => :environment do |_task, args|
+    require 'open3'
+
+    slug = args[:slug]
+    abort 'Usage: rake fromthepage:delete_migrated_page_images[slug]' if slug.blank?
+
+    user = User.find_by(slug: slug)
+    collection = Collection.find_by(slug: slug)
+
+    if user && collection
+      abort "Both a user and collection have the slug #{slug.inspect}; no files were deleted."
+    end
+
+    owner = collection || user
+    abort "No user or collection found with slug #{slug.inspect}." unless owner
+
+    pages = if collection
+              collection.pages
+            else
+              Page.joins(:work).where(works: { owner_user_id: user.id })
+            end
+    pages = pages.where.not(base_image: [nil, ''])
+
+    deleted_files = 0
+    deleted_bytes = 0
+
+    pages.find_each do |page|
+      next unless page.image.attached?
+
+      legacy_path = Rails.root.join(
+        'public',
+        page.base_image.sub(%r{\A.*public/?}, '')
+      )
+      extension = File.extname(legacy_path)
+      thumbnail_path = legacy_path.sub(/#{Regexp.escape(extension)}\z/, "_thumb#{extension}")
+
+      [legacy_path, thumbnail_path].each do |path|
+        next unless File.file?(path) || File.symlink?(path)
+
+        output, status = Open3.capture2e('du', '-b', '--', path.to_s)
+        abort "Could not read the size of #{path}: #{output}" unless status.success?
+
+        bytes = output.split.first.to_i
+        abort "Could not delete #{path}." unless system('rm', '--', path.to_s)
+
+        deleted_files += 1
+        deleted_bytes += bytes
+        puts "Deleted #{path}"
+      end
+    end
+
+    deleted_mebibytes = deleted_bytes.fdiv(1024 * 1024)
+    puts format('Deleted %<files>d files and freed %<mib>.2f MiB.',
+                files: deleted_files,
+                mib: deleted_mebibytes)
+  end
+end


### PR DESCRIPTION
### Motivation
- Provide a safe, one-off maintenance task to remove legacy page image files that were migrated to ActiveStorage to reclaim disk space.
- Allow targeting by a user or collection slug and avoid accidental deletion when a slug matches both a user and a collection.

### Description
- Added a new rake task `fromthepage:delete_migrated_page_images[slug]` that locates pages for a collection or a user's works and skips pages without a `base_image` or without an attached ActiveStorage `image`.
- For each page it computes the legacy image path and a corresponding `_thumb` path, checks that each path is a file or symlink, measures the file size with `du -b`, removes the file with `rm`, and accumulates deleted file and byte counts.
- Performs safety checks and aborts with clear messages if the slug is missing, ambiguous (both user and collection), not found, if size cannot be read, or if removal fails.
- Prints per-file deletion messages and a final summary showing the number of files deleted and MiB freed.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c8865dce08322b98ee92e9b560e24)