### PR TITLE
Revert local image URL to !7900,7900 constraint; log image URL in Gen…

### DIFF
--- a/app/interactors/ai_transcription/generate.rb
+++ b/app/interactors/ai_transcription/generate.rb
@@ -69,6 +69,8 @@ class AiTranscription::Generate < ApplicationInteractor
 
     raise ArgumentError, 'Page has no image to transcribe' if @image_url.blank?
 
+    Rails.logger.info("AiTranscription::Generate image URL for page #{@page.id}: #{@image_url}")
+
     @image_url
   end
 


### PR DESCRIPTION
…erate

Add Rails.logger.info in Generate so the image URL passed to the AI handler is visible in logs for debugging.