### PR TITLE
CI: shard RSpec across matrix and enable parallel Coveralls reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,19 +90,24 @@ jobs:
 
       - name: Run tests
         run: |
-          mapfile -t SPEC_FILES < <(find spec -name '*_spec.rb' | sort)
-          SHARD_FILES=()
+          SPEC_FILES=$(mktemp)
+          SHARD_FILES=$(mktemp)
 
-          for i in "${!SPEC_FILES[@]}"; do
-            if [ $((i % SPEC_SHARD_COUNT)) -eq "$SPEC_SHARD_INDEX" ]; then
-              SHARD_FILES+=("${SPEC_FILES[$i]}")
-            fi
-          done
+          find spec -name '*_spec.rb' | sort > "$SPEC_FILES"
+          awk -v shard="$SPEC_SHARD_INDEX" -v count="$SPEC_SHARD_COUNT" '((NR - 1) % count) == shard { print }' "$SPEC_FILES" > "$SHARD_FILES"
 
-          printf 'Running %d of %d spec files on shard %d/%d:\n' "${#SHARD_FILES[@]}" "${#SPEC_FILES[@]}" "$((SPEC_SHARD_INDEX + 1))" "$SPEC_SHARD_COUNT"
-          printf '  %s\n' "${SHARD_FILES[@]}"
+          SPEC_FILE_COUNT=$(wc -l < "$SPEC_FILES" | tr -d ' ')
+          SHARD_FILE_COUNT=$(wc -l < "$SHARD_FILES" | tr -d ' ')
 
-          xvfb-run -a bundle exec rspec "${SHARD_FILES[@]}"
+          printf 'Running %d of %d spec files on shard %d/%d:\n' "$SHARD_FILE_COUNT" "$SPEC_FILE_COUNT" "$((SPEC_SHARD_INDEX + 1))" "$SPEC_SHARD_COUNT"
+          sed 's/^/  /' "$SHARD_FILES"
+
+          if [ "$SHARD_FILE_COUNT" -eq 0 ]; then
+            echo 'No spec files were assigned to this shard.'
+            exit 1
+          fi
+
+          xargs xvfb-run -a bundle exec rspec < "$SHARD_FILES"
         env:
           COVERAGE: true
           CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard_index: [0, 1, 2, 3]
+        shard_count: [4]
     container:
       image: ghcr.io/willnigel23/ftp-ci:latest
 
@@ -44,8 +49,10 @@ jobs:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_HOST: mysql
       ELASTIC_HOST_URL: http://elasticsearch:9200
-      ELASTIC_SUFFIX: ci
+      ELASTIC_SUFFIX: ci_${{ matrix.shard_index }}
       GEMINI_API_KEY: redacted
+      SPEC_SHARD_INDEX: ${{ matrix.shard_index }}
+      SPEC_SHARD_COUNT: ${{ matrix.shard_count }}
 
     steps:
       - name: Checkout code
@@ -82,7 +89,20 @@ jobs:
           ELASTIC_ENABLED: true
 
       - name: Run tests
-        run: xvfb-run -a bundle exec rspec spec
+        run: |
+          mapfile -t SPEC_FILES < <(find spec -name '*_spec.rb' | sort)
+          SHARD_FILES=()
+
+          for i in "${!SPEC_FILES[@]}"; do
+            if [ $((i % SPEC_SHARD_COUNT)) -eq "$SPEC_SHARD_INDEX" ]; then
+              SHARD_FILES+=("${SPEC_FILES[$i]}")
+            fi
+          done
+
+          printf 'Running %d of %d spec files on shard %d/%d:\n' "${#SHARD_FILES[@]}" "${#SPEC_FILES[@]}" "$((SPEC_SHARD_INDEX + 1))" "$SPEC_SHARD_COUNT"
+          printf '  %s\n' "${SHARD_FILES[@]}"
+
+          xvfb-run -a bundle exec rspec "${SHARD_FILES[@]}"
         env:
           COVERAGE: true
           CI: true
@@ -94,6 +114,19 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: "./coverage/lcov.info"
+          parallel: true
+          flag-name: rspec-${{ matrix.shard_index }}
+
+  coveralls_finish:
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ (github.event_name == 'pull_request' && github.ref != 'refs/heads/development') || (github.event_name == 'push' && github.ref == 'refs/heads/development') }}
+    steps:
+      - name: Finish Coveralls parallel build
+        uses: coverallsapp/github-action@v2.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
 
   rubocop:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation

- Reduce CI runtime and make test execution parallel by sharding `rspec` across multiple matrix jobs. 
- Ensure coverage is reported from parallel jobs and aggregated correctly by Coveralls. 

### Description

- Add a job matrix with `shard_index` and `shard_count` and set `strategy.fail-fast: false` to run multiple test shards in parallel. 
- Expose `SPEC_SHARD_INDEX` and `SPEC_SHARD_COUNT` env vars and include the shard index in `ELASTIC_SUFFIX` via `ELASTIC_SUFFIX: ci_${{ matrix.shard_index }}`. 
- Replace the single `Run tests` command with a shell script that collects all `*_spec.rb` files, selects the subset for the current shard using modulo arithmetic, prints the shard summary, and runs `xvfb-run -a bundle exec rspec` on the shard's files. 
- Configure the Coveralls action for parallel uploads via `parallel: true` and `flag-name: rspec-${{ matrix.shard_index }}`, and add a `coveralls_finish` job that runs the Coveralls action with `parallel-finished: true` to finalize aggregation. 

### Testing

- No automated tests were executed as part of this configuration-only change to the CI workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35bd7405f48322b666bf0b58ae4cd9)