### PR TITLE
Tighten Ahoy activity grouping to 11 minutes, remove save-padding, and expose `sendActiveEditing` to window

### DIFF
--- a/app/views/transcribe/translate.html.slim
+++ b/app/views/transcribe/translate.html.slim
@@ -115,6 +115,8 @@ h2.legend =t('.page_notes')
       }
     }
 
+    window.sendActiveEditing = sendActiveEditing;
+
     var lang = "#{@collection.language}";
     var fromImage = JSON.parse("#{@fromImage}") || false;
     function updateTranscriptionOrImageDisplay(){

--- a/lib/ahoy_activity_utils.rb
+++ b/lib/ahoy_activity_utils.rb
@@ -70,7 +70,7 @@ module AhoyActivityUtils
                 .delete_all
   end
 
-  def self.total_contiguous_seconds(times_and_names, tolerance = 90.minutes)
+  def self.total_contiguous_seconds(times_and_names, tolerance = 11.minutes)
     total_seconds = 0
     from_time = nil
 
@@ -81,18 +81,6 @@ module AhoyActivityUtils
       time_diff = from_time.nil? ? 0 : (time - from_time).round
       if time_diff < tolerance && time_diff > 0
         total_seconds += time_diff
-      else
-        # if less than tolerance and there's a discontinuity
-        # is the first event a save
-        # use save transcription or assign categories for indicating a save since they happen at the same event time
-        events = grouped_events[time]
-        names = events.map { |e| e[1] }
-        if names.include?('transcribe#assign_categories') || names.include?('transcribe#save_transcription')
-          # if the first event was a save, they were transcribing and we need to pad
-          # just pad by adding 20 minutes
-          # in the future we may want to pad based on project type text: 20 minutes, spreadsheet: 90 minutes, field: 5 minutes
-          total_seconds += 20*60
-        end
       end
       from_time = time
     end

--- a/spec/models/ahoy_activity_utils_spec.rb
+++ b/spec/models/ahoy_activity_utils_spec.rb
@@ -34,9 +34,18 @@ RSpec.describe AhoyActivityUtils do
         expect(duration_c).to eq(10.minutes)
     end
 
-    it "skips times greater than 90 minutes apart by default" do
+    it "counts times less than 11 minutes apart by default" do
         after   = 10.minutes.ago
-        before  = 100.minutes.ago
+        before  = 20.minutes.ago
+
+        duration = AhoyActivityUtils.total_contiguous_seconds([[before, 'dummy'], [after, 'dummy']])
+
+        expect(duration).to eq(10.minutes)
+    end
+
+    it "skips times greater than 11 minutes apart by default" do
+        after   = 10.minutes.ago
+        before  = 22.minutes.ago
 
         duration = AhoyActivityUtils.total_contiguous_seconds([[before, 'dummy'], [after, 'dummy']])
 
@@ -53,18 +62,30 @@ RSpec.describe AhoyActivityUtils do
     end
 
     it "sums contiguous elements, skips non-contiguous gaps" do
-        times = [[1.day.ago, 'dummy'], [(1.day.ago + 30.minutes), 'dummy'], [60.minutes.ago, 'dummy'], [30.minutes.ago, 'dummy']]
+        times = [[1.day.ago, 'dummy'], [(1.day.ago + 10.minutes), 'dummy'], [60.minutes.ago, 'dummy'], [50.minutes.ago, 'dummy']]
 
         duration = AhoyActivityUtils.total_contiguous_seconds(times)
 
-        expect(duration).to eq(60.minutes)
+        expect(duration).to eq(20.minutes)
     end
     it "sums shuffled timestamps correctly" do
-        times = [[1.day.ago, 'dummy'], [(1.day.ago + 30.minutes), 'dummy'], [60.minutes.ago, 'dummy'], [30.minutes.ago, 'dummy']].shuffle
+        times = [[1.day.ago, 'dummy'], [(1.day.ago + 10.minutes), 'dummy'], [60.minutes.ago, 'dummy'], [50.minutes.ago, 'dummy']].shuffle
 
         duration = AhoyActivityUtils.total_contiguous_seconds(times)
 
-        expect(duration).to eq(60.minutes)
+        expect(duration).to eq(20.minutes)
+    end
+
+    it "does not pad isolated save events" do
+        duration = AhoyActivityUtils.total_contiguous_seconds([[10.minutes.ago, 'transcribe#save_transcription']])
+
+        expect(duration).to eq(0)
+    end
+
+    it "does not pad isolated category assignment events" do
+        duration = AhoyActivityUtils.total_contiguous_seconds([[10.minutes.ago, 'transcribe#assign_categories']])
+
+        expect(duration).to eq(0)
     end
   end
 end


### PR DESCRIPTION
### Motivation

- Reduce the contiguous-activity grouping window so short gaps aren't treated as continuous editing sessions.  
- Stop artificially padding activity when the first event at a discontinuity is a save or category assignment.  
- Make the `sendActiveEditing` helper available on the global `window` so other scripts can invoke it.

### Description

- Change `AhoyActivityUtils.total_contiguous_seconds` default `tolerance` from `90.minutes` to `11.minutes`.  
- Remove code that added a 20-minute padding when the first event in a new time bucket was `transcribe#assign_categories` or `transcribe#save_transcription`.  
- Update and add specs in `spec/models/ahoy_activity_utils_spec.rb` to reflect the new 11-minute tolerance and the removed padding behavior, including tests that isolated save/assign events do not produce padding.  
- Expose the client-side function by assigning `window.sendActiveEditing = sendActiveEditing` in `app/views/transcribe/translate.html.slim`.

### Testing

- Ran model specs with `bundle exec rspec spec/models/ahoy_activity_utils_spec.rb`, and the updated examples passed.  
- The modified spec assertions now validate contiguous counting with an 11-minute tolerance and confirm no padding for isolated save/category events, and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3691504d808322aa245ea09debf780)