### PR TITLE
Remove riiif dependency: fetch images directly, resize only for Claude

### DIFF
--- a/app/interactors/ai_transcription/generate.rb
+++ b/app/interactors/ai_transcription/generate.rb
@@ -72,22 +72,23 @@ class AiTranscription::Generate < ApplicationInteractor
 
   def image_url
     return @image_url if defined?(@image_url)
-
     @image_url = @page.image_url_for_ai
+  end
 
-    raise ArgumentError, 'Page has no image to transcribe' if @image_url.blank?
-
-    Rails.logger.info("AiTranscription::Generate image URL for page #{@page.id}: #{@image_url}")
-
-    @image_url
+  def local_image_path
+    @local_image_path ||= @page.local_image_path
   end
 
   def transcribe_handler
+    raise ArgumentError, 'Page has no image to transcribe' if image_url.blank? && local_image_path.blank?
+
+    Rails.logger.info("AiTranscription::Generate image URL for page #{@page.id}: #{image_url || local_image_path}")
+
     @transcribe_handler ||= handler_class.new(
       model: @ai_transcription.model,
       prompt: @ai_transcription.prompt,
       image_url: image_url,
-      image_path: @page.local_image_path
+      image_path: local_image_path
     )
   end
 

--- a/app/interactors/ai_transcription/lib/gemini/transcribe_handler.rb
+++ b/app/interactors/ai_transcription/lib/gemini/transcribe_handler.rb
@@ -85,7 +85,7 @@ class AiTranscription::Lib::Gemini::TranscribeHandler < AiTranscription::Lib::Ba
           {
             inline_data: {
               mime_type: 'image/jpeg',
-              data: fetch_and_encode_image(url: @image_url)
+              data: encoded_image
             }
           }
         ]
@@ -103,6 +103,15 @@ class AiTranscription::Lib::Gemini::TranscribeHandler < AiTranscription::Lib::Ba
     end
 
     @payload
+  end
+
+  def encoded_image
+    return @encoded_image if defined?(@encoded_image)
+    @encoded_image = if @image_path
+      Base64.strict_encode64(File.binread(@image_path))
+    else
+      fetch_and_encode_image(url: @image_url)
+    end
   end
 
   def extract_texts_from_response(response)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -653,7 +653,7 @@ class Page < ApplicationRecord
       "https://iiif.archive.org/iiif/#{work.ia_work.book_id}$#{ia_leaf.leaf_number}/full/#{size}/0/default.jpg"
     elsif image.attached?
       Rails.application.routes.url_helpers.url_for(image)
-    # CarrierWave local files: return nil — callers use local_image_path for disk read
+      # CarrierWave local files: return nil — callers use local_image_path for disk read
     end
   end
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -651,11 +651,9 @@ class Page < ApplicationRecord
       end
     elsif ia_leaf
       "https://iiif.archive.org/iiif/#{work.ia_work.book_id}$#{ia_leaf.leaf_number}/full/#{size}/0/default.jpg"
-    elsif canonical_facsimile_url.present?
-      raw_host = Rails.application.config.action_mailer.default_url_options[:host]
-      host, port = raw_host.split(':', 2)
-      base = port ? "http://#{host}:#{port}" : "https://#{host}"
-      "#{base}/image-service/#{id}/full/#{size}/0/default.jpg"
+    elsif image.attached?
+      Rails.application.routes.url_helpers.url_for(image)
+    # CarrierWave local files: return nil — callers use local_image_path for disk read
     end
   end
 

--- a/spec/interactors/ai_transcription/generate_spec.rb
+++ b/spec/interactors/ai_transcription/generate_spec.rb
@@ -242,6 +242,7 @@ describe AiTranscription::Generate do
     before do
       allow(ai_transcription).to receive(:page).and_return(page)
       allow(page).to receive(:image_url_for_ai).and_return(nil)
+      allow(page).to receive(:local_image_path).and_return(nil)
     end
 
     it 'fails to generate transcription' do


### PR DESCRIPTION
image_url_for_ai no longer routes local images through the riiif IIIF server (/image-service/...). Active Storage images return a direct AS URL; CarrierWave local files return nil so callers use local_image_path for disk reads.

Gemini handler now reads CarrierWave files from disk via @image_path (raw bytes, no resizing — Gemini has no dimension limits). Claude handler already uses the same disk-read path with RMagick resize.