### PR TITLE
Redirect Riiif image-service root requests to IIIF info endpoint and add spec

### DIFF
--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -4,3 +4,15 @@ require 'iiif/from_the_page_file_resolver'
 ActiveSupport::Reloader.to_prepare do
   Riiif::Image.file_resolver = Riiif::FromThePageFileResolver.new
 end
+
+module RiiifImagesControllerRedirectPatch
+  def redirect
+    redirect_to "/image-service/#{ERB::Util.url_encode(params[:id].to_s)}/info.json"
+  end
+end
+
+ActiveSupport::Reloader.to_prepare do
+  next if Riiif::ImagesController < RiiifImagesControllerRedirectPatch
+
+  Riiif::ImagesController.prepend(RiiifImagesControllerRedirectPatch)
+end

--- a/spec/requests/riiif_redirect_spec.rb
+++ b/spec/requests/riiif_redirect_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe 'Riiif image service redirects' do
+  it 'redirects bare image service requests to the IIIF info endpoint' do
+    get '/image-service/32407848'
+
+    expect(response).to redirect_to('/image-service/32407848/info.json')
+  end
+end


### PR DESCRIPTION
### Motivation
- Ensure bare image service requests (e.g. `/image-service/:id`) are forwarded to the IIIF `info.json` endpoint for compatibility with consumers.
- Apply the redirect at the controller layer so the existing Riiif service routes resolve to the canonical IIIF info URL.

### Description
- Added a patch module `RiiifImagesControllerRedirectPatch` that implements `redirect` to `redirect_to "/image-service/#{ERB::Util.url_encode(params[:id].to_s)}/info.json"`.
- Prepend the patch into `Riiif::ImagesController` inside `ActiveSupport::Reloader.to_prepare` with a guard `next if Riiif::ImagesController < RiiifImagesControllerRedirectPatch` to avoid double-prepending.
- The initializer continues to require the custom file resolver and set `Riiif::Image.file_resolver = Riiif::FromThePageFileResolver.new` on reloads.
- Added a request spec at `spec/requests/riiif_redirect_spec.rb` that asserts a GET to `/image-service/32407848` redirects to `/image-service/32407848/info.json`.

### Testing
- Added and ran the new request spec `spec/requests/riiif_redirect_spec.rb` using `bundle exec rspec spec/requests/riiif_redirect_spec.rb`. The test passed.
- No other automated tests were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bf3f85a108322af19471b1e9621c9)