### PR TITLE
Cache landing page counts to reduce DB queries

### DIFF
--- a/app/views/static/landing_page.html.erb
+++ b/app/views/static/landing_page.html.erb
@@ -333,7 +333,9 @@
                 <div class="col-lg-3 col-md-6 col-6">
                     <div class="item" data-aos="zoom-in" data-aos-duration="800">
                         <h4>Transcribers</h4>
-                        <p><%= Deed.where(created_at: (1.year.ago)..).select(:user_id).distinct.count %></p>
+                        <% cache('landing_page/transcribers_count', expires_in: 1.day) do %>
+                            <p><%= Deed.where(created_at: (1.year.ago)..).select(:user_id).distinct.count %></p>
+                        <% end %>
                     </div>
                 </div>
 
@@ -347,7 +349,9 @@
                 <div class="col-lg-3 col-md-6 col-6">
                     <div class="item" data-aos="zoom-in" data-aos-duration="1000">
                         <h4>Pages Transcribed</h4>
-                        <p><%= number_with_delimiter Page.where.not(status: :new).count %></p>
+                        <% cache('landing_page/pages_transcribed_count', expires_in: 10.minutes) do %>
+                            <p><%= number_with_delimiter Page.where.not(status: :new).count %></p>
+                        <% end %>
                     </div>
                 </div>
 


### PR DESCRIPTION
### Motivation
- Reduce database load and page render latency on the landing page by caching frequently-read aggregate counts.

### Description
- Wrap the transcribers count query (`Deed.where(...).select(:user_id).distinct.count`) in a view cache `cache('landing_page/transcribers_count', expires_in: 1.day)` and the pages transcribed count (`Page.where.not(status: :new).count`) in `cache('landing_page/pages_transcribed_count', expires_in: 10.minutes)`.

### Testing
- Ran the Rails test suite with `bundle exec rspec` and all specs passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d78d094ec83228a65056a87ab50fc)