### PR TITLE
Optimize AI transcription counts and add index on ai_transcriptions (page_id, id)

### DIFF
--- a/app/controllers/collection/ai_transcriptions_controller.rb
+++ b/app/controllers/collection/ai_transcriptions_controller.rb
@@ -44,28 +44,40 @@ class Collection::AiTranscriptionsController < CollectionController
   private
 
   def calculate_counts
+    collection_pages = Page
+      .joins(:work)
+      .where(works: { collection_id: @collection.id })
+      .reorder(nil)
+
     latest_per_page = AiTranscription
-      .where(page_id: @collection.pages.select(:id))
+      .where(page_id: collection_pages.select(:id))
       .select('MAX(id) AS id')
       .group(:page_id)
 
     latest_ai_transcriptions = AiTranscription
       .joins("INNER JOIN (#{latest_per_page.to_sql}) latest ON latest.id = ai_transcriptions.id")
 
-    ai_transcriptions_count = latest_ai_transcriptions
-      .group(:status)
-      .count
+    ai_transcriptions_count, new_transcriptions_count, queued_transcriptions_count,
+      processing_transcriptions_count, finished_transcriptions_count, failed_transcriptions_count =
+      latest_ai_transcriptions.pick(
+        Arel.sql('COUNT(*)'),
+        Arel.sql("SUM(CASE WHEN ai_transcriptions.status = 'new' THEN 1 ELSE 0 END)"),
+        Arel.sql("SUM(CASE WHEN ai_transcriptions.status = 'queued' THEN 1 ELSE 0 END)"),
+        Arel.sql("SUM(CASE WHEN ai_transcriptions.status = 'processing' THEN 1 ELSE 0 END)"),
+        Arel.sql("SUM(CASE WHEN ai_transcriptions.status = 'finished' THEN 1 ELSE 0 END)"),
+        Arel.sql("SUM(CASE WHEN ai_transcriptions.status = 'error' THEN 1 ELSE 0 END)")
+      )
 
     @works_count = @collection.works.count
-    @pages_count = @collection.pages.count
-    @ai_transcriptions_count = latest_per_page.to_a.size
+    @pages_count = collection_pages.count
+    @ai_transcriptions_count = ai_transcriptions_count.to_i
     @queued_transcriptions_count =
-      ai_transcriptions_count['new'].to_i +
-      ai_transcriptions_count['queued'].to_i +
-      ai_transcriptions_count['processing'].to_i
+      new_transcriptions_count.to_i +
+      queued_transcriptions_count.to_i +
+      processing_transcriptions_count.to_i
 
-    @finished_transcriptions_count = ai_transcriptions_count['finished'].to_i
-    @failed_transcriptions_count = ai_transcriptions_count['error'].to_i
+    @finished_transcriptions_count = finished_transcriptions_count.to_i
+    @failed_transcriptions_count = failed_transcriptions_count.to_i
     @not_started_transcriptions_count = @pages_count - @ai_transcriptions_count
 
     @failed_ai_transcriptions = latest_ai_transcriptions

--- a/app/controllers/work/ai_transcriptions_controller.rb
+++ b/app/controllers/work/ai_transcriptions_controller.rb
@@ -47,27 +47,36 @@ class Work::AiTranscriptionsController < WorkController
   private
 
   def calculate_counts
+    work_pages = @work.pages.reorder(nil)
+
     latest_per_page = AiTranscription
-      .where(page_id: @work.pages.select(:id))
+      .where(page_id: work_pages.select(:id))
       .select('MAX(id) AS id')
       .group(:page_id)
 
     latest_ai_transcriptions = AiTranscription
       .joins("INNER JOIN (#{latest_per_page.to_sql}) latest ON latest.id = ai_transcriptions.id")
 
-    ai_transcriptions_count = latest_ai_transcriptions
-      .group(:status)
-      .count
+    ai_transcriptions_count, new_transcriptions_count, queued_transcriptions_count,
+      processing_transcriptions_count, finished_transcriptions_count, failed_transcriptions_count =
+      latest_ai_transcriptions.pick(
+        Arel.sql('COUNT(*)'),
+        Arel.sql("SUM(CASE WHEN ai_transcriptions.status = 'new' THEN 1 ELSE 0 END)"),
+        Arel.sql("SUM(CASE WHEN ai_transcriptions.status = 'queued' THEN 1 ELSE 0 END)"),
+        Arel.sql("SUM(CASE WHEN ai_transcriptions.status = 'processing' THEN 1 ELSE 0 END)"),
+        Arel.sql("SUM(CASE WHEN ai_transcriptions.status = 'finished' THEN 1 ELSE 0 END)"),
+        Arel.sql("SUM(CASE WHEN ai_transcriptions.status = 'error' THEN 1 ELSE 0 END)")
+      )
 
-    @pages_count = @work.pages.count
-    @ai_transcriptions_count = latest_per_page.to_a.size
+    @pages_count = work_pages.count
+    @ai_transcriptions_count = ai_transcriptions_count.to_i
     @queued_transcriptions_count =
-      ai_transcriptions_count['new'].to_i +
-      ai_transcriptions_count['queued'].to_i +
-      ai_transcriptions_count['processing'].to_i
+      new_transcriptions_count.to_i +
+      queued_transcriptions_count.to_i +
+      processing_transcriptions_count.to_i
 
-    @finished_transcriptions_count = ai_transcriptions_count['finished'].to_i
-    @failed_transcriptions_count = ai_transcriptions_count['error'].to_i
+    @finished_transcriptions_count = finished_transcriptions_count.to_i
+    @failed_transcriptions_count = failed_transcriptions_count.to_i
     @not_started_transcriptions_count = @pages_count - @ai_transcriptions_count
 
     @failed_ai_transcriptions = latest_ai_transcriptions

--- a/db/migrate/20260626000000_add_page_id_and_id_index_to_ai_transcriptions.rb
+++ b/db/migrate/20260626000000_add_page_id_and_id_index_to_ai_transcriptions.rb
@@ -1,0 +1,5 @@
+class AddPageIdAndIdIndexToAiTranscriptions < ActiveRecord::Migration[7.2]
+  def change
+    add_index :ai_transcriptions, [:page_id, :id], name: 'index_ai_transcriptions_on_page_id_and_id'
+  end
+end


### PR DESCRIPTION
### Motivation
- Reduce expensive queries and memory usage when calculating latest AI transcription counts for collections and works.
- Ensure the page-based MAX(id) lookup can use an index and avoid ordering that prevents index usage.
- Provide a database index to support the MAX(id) per `page_id` pattern used to select latest transcriptions.

### Description
- Replaced page selection and default ordering with `reorder(nil)` and explicit `Page` relation variables (`collection_pages` and `work_pages`) to avoid implicit ordering and enable index usage.
- Rewrote the status counting logic to fetch overall and per-status counts in a single query using `pick` with `Arel.sql` and `SUM(CASE WHEN ...)` expressions instead of `group(...).count`, and set numeric counters from the returned values.
- Kept the existing `latest_per_page` subquery (MAX(id) per `page_id`) but adjusted callers to use the new page relations and renamed variables for clarity.
- Added a migration `AddPageIdAndIdIndexToAiTranscriptions` to add an index on `[:page_id, :id]` to support the MAX(id) lookup and improve query performance.

### Testing
- Ran the Rails test suite with `bundle exec rails test`, and the test suite passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d78d094ec83228a65056a87ab50fc)