### PR TITLE
Allow AI transcription tasks to run per engine

### DIFF
--- a/app/interactors/ai_transcription/create.rb
+++ b/app/interactors/ai_transcription/create.rb
@@ -54,7 +54,7 @@ class AiTranscription::Create < ApplicationInteractor
   end
 
   def find_or_generate_ai_transcription
-    ai_transcription = @page.ai_transcription
+    ai_transcription = latest_ai_transcription_for_model_engine
 
     if ai_transcription.nil? || ((ai_transcription.status_finished? || ai_transcription.status_processing?) && @retranscribe)
       return AiTranscription.create!(
@@ -74,5 +74,13 @@ class AiTranscription::Create < ApplicationInteractor
     end
 
     raise StandardError, 'AI Transcription generation is either in progress or completed!'
+  end
+
+  def latest_ai_transcription_for_model_engine
+    engine = AiTranscription.engine_for_model(@sanitized_model)
+
+    @page.ai_transcriptions
+         .order(created_at: :desc)
+         .detect { |ai_transcription| ai_transcription.engine == engine }
   end
 end

--- a/app/models/ai_transcription.rb
+++ b/app/models/ai_transcription.rb
@@ -71,6 +71,14 @@ class AiTranscription < ApplicationRecord
     model != ALTO_MODEL
   end
 
+  def engine
+    self.class.engine_for_model(model)
+  end
+
+  def self.engine_for_model(model)
+    model.to_s.start_with?('claude') ? 'claude' : 'gemini'
+  end
+
   def error_message
     return if metadata.blank? || !metadata.is_a?(Hash)
 

--- a/spec/interactors/ai_transcription/create_spec.rb
+++ b/spec/interactors/ai_transcription/create_spec.rb
@@ -179,6 +179,41 @@ describe AiTranscription::Create do
         end
       end
     end
+
+    context 'when latest finished ai_transcription is from another engine' do
+      let(:model) { 'claude-sonnet-4-6' }
+      let!(:ai_transcription) do
+        create(:ai_transcription, page_id: page.id, model: 'gemini-3-pro-preview', source_text: nil, status: :finished)
+      end
+
+      it 'creates a new processing ai_transcription record without retranscribe mode' do
+        expect(result.success?).to be_truthy
+        expect(result.ai_transcription).to have_attributes(
+          page_id: page.id,
+          model: model,
+          prompt: prompt,
+          status: 'processing'
+        )
+        expect(result.ai_transcription.id).not_to eq(ai_transcription.id)
+      end
+    end
+
+    context 'when an older finished ai_transcription is from the same engine' do
+      let(:model) { 'claude-sonnet-4-6' }
+      let!(:same_engine_ai_transcription) do
+        create(:ai_transcription, page_id: page.id, model: 'claude-opus-4-6',
+                                  source_text: nil, status: :finished, created_at: 2.days.ago)
+      end
+      let!(:different_engine_ai_transcription) do
+        create(:ai_transcription, page_id: page.id, model: 'gemini-3-pro-preview',
+                                  source_text: nil, status: :finished, created_at: 1.day.ago)
+      end
+
+      it 'blocks user from creating a duplicate transcription for that engine' do
+        expect(result.success?).to be_falsey
+        expect(result.full_errors.message).to eq('AI Transcription generation is either in progress or completed!')
+      end
+    end
   end
 
   context 'when collection is field_based' do


### PR DESCRIPTION
### Motivation

- Support running the normal `transcribe` rake tasks through different AI engines so a Claude transcription can be created for a page that already has a Gemini transcription. 
- Avoid skipping pages solely because any prior AI transcription exists, while still preventing duplicate transcriptions for the same engine. 

### Description

- Add engine detection to `AiTranscription` by introducing `engine` and `self.engine_for_model(model)` so models beginning with `claude` are treated as Claude and others default to Gemini (`app/models/ai_transcription.rb`).
- Change `AiTranscription::Create` to look up the latest transcription for the requested model's engine via `latest_ai_transcription_for_model_engine` and only skip/create based on that engine instead of the single latest transcription (`app/interactors/ai_transcription/create.rb`).
- Add specs that verify a normal (non-`retranscribe`) create will produce a Claude record when the latest finished record is Gemini, and that same-engine duplicates are still blocked (`spec/interactors/ai_transcription/create_spec.rb`).

### Testing

- Ran Ruby syntax checks with `ruby -c` for `app/models/ai_transcription.rb`, `app/interactors/ai_transcription/create.rb`, and the updated spec file, and they returned OK.
- Attempted to run the relevant specs via `bin/bundle exec rspec spec/interactors/ai_transcription/create_spec.rb spec/models/ai_transcription_spec.rb`, but full spec execution was blocked because bundler/ruby setup in the environment could not install gems (Gemfile requires Ruby 3.3.5 while the environment has Ruby 3.4.4), so the `rspec` run could not complete.
- The new/modified code and specs were committed and verified with local syntax checks; behavior covered by the added specs is ready to run in CI or a correctly provisioned dev environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e9a70f9548322897b9a1ffd682cb6)