### PR TITLE
Require login to access work-queue filters and hide review controls for guests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -433,6 +433,14 @@ def update_search_attempt_user(user, session_var)
   end
 end
 
+
+def require_login_for_work_queue
+  return false if user_signed_in?
+
+  response.headers['X-Robots-Tag'] = 'noindex, nofollow, noarchive'
+  head :not_found
+end
+
 private
 
 def store_current_location

--- a/app/controllers/collection_controller.rb
+++ b/app/controllers/collection_controller.rb
@@ -680,6 +680,8 @@ class CollectionController < ApplicationController
   end
 
   def needs_transcription_pages
+    return if require_login_for_work_queue
+
     work_ids = @collection.works.pluck(:id)
     @review='transcription'
     @pages = Page.where(work_id: work_ids).joins(:work).merge(Work.unrestricted).needs_transcription.order(work_id: :asc, position: :asc).paginate(page: params[:page], per_page: 10)
@@ -690,6 +692,8 @@ class CollectionController < ApplicationController
   end
 
   def needs_review_pages
+    return if require_login_for_work_queue
+
     work_ids = @collection.works.pluck(:id)
     @review='review'
     @pages = Page.where(work_id: work_ids).joins(:work).merge(Work.unrestricted).review.paginate(page: params[:page], per_page: 10)
@@ -697,6 +701,8 @@ class CollectionController < ApplicationController
   end
 
   def needs_metadata_works
+    return if require_login_for_work_queue
+
     if params['need_review']
       @works = @collection.works.where(description_status: 'needsreview')
     else

--- a/app/controllers/display_controller.rb
+++ b/app/controllers/display_controller.rb
@@ -272,5 +272,4 @@ class DisplayController < ApplicationController
   def work_queue_filter?(filter)
     %w[review incomplete transcription index translation translation_review translation_index].include?(filter)
   end
-
 end

--- a/app/controllers/display_controller.rb
+++ b/app/controllers/display_controller.rb
@@ -17,6 +17,7 @@ class DisplayController < ApplicationController
     end
     if params.has_key?(:needs_review)
       @review = params[:needs_review]
+      return if work_queue_filter?(@review) && require_login_for_work_queue
     end
 
     # Handle page range parameter
@@ -265,4 +266,11 @@ class DisplayController < ApplicationController
       nil
     end
   end
+
+  private
+
+  def work_queue_filter?(filter)
+    %w[review incomplete transcription index translation translation_review translation_index].include?(filter)
+  end
+
 end

--- a/app/views/collection/show.html.slim
+++ b/app/views/collection/show.html.slim
@@ -137,7 +137,7 @@
         =search_field_tag :search_by_title, @search_attemp&.query, placeholder: t('.search_by_title')
         =button_tag t('.search')
 
-    -if notes_visible?(@collection, current_user) && (@collection.is_a?(Collection) || current_user&.can_transcribe?(nil, @collection))
+    -if user_signed_in? && notes_visible?(@collection, current_user) && (@collection.is_a?(Collection) || current_user&.can_transcribe?(nil, @collection))
       -if @collection.active? && @collection.text_entry?
         ruby:
           pages_need_correction_count = Page.where(work_id: @collection.work_ids, status: [:new, :incomplete]).count

--- a/app/views/display/_multi_page.html.slim
+++ b/app/views/display/_multi_page.html.slim
@@ -41,7 +41,7 @@
 
         -if @total != @count
           =button_to t('.view_all_pages'), {action: "read_work", work_id: @work.slug, needs_review: 'none'}, class: 'review-button'
-        -elsif @collection.active? && current_user&.can_transcribe?(@work, @collection) && notes_visible?(@collection, current_user)
+        -elsif user_signed_in? && @collection.active? && current_user&.can_transcribe?(@work, @collection) && notes_visible?(@collection, current_user)
           -if @work.pages.needs_transcription.any?
             =button_to t('.pages_need_transcription'), { action: "read_work", work_id: @work.slug, needs_review: 'transcription' }, class: 'review-button'
           -if current_user&.can_review?(@collection)

--- a/spec/requests/collection_controller_spec.rb
+++ b/spec/requests/collection_controller_spec.rb
@@ -79,6 +79,17 @@ describe CollectionController do
     end
   end
 
+  describe '#needs_transcription_pages' do
+    let(:action_path) { collection_needs_transcription_path(owner, collection) }
+
+    it 'returns not found and discourages indexing when logged out' do
+      get action_path
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.headers['X-Robots-Tag']).to eq('noindex, nofollow, noarchive')
+    end
+  end
+
   describe '#edit' do
     let(:action_path) { edit_collection_path(owner, collection) }
 

--- a/spec/requests/display_controller_spec.rb
+++ b/spec/requests/display_controller_spec.rb
@@ -146,6 +146,15 @@ describe DisplayController do
       end
     end
 
+    context 'when logged out and requesting a work queue filter' do
+      it 'returns not found and discourages indexing' do
+        get action_path, params: { needs_review: 'transcription' }
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.headers['X-Robots-Tag']).to eq('noindex, nofollow, noarchive')
+      end
+    end
+
     context 'with valid page range' do
       let(:action_path) { collection_read_work_with_range_path(owner, collection, work, '3-7') }
 

--- a/spec/requests/display_controller_spec.rb
+++ b/spec/requests/display_controller_spec.rb
@@ -223,6 +223,10 @@ describe DisplayController do
       let(:action_path) { collection_read_work_with_range_path(owner, collection, work, '3-7') }
       let(:params) { { needs_review: 'review' } }
 
+      before do
+        login_as owner
+      end
+
       it 'applies both filters' do
         get action_path, params: params
 


### PR DESCRIPTION
### Motivation

- Prevent unauthenticated users from accessing work-queue filtered views (review/transcription/index/etc.) and stop search engines from indexing those pages.
- Hide review/transcription/index controls in collection and work views for guests to avoid exposing workflow actions to unauthenticated visitors.

### Description

- Added `require_login_for_work_queue` to `ApplicationController` to return `404` and set `X-Robots-Tag: noindex, nofollow, noarchive` when the user is not signed in.
- Early-returned from `CollectionController` work-queue actions (`needs_transcription_pages`, `needs_review_pages`, `needs_metadata_works`) when `require_login_for_work_queue` triggers.
- Added a `work_queue_filter?` helper and a guard in `DisplayController#read_work` to block work-queue filtered reads for anonymous users.
- Updated collection and multi-page display templates to only show review/transcription buttons when `user_signed_in?` in addition to existing permission checks.
- Added request specs to assert unauthenticated access returns `:not_found` and includes the `X-Robots-Tag` header for both collection work-queue and read-work endpoints.

### Testing

- Ran `bundle exec rspec` and all specs completed successfully, including the new tests in `spec/requests/collection_controller_spec.rb` and `spec/requests/display_controller_spec.rb` which assert `:not_found` and the `X-Robots-Tag` header for unauthenticated work-queue requests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3eaa0b7bb883229fa07002505b5124)