### PR TITLE
Add cached_page_xml_to_html helper and use cache in page views

### DIFF
--- a/app/helpers/abstract_xml_helper.rb
+++ b/app/helpers/abstract_xml_helper.rb
@@ -523,4 +523,26 @@ module AbstractXmlHelper
           .gsub('&amp;amp;', '&amp;')
           .gsub('&amp;apos;', '&apos;')
   end
+
+  def cached_page_xml_to_html(page, attribute, preserve_lb: true, collection: nil, highlight_article_id: nil)
+    xml_text = page.public_send(attribute)
+    return '' if xml_text.blank?
+
+    collection ||= @collection
+
+    if highlight_article_id.present?
+      return xml_to_html(xml_text.to_s.dup, preserve_lb, false, collection, highlight_article_id)
+    end
+
+    Rails.cache.fetch([
+      'xml_to_html',
+      page.cache_key_with_version,
+      attribute,
+      preserve_lb,
+      collection&.class&.name,
+      collection&.cache_key_with_version
+    ]) do
+      xml_to_html(xml_text.to_s.dup, preserve_lb, false, collection)
+    end
+  end
 end

--- a/app/helpers/abstract_xml_helper.rb
+++ b/app/helpers/abstract_xml_helper.rb
@@ -524,8 +524,8 @@ module AbstractXmlHelper
           .gsub('&amp;apos;', '&apos;')
   end
 
-  def cached_page_xml_to_html(page, attribute, preserve_lb: true, collection: nil, highlight_article_id: nil)
-    xml_text = page.public_send(attribute)
+  def cached_record_xml_to_html(record, attribute, preserve_lb: true, collection: nil, highlight_article_id: nil)
+    xml_text = record.public_send(attribute)
     return '' if xml_text.blank?
 
     collection ||= @collection
@@ -536,7 +536,8 @@ module AbstractXmlHelper
 
     Rails.cache.fetch([
       'xml_to_html',
-      page.cache_key_with_version,
+      record.class.name,
+      record.cache_key_with_version,
       attribute,
       preserve_lb,
       collection&.class&.name,
@@ -544,5 +545,19 @@ module AbstractXmlHelper
     ]) do
       xml_to_html(xml_text.to_s.dup, preserve_lb, false, collection)
     end
+  end
+
+  def cached_page_xml_to_html(page, attribute, preserve_lb: true, collection: nil, highlight_article_id: nil)
+    cached_record_xml_to_html(
+      page,
+      attribute,
+      preserve_lb: preserve_lb,
+      collection: collection,
+      highlight_article_id: highlight_article_id
+    )
+  end
+
+  def cached_article_xml_to_html(article, preserve_lb: true, collection: nil)
+    cached_record_xml_to_html(article, :xml_text, preserve_lb: preserve_lb, collection: collection)
   end
 end

--- a/app/views/article/_tooltip.html.slim
+++ b/app/views/article/_tooltip.html.slim
@@ -1,7 +1,7 @@
 h5.tooltip_header =@article.title
 
 -if @article.xml_text != nil && !@article.xml_text.empty?
-  .tooltip_content ==xml_to_html(@article.xml_text)
+  .tooltip_content ==cached_article_xml_to_html(@article, collection: @collection)
 
 -unless @article.categories.empty?
   .tooltop_content.small

--- a/app/views/article/show.html.slim
+++ b/app/views/article/show.html.slim
@@ -2,7 +2,7 @@
 
 .article-columns.columns
   article.maincol
-    -description = xml_to_html(@article.xml_text)
+    -description = cached_article_xml_to_html(@article, collection: @collection)
     h3= t('.description')
     -if description.present?
       .big[*language_attrs(@collection)] ==description

--- a/app/views/display/_multi_page.html.slim
+++ b/app/views/display/_multi_page.html.slim
@@ -65,7 +65,7 @@
       -if @article
         h4 =@article.title
         -if @article.xml_text != nil && !@article.xml_text.empty?
-          =raw(xml_to_html(@article.xml_text))
+          =raw(cached_article_xml_to_html(@article, collection: @collection))
         =render :partial => 'article/article_links'
 
       -if @collection.categories.present?

--- a/app/views/display/_pages_view.html.slim
+++ b/app/views/display/_pages_view.html.slim
@@ -49,7 +49,7 @@
         h4.work-page_title =link_to page.title, page_params(page), onclick: "resultClicked();"
 
       .work-page_text[*language_attrs(@collection)]
-        -transcription = xml_to_html(page.xml_text, false, false, nil, params[:article_id])
+        -transcription = cached_page_xml_to_html(page, :xml_text, preserve_lb: false, collection: @collection, highlight_article_id: params[:article_id])
         -if @search_string
           -transcription = SearchAttempt::Lib::Utils.highlight_terms(transcription, @search_string)
         -if current_user
@@ -87,7 +87,7 @@
       -if page.work.supports_translation
         button.outline.work-page_toggle-view= t('.translation')
         .work-page_text(style="display:none")
-          -translation = xml_to_html(page.xml_translation, false)
+          -translation = cached_page_xml_to_html(page, :xml_translation, preserve_lb: false, collection: @collection)
           -if page.translation_status == 'blank'
             p.nodata_text == t('.this_page_is_blank')
           -elsif translation.present?

--- a/app/views/display/display_page.html.slim
+++ b/app/views/display/display_page.html.slim
@@ -58,19 +58,19 @@
             small.headline_aside =link_to t('.show_translation'), collection_display_page_path(@collection.owner, @collection, @work, @page.id, translation: true), class: 'button outline'
     .page-preview[*language_attrs(@collection)]
       -if translation_mode?
-        -text = xml_to_html(@page.xml_translation)
+        -text = cached_page_xml_to_html(@page, :xml_translation, collection: @collection)
         -action = 'translate'
         -help_word = t('.help_translate')
         -text_type = t('.translated')
 
       -elsif correction_mode?
-        -text = xml_to_html(@page.xml_text)
+        -text = cached_page_xml_to_html(@page, :xml_text, collection: @collection)
         -action = 'display_page'
         -help_word = t('.help_correct')
         -text_type = t('.corrected')
 
       -else
-        -text = xml_to_html(@page.xml_text)
+        -text = cached_page_xml_to_html(@page, :xml_text, collection: @collection)
         -action = 'display_page'
         -help_word = t('.help_transcribe')
         -text_type = t('.transcribed')

--- a/app/views/shared/_article_tabs.html.slim
+++ b/app/views/shared/_article_tabs.html.slim
@@ -18,7 +18,7 @@
     :path => "#{collection_article_version_path(@collection.owner, @collection, @article)}",
   }]
 
--description = xml_to_html(@article.xml_text)
+-description = cached_article_xml_to_html(@article, collection: @collection)
 -selected_tab = tabs.find { |tab| tab[:selected] == selected }[:name] rescue ""
 -content_for :page_title, selected == 1 ? @article.title : "#{selected_tab} - #{@article.title}"
 -content_for :meta_description, "#{@article.title} - #{t('.subject')} #{selected_tab.downcase}. #{strip_tags(description).truncate(150, separator: ' ')}"

--- a/app/views/shared/_page_tabs.html.slim
+++ b/app/views/shared/_page_tabs.html.slim
@@ -62,7 +62,7 @@ ruby:
     }
   end
 
-  description = xml_to_html(@page.xml_text)
+  description = cached_page_xml_to_html(@page, :xml_text, collection: @collection)
   selected_tab = tabs.find { |tab| tab[:selected] == selected }[:name] rescue ''
   tab_title = [3, 6].include?(selected) ? "#{selected_tab.downcase} #{t('.page')}" : "#{t('.page')} #{selected_tab.downcase}"
   page_title = @collection.present? ? "#{@page.title} (#{@collection.title}, #{@work.title})" : "#{@page.title} (#{@work.title})"

--- a/spec/helpers/abstract_xml_helper_spec.rb
+++ b/spec/helpers/abstract_xml_helper_spec.rb
@@ -156,11 +156,22 @@ RSpec.describe AbstractXmlHelper, type: :helper do
         cache_key_with_version: 'pages/1-20260101000000000000'
       )
     end
+    let(:article) do
+      double(
+        'Article',
+        xml_text: "<?xml version='1.0' encoding='UTF-8'?><page><p>Cached article</p></page>",
+        cache_key_with_version: 'pages/1-20260101000000000000'
+      )
+    end
     let(:collection) { double('Collection', cache_key_with_version: 'collections/1-20260101000000000000') }
     let(:document_set) { double('DocumentSet', cache_key_with_version: 'document_sets/1-20260101000000000000') }
 
     before do
       allow(Rails).to receive(:cache).and_return(cache)
+      allow(page).to receive(:class).and_return(double(name: 'Page'))
+      allow(article).to receive(:class).and_return(double(name: 'Article'))
+      allow(collection).to receive(:class).and_return(double(name: 'Collection'))
+      allow(document_set).to receive(:class).and_return(double(name: 'DocumentSet'))
     end
 
     it 'reuses cached page XML HTML for the same access object and line-break setting' do
@@ -207,6 +218,18 @@ RSpec.describe AbstractXmlHelper, type: :helper do
 
       expect(helper.cached_page_xml_to_html(page, :xml_text, preserve_lb: false, collection: collection)).to eq('<p>Cached text</p>')
       expect(helper.cached_page_xml_to_html(page, :xml_translation, preserve_lb: false, collection: collection)).to eq('<p>Cached translation</p>')
+    end
+
+    it 'keeps separate cache entries for record classes' do
+      expect(helper).to receive(:xml_to_html)
+        .with(page.xml_text, true, false, collection)
+        .and_return('<p>Cached page</p>')
+      expect(helper).to receive(:xml_to_html)
+        .with(article.xml_text, true, false, collection)
+        .and_return('<p>Cached article</p>')
+
+      expect(helper.cached_page_xml_to_html(page, :xml_text, collection: collection)).to eq('<p>Cached page</p>')
+      expect(helper.cached_article_xml_to_html(article, collection: collection)).to eq('<p>Cached article</p>')
     end
 
     it 'does not cache highlighted article variants' do

--- a/spec/helpers/abstract_xml_helper_spec.rb
+++ b/spec/helpers/abstract_xml_helper_spec.rb
@@ -145,4 +145,87 @@ RSpec.describe AbstractXmlHelper, type: :helper do
       expect(result.scan(/padding-left:2\.0em;/).length).to eq(2)
     end
   end
+
+  describe '#cached_page_xml_to_html' do
+    let(:cache) { ActiveSupport::Cache::MemoryStore.new }
+    let(:page) do
+      double(
+        'Page',
+        xml_text: "<?xml version='1.0' encoding='UTF-8'?><page><p>Cached text</p></page>",
+        xml_translation: "<?xml version='1.0' encoding='UTF-8'?><page><p>Cached translation</p></page>",
+        cache_key_with_version: 'pages/1-20260101000000000000'
+      )
+    end
+    let(:collection) { double('Collection', cache_key_with_version: 'collections/1-20260101000000000000') }
+    let(:document_set) { double('DocumentSet', cache_key_with_version: 'document_sets/1-20260101000000000000') }
+
+    before do
+      allow(Rails).to receive(:cache).and_return(cache)
+    end
+
+    it 'reuses cached page XML HTML for the same access object and line-break setting' do
+      expect(helper).to receive(:xml_to_html)
+        .once
+        .with(page.xml_text, true, false, collection)
+        .and_return('<p>Cached text</p>')
+
+      expect(helper.cached_page_xml_to_html(page, :xml_text, collection: collection)).to eq('<p>Cached text</p>')
+      expect(helper.cached_page_xml_to_html(page, :xml_text, collection: collection)).to eq('<p>Cached text</p>')
+    end
+
+    it 'keeps separate cache entries for separate access objects' do
+      expect(helper).to receive(:xml_to_html)
+        .with(page.xml_text, true, false, collection)
+        .and_return('<p>Collection text</p>')
+      expect(helper).to receive(:xml_to_html)
+        .with(page.xml_text, true, false, document_set)
+        .and_return('<p>Document set text</p>')
+
+      expect(helper.cached_page_xml_to_html(page, :xml_text, collection: collection)).to eq('<p>Collection text</p>')
+      expect(helper.cached_page_xml_to_html(page, :xml_text, collection: document_set)).to eq('<p>Document set text</p>')
+    end
+
+    it 'keeps separate cache entries for line-break variants' do
+      expect(helper).to receive(:xml_to_html)
+        .with(page.xml_text, true, false, collection)
+        .and_return('<p>Preserved line breaks</p>')
+      expect(helper).to receive(:xml_to_html)
+        .with(page.xml_text, false, false, collection)
+        .and_return('<p>Collapsed line breaks</p>')
+
+      expect(helper.cached_page_xml_to_html(page, :xml_text, preserve_lb: true, collection: collection)).to eq('<p>Preserved line breaks</p>')
+      expect(helper.cached_page_xml_to_html(page, :xml_text, preserve_lb: false, collection: collection)).to eq('<p>Collapsed line breaks</p>')
+    end
+
+    it 'keeps separate cache entries for XML attributes' do
+      expect(helper).to receive(:xml_to_html)
+        .with(page.xml_text, false, false, collection)
+        .and_return('<p>Cached text</p>')
+      expect(helper).to receive(:xml_to_html)
+        .with(page.xml_translation, false, false, collection)
+        .and_return('<p>Cached translation</p>')
+
+      expect(helper.cached_page_xml_to_html(page, :xml_text, preserve_lb: false, collection: collection)).to eq('<p>Cached text</p>')
+      expect(helper.cached_page_xml_to_html(page, :xml_translation, preserve_lb: false, collection: collection)).to eq('<p>Cached translation</p>')
+    end
+
+    it 'does not cache highlighted article variants' do
+      expect(helper).to receive(:xml_to_html)
+        .twice
+        .with(page.xml_text, false, false, collection, '123')
+        .and_return('<p>Highlighted text</p>')
+
+      2.times do
+        expect(
+          helper.cached_page_xml_to_html(
+            page,
+            :xml_text,
+            preserve_lb: false,
+            collection: collection,
+            highlight_article_id: '123'
+          )
+        ).to eq('<p>Highlighted text</p>')
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Motivation

- Reduce repeated expensive `xml_to_html` rendering by caching HTML output for page XML fields when possible.
- Ensure different cache entries for combinations of page, attribute, collection, and line-break preservation, while avoiding caching of highlight-specific variants.

### Description

- Add `cached_page_xml_to_html(page, attribute, preserve_lb: true, collection: nil, highlight_article_id: nil)` to `AbstractXmlHelper`, which uses `Rails.cache.fetch` with a key including `'xml_to_html'`, `page.cache_key_with_version`, `attribute`, `preserve_lb`, `collection` class name and `collection.cache_key_with_version`, and falls back to calling `xml_to_html` for misses.
- Short-circuit and bypass the cache when `highlight_article_id` is present by delegating directly to `xml_to_html` with the highlight argument.
- Replace direct `xml_to_html` calls in `app/views/display/_pages_view.html.slim`, `app/views/display/display_page.html.slim`, and `app/views/shared/_page_tabs.html.slim` with `cached_page_xml_to_html` for `xml_text` and `xml_translation` usages.
- Add unit tests in `spec/helpers/abstract_xml_helper_spec.rb` to verify caching behavior, cache key separation by collection/line-break/attribute, and that highlighted variants are not cached.

### Testing

- Ran the new helper specs with `bundle exec rspec spec/helpers/abstract_xml_helper_spec.rb` and all examples passed.
- The tests verify that `xml_to_html` is only invoked once for identical cache keys and invoked separately for differing collections, `preserve_lb` values, and XML attributes, and that highlight variants bypass caching.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ef0267bdc8322bef9f55e7e9d8200)