### PR TITLE
Add AI transcription error detail pages

### DIFF
--- a/app/controllers/collection/ai_transcriptions_controller.rb
+++ b/app/controllers/collection/ai_transcriptions_controller.rb
@@ -23,6 +23,10 @@ class Collection::AiTranscriptionsController < CollectionController
     respond_to(&:turbo_stream)
   end
 
+  def error
+    load_ai_transcription
+  end
+
   def update
     @result = AiTranscription::BulkRetry.new(
       collection: @collection,
@@ -42,6 +46,27 @@ class Collection::AiTranscriptionsController < CollectionController
   end
 
   private
+
+  def authorized?
+    unless user_signed_in?
+      redirect_to dashboard_path
+      return
+    end
+
+    unless current_user.admin || current_user.like_owner?(@collection)
+      redirect_to collection_path(@collection.owner, @collection)
+    end
+  end
+
+  def load_ai_transcription
+    @ai_transcription = AiTranscription
+      .includes(page: { work: :collection })
+      .find(params[:ai_transcription_id])
+    raise ActiveRecord::RecordNotFound unless @ai_transcription.collection == @collection
+
+    @page = @ai_transcription.page
+    @work = @page.work
+  end
 
   def calculate_counts
     collection_pages = Page

--- a/app/controllers/work/ai_transcriptions_controller.rb
+++ b/app/controllers/work/ai_transcriptions_controller.rb
@@ -25,6 +25,10 @@ class Work::AiTranscriptionsController < WorkController
     respond_to(&:turbo_stream)
   end
 
+  def error
+    load_ai_transcription
+  end
+
   def update
     @result = AiTranscription::BulkRetry.new(
       collection: @collection,
@@ -45,6 +49,26 @@ class Work::AiTranscriptionsController < WorkController
   end
 
   private
+
+  def authorized?
+    unless user_signed_in?
+      ajax_redirect_to dashboard_path
+      return
+    end
+
+    ajax_redirect_to dashboard_path unless current_user.admin ||
+      current_user.like_owner?(@work)
+  end
+
+  def load_ai_transcription
+    @ai_transcription = AiTranscription
+      .includes(page: { work: :collection })
+      .find(params[:ai_transcription_id])
+    raise ActiveRecord::RecordNotFound unless @ai_transcription.work == @work
+
+    @page = @ai_transcription.page
+    @collection = @work.collection
+  end
 
   def calculate_counts
     work_pages = @work.pages.reorder(nil)

--- a/app/views/admin_mailer/email_stats.html.slim
+++ b/app/views/admin_mailer/email_stats.html.slim
@@ -55,7 +55,7 @@ p This is the activity from the last #{@hours} hours.
   h2.nomargin Failed AI Transcriptions
   -@failed_ai_transcriptions.each do |ai_transcription|
     -work = ai_transcription.page.work
-    =link_to ai_transcription.page.title, collection_display_page_url(ai_transcription.collection.owner, ai_transcription.collection, work, ai_transcription.page, only_path: false)
+    =link_to ai_transcription.page.title, collection_ai_transcription_error_url(ai_transcription.collection.owner, ai_transcription.collection, ai_transcription, only_path: false)
     |
     =ai_transcription.error_message.presence || 'Error details not provided'
     -if ai_transcription.collection.present?

--- a/app/views/ai_transcriptions/_error_detail.html.slim
+++ b/app/views/ai_transcriptions/_error_detail.html.slim
@@ -1,0 +1,44 @@
+.ai-transcription-error-detail
+  h1 AI Transcription Error Details
+
+  table.form
+    tr
+      th Page Title
+      td =link_to @page.title, collection_display_page_path(@collection.owner, @collection, @work, @page)
+    tr
+      th Work Title
+      td =link_to @work.title, collection_read_work_path(@collection.owner, @collection, @work)
+    tr
+      th Collection Title
+      td =link_to @collection.title, collection_path(@collection.owner, @collection)
+    tr
+      th Status
+      td =@ai_transcription.status
+    tr
+      th Model
+      td =@ai_transcription.model
+    tr
+      th Created At
+      td =l(@ai_transcription.created_at, format: :long)
+    tr
+      th Updated At
+      td =l(@ai_transcription.updated_at, format: :long)
+    -if @ai_transcription.supports_prompt?
+      tr
+        th Prompt
+        td
+          pre =@ai_transcription.prompt.presence || 'No prompt stored'
+    -if @ai_transcription.reasoning.present?
+      tr
+        th Reasoning
+        td
+          pre =@ai_transcription.reasoning
+    -if @ai_transcription.source_text.present?
+      tr
+        th Source Text
+        td
+          pre =@ai_transcription.source_text
+    tr
+      th Error Message
+      td
+        pre =@ai_transcription.error_message.presence || 'Error details not provided'

--- a/app/views/collection/ai_transcriptions/_form.html.slim
+++ b/app/views/collection/ai_transcriptions/_form.html.slim
@@ -60,7 +60,7 @@
                 li
                   =work.title
                   |  —
-                  =link_to ai_transcription.page.title, collection_display_page_path(collection.owner, collection, work, ai_transcription.page)
+                  =link_to ai_transcription.page.title, collection_ai_transcription_error_path(collection.owner, collection, ai_transcription)
                   |  —
                   =ai_transcription.error_message.presence || t('.unknown_error')
             -if @failed_ai_transcriptions_hidden_count.positive?

--- a/app/views/collection/ai_transcriptions/error.html.slim
+++ b/app/views/collection/ai_transcriptions/error.html.slim
@@ -1,0 +1,1 @@
+=render 'ai_transcriptions/error_detail'

--- a/app/views/work/ai_transcriptions/_form.html.slim
+++ b/app/views/work/ai_transcriptions/_form.html.slim
@@ -57,7 +57,7 @@
             ul
               -@failed_ai_transcriptions.each do |ai_transcription|
                 li
-                  =link_to ai_transcription.page.title, collection_display_page_path(collection.owner, collection, work, ai_transcription.page)
+                  =link_to ai_transcription.page.title, collection_work_ai_transcription_error_path(collection.owner, collection, work, ai_transcription)
                   |  —
                   =ai_transcription.error_message.presence || t('.unknown_error')
             -if @failed_ai_transcriptions_hidden_count.positive?

--- a/app/views/work/ai_transcriptions/error.html.slim
+++ b/app/views/work/ai_transcriptions/error.html.slim
@@ -1,0 +1,1 @@
+=render 'ai_transcriptions/error_detail'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -520,6 +520,7 @@ Fromthepage::Application.routes.draw do
       get 'edit/quality_control', on: :member, to: 'collection#edit_quality_control'
 
       scope module: :collection do
+        get 'ai_transcriptions/:ai_transcription_id/error', to: 'ai_transcriptions#error', as: :ai_transcription_error
         resource :ai_transcriptions, only: [:edit, :create, :update]
       end
 
@@ -567,6 +568,7 @@ Fromthepage::Application.routes.draw do
       end
 
       resources :work, path: '', only: [] do
+        get 'ai_transcriptions/:ai_transcription_id/error', to: 'work/ai_transcriptions#error', as: :ai_transcription_error
         resource :ai_transcriptions, only: [:edit, :create, :update], controller: 'work/ai_transcriptions'
       end
 


### PR DESCRIPTION
### Motivation
- Provide a dedicated detail page for failed `AiTranscription` records so admins and project owners can inspect error messages and metadata. 
- Surface the error detail from existing failed-transcription lists so operators can quickly diagnose recurring failures.

### Description
- Added collection- and work-scoped GET routes for an error detail action under the existing collection/work route scopes in `config/routes.rb` (`ai_transcriptions/:ai_transcription_id/error`).
- Implemented `error` actions and `load_ai_transcription` helpers in `Collection::AiTranscriptionsController` and `Work::AiTranscriptionsController` that load `AiTranscription` by `params[:ai_transcription_id]`, verify ownership (collection/work), and reuse the existing admin/owner `authorized?` access pattern.
- Added a shared view partial `app/views/ai_transcriptions/_error_detail.html.slim` and collection/work error templates that render page/work/collection titles, status, model, timestamps, prompt (when supported), reasoning, source text, and stored error message.
- Updated failed-transcription links in `app/views/admin_mailer/email_stats.html.slim`, `app/views/collection/ai_transcriptions/_form.html.slim`, and `app/views/work/ai_transcriptions/_form.html.slim` to point to the new detail routes.

### Testing
- Ran `git diff --check` and it produced no whitespace or formatting errors (success).
- Ran `ruby -c config/routes.rb` and `ruby -c` on the modified controllers and they returned `Syntax OK` (success).
- Attempted to list routes with `bin/rails routes | rg "ai_transcription_error"`, but it was blocked by a local Ruby version mismatch (Gemfile requires `3.3.5`, environment is `3.4.4`) so route verification via Rails commanded routes was not executed (blocked).
- All automated syntax checks performed succeeded where available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fd75177c48322b5acea5b0b6a79fd)