### PR TITLE
Support DocumentSet targets and use slugs for CONTENTdm export (task, controller, views, specs)

### DIFF
--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -191,9 +191,12 @@ class ExportController < ApplicationController
   end
 
   def edit_contentdm_credentials
-    if ContentdmTranslator.collection_is_cdm?(@collection)
+    @sync_target = @collection
+    @cdm_collection = cdm_collection_for(@sync_target)
+
+    if ContentdmTranslator.collection_is_cdm?(@sync_target)
       begin
-        field_config = ContentdmTranslator.fetch_cdm_field_config(@collection)
+        field_config = ContentdmTranslator.fetch_cdm_field_config(@sync_target)
         @cdm_fulltext_fields = field_config.select { |e| e['type'] == 'FTS' }.map { |e| [e['name'], e['nick']] }
         @cdm_metadata_fields = field_config.map { |e| [e['name'], e['nick']] }
       rescue => e
@@ -212,10 +215,11 @@ class ExportController < ApplicationController
 
     # persist license key and export settings so the user doesn't have to retype them
     if error_message.blank? || !error_message.match(/license.*invalid/)
-      @collection.license_key = license_key
-      @collection.save!
+      cdm_collection = cdm_collection_for(@collection)
+      cdm_collection.license_key = license_key
+      cdm_collection.save!
 
-      cdm_setting = @collection.cdm_export_setting || @collection.build_cdm_export_setting
+      cdm_setting = cdm_collection.cdm_export_setting || cdm_collection.build_cdm_export_setting
       cdm_setting.transcript_source    = params[:transcript_source].presence || CdmExportSetting::HUMAN_ONLY
       cdm_setting.fulltext_field       = params[:cdm_fulltext_field].presence
       cdm_setting.include_ai_provenance = params[:include_ai_provenance] == '1'
@@ -227,23 +231,29 @@ class ExportController < ApplicationController
     # redirect to or render edit screen with error
     if error_message
       flash[:error] = error_message
-      render action: :edit_contentdm_credentials, collection_id: @collection.id
+      @sync_target = @collection
+      @cdm_collection = cdm_collection_for(@sync_target)
+      render action: :edit_contentdm_credentials, collection_id: @collection.slug
       return
     end
 
     # pass credentials, FTS field, and search to background job
     log_file = ContentdmTranslator.log_file(@collection)
     FileUtils.mkdir_p(File.dirname(log_file)) unless Dir.exist? File.dirname(log_file)
-    cmd = "rake fromthepage:cdm_transcript_export[#{@collection.id}] > #{log_file} 2>&1 &"
+    cmd = "rake fromthepage:cdm_transcript_export[#{@collection.slug}] > #{log_file} 2>&1 &"
     logger.info(cmd)
     system({ 'contentdm_username' => contentdm_user_name, 'contentdm_password' => contentdm_password, 'contentdm_license' => license_key }, cmd)
 
     # display results somehow
     flash[:notice] = t('.updating_contentdm_message')
-    ajax_redirect_to action: :index, collection_id: @collection.id
+    ajax_redirect_to action: :index, collection_id: @collection.slug
   end
 
   private
+
+  def cdm_collection_for(collection_or_set)
+    collection_or_set.is_a?(DocumentSet) ? collection_or_set.collection : collection_or_set
+  end
 
   def require_owner
     unless user_signed_in? && current_user.like_owner?(@collection)

--- a/app/views/export/edit_contentdm_credentials.html.slim
+++ b/app/views/export/edit_contentdm_credentials.html.slim
@@ -10,9 +10,11 @@
   h1 =t('.contentdm_credentials')
   p =t('.contentdm_credentials_description')
 
-  =form_for(@collection, url: { :action => 'update_contentdm_credentials' }, :method => :post) do |f|
-    =validation_summary @collection.errors
-    =hidden_field_tag :collection_id, @collection.id
+  -sync_target = @sync_target || @collection
+  -cdm_collection = @cdm_collection || @collection
+  =form_for(cdm_collection, url: { :action => 'update_contentdm_credentials' }, :method => :post) do |f|
+    =validation_summary cdm_collection.errors
+    =hidden_field_tag :collection_id, sync_target.slug
     table.form
       tr
         th =f.label :license_key, t('.license_key')

--- a/app/views/export/index.html.slim
+++ b/app/views/export/index.html.slim
@@ -10,16 +10,17 @@ p.big
   span =t('.export_all_works_description')
 
 
--if ContentdmTranslator.collection_is_cdm?(@collection) && @collection.text_entry? && @collection.is_a?(Collection)
+-cdm_collection = @collection.is_a?(DocumentSet) ? @collection.collection : @collection
+-if ContentdmTranslator.collection_is_cdm?(@collection) && cdm_collection.text_entry?
   h2 =t('.export_to_contentdm')
   p.big
     span.fright(style="margin-left: 30px")
-      =link_to(export_edit_contentdm_credentials_path(collection_id: @collection.id), { class: 'button btnExport', id: 'btnExportContentdm', data: { controller: 'litebox', litebox: { hash: '', collection_id: @collection.id }, collection_id: @collection.id } })
+      =link_to(export_edit_contentdm_credentials_path(collection_id: @collection.slug), { class: 'button btnExport', id: 'btnExportContentdm', data: { controller: 'litebox', litebox: { hash: '', collection_id: @collection.slug }, collection_id: @collection.slug } })
         =svg_symbol '#icon-export', class: 'icon'
         span =t('.export_to_contentdm')
     span =t('.export_to_contentdm_description')
 
--if @collection.text_entry?
+-if cdm_collection.text_entry?
   h2 =t('.export_individual_works')
   p.big =t('.export_individual_works_description')
 

--- a/lib/tasks/cdm_transcript_export.rake
+++ b/lib/tasks/cdm_transcript_export.rake
@@ -1,16 +1,16 @@
 require 'contentdm_translator'
 namespace :fromthepage do
   desc 'Export transcripts for completed works to CONTENTdm'
-  task :cdm_transcript_export, [:collection_id] => :environment do |t, args|
-    collection_id = args.collection_id.to_i
-    collection = Collection.find(collection_id)
+  task :cdm_transcript_export, [:target_slug] => :environment do |t, args|
+    sync_target = Collection.friendly.find(args.target_slug, allow_nil: true) || DocumentSet.friendly.find(args.target_slug)
+    collection = sync_target.is_a?(DocumentSet) ? sync_target.collection : sync_target
     username = ENV['contentdm_username']
     password = ENV['contentdm_password']
     license = ENV['contentdm_license']
 
     include_ai_drafts = collection.cdm_export_setting&.transcript_source == CdmExportSetting::HUMAN_AND_AI
 
-    collection.works.joins(:sc_manifest, :work_statistic).each do |work|
+    sync_target.works.joins(:sc_manifest, :work_statistic).each do |work|
       if include_ai_drafts || work.work_statistic.complete >= 99
         print "\tBeginning export of work #{work.id}, '#{work.title}' \n"
         ContentdmTranslator.export_work_to_cdm_with_retry(work, username, password, license)

--- a/spec/tasks/cdm_transcript_export_spec.rb
+++ b/spec/tasks/cdm_transcript_export_spec.rb
@@ -41,7 +41,7 @@ describe 'fromthepage:cdm_transcript_export' do
 
   def run_task
     Rake::Task['fromthepage:cdm_transcript_export'].reenable
-    capture_stdout { Rake::Task['fromthepage:cdm_transcript_export'].invoke(collection.id) }
+    capture_stdout { Rake::Task['fromthepage:cdm_transcript_export'].invoke(collection.slug) }
   end
 
   context 'with human_only setting (default)' do
@@ -69,6 +69,33 @@ describe 'fromthepage:cdm_transcript_export' do
     it 'also exports incomplete works' do
       run_task
       expect(ContentdmTranslator).to have_received(:export_work_to_cdm_with_retry).with(incomplete_work, any_args)
+    end
+  end
+
+  context 'with a document set argument' do
+    let(:document_set) { create(:document_set, collection: collection, owner_user_id: owner.id) }
+    let(:outside_work) do
+      create(:work, collection: collection).tap do |w|
+        create(:sc_manifest, work: w)
+        w.work_statistic.update!(complete: 100)
+      end
+    end
+
+    before do
+      create(:cdm_export_setting, collection: collection)
+      document_set.works << complete_work
+      outside_work
+    end
+
+    def run_document_set_task
+      Rake::Task['fromthepage:cdm_transcript_export'].reenable
+      capture_stdout { Rake::Task['fromthepage:cdm_transcript_export'].invoke(document_set.slug) }
+    end
+
+    it 'exports only works in the document set' do
+      run_document_set_task
+      expect(ContentdmTranslator).to have_received(:export_work_to_cdm_with_retry).with(complete_work, any_args)
+      expect(ContentdmTranslator).not_to have_received(:export_work_to_cdm_with_retry).with(outside_work, any_args)
     end
   end
 


### PR DESCRIPTION
### Motivation

- Allow CONTENTdm transcript exports to be invoked for either a `Collection` or a `DocumentSet` and use human-friendly slugs as the task/controller identifiers instead of numeric ids.

### Description

- Change the export rake task to accept a `target_slug` and resolve it to either a `Collection` or `DocumentSet` using `friendly.find`, iterating works on the resolved `sync_target` and preserving the parent `collection` for settings and notifications.
- Update the controller to pass slugs to the background job and to persist license/settings on the resolved CDM collection via a new helper `cdm_collection_for` and to set `@sync_target`/`@cdm_collection` for the edit flow.
- Update views to use the slug for links and form submissions, and to handle `DocumentSet` by resolving its parent collection for CONTENTdm-related form fields.
- Update specs in `spec/tasks/cdm_transcript_export_spec.rb` to invoke the rake task with slugs and add a new context that verifies exporting only works within a `DocumentSet`.

### Testing

- Ran the updated task spec `spec/tasks/cdm_transcript_export_spec.rb`, which passed locally after changes (including the new `DocumentSet` context).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4521f9c784832284001850d615e042)