### PR TITLE
Add link to blog interviews on case studies page

### DIFF
--- a/app/views/static/case_studies.html.slim
+++ b/app/views/static/case_studies.html.slim
@@ -20,5 +20,8 @@
 
       =link_to 'Read the full case study', case_study_ayn_rand_institute_path, class: 'button'
 
+  section#interviews
+    p Want to hear more from the people behind these projects? Read our #{link_to('interviews with archivists, librarians, and scholars', "https://content.fromthepage.com/?s=interview")} on the FromThePage blog.
+
   section#your-story
     p Interested in using FromThePage for your institution? #{link_to('Contact us', contact_path(contact_form_token))}.


### PR DESCRIPTION
Points visitors to interviews with archivists, librarians, and scholars featured on the FromThePage blog.