### PR TITLE
Fix LaTeX table footer for PDF export

### DIFF
--- a/app/interactors/work/export/lib/utils.rb
+++ b/app/interactors/work/export/lib/utils.rb
@@ -251,7 +251,7 @@ class Work::Export::Lib::Utils
       end
     end
 
-    latex += "\\bottomrule\\noalign{}\n"
+    latex += "\\bottomrule\n"
     latex += "\\end{xltabular}\n"
 
     latex

--- a/spec/interactors/work/export/lib/utils_spec.rb
+++ b/spec/interactors/work/export/lib/utils_spec.rb
@@ -74,5 +74,18 @@ describe Work::Export::Lib::Utils do
 
       expect(result).to match(/A & B \\\\\s*\nC & D \\\\\s*\n\\midrule/)
     end
+
+    it 'does not append an empty noalign after the bottom rule' do
+      xml = <<~XML
+        <page><table class="tabular"><tbody>
+          <tr><td>[illegible]</td><td>cash for flour</td><td>72</td><td>-</td></tr>
+        </tbody></table></page>
+      XML
+
+      result = described_class.xml_to_latex(page: page, xml_text: xml)
+
+      expect(result).to include("\\bottomrule\n\\end{xltabular}")
+      expect(result).not_to include('\\bottomrule\\noalign{}')
+    end
   end
 end


### PR DESCRIPTION
### Motivation
- LuaLaTeX was failing when compiling generated tables because an empty `\noalign{}` was emitted after `\bottomrule`, causing a `Missing number, treated as zero` fatal error at `\end{xltabular}`.

### Description
- Remove the stray `\noalign{}` emitted after `\bottomrule` in `app/interactors/work/export/lib/utils.rb` so table footers end cleanly before `\end{xltabular}`.
- Add a regression spec `spec/interactors/work/export/lib/utils_spec.rb` that asserts table output contains `\bottomrule\n\end{xltabular}` and does not include `\bottomrule\noalign{}` for the problematic table case.

### Testing
- Run syntax checks with `ruby -c` on both `app/interactors/work/export/lib/utils.rb` and the modified spec, which returned `Syntax OK` for both files.
- Run `git diff --check` which reported no whitespace or diff errors for the change.
- Attempted to run the spec runner via `bundle exec`, but execution was blocked by a Ruby version mismatch in this environment (active Ruby `3.4.4` vs Gemfile-specified `3.3.5`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a6afee61c8322a280a302fde9abd6)