### PR TITLE
Escape Unicode vulgar fractions in LaTeX export

### DIFF
--- a/app/interactors/work/export/lib/utils.rb
+++ b/app/interactors/work/export/lib/utils.rb
@@ -22,6 +22,27 @@ class Work::Export::Lib::Utils
   # Zero-width and invisible Unicode characters that LaTeX cannot handle
   LATEX_INVISIBLE_CHARS = /[\u{2060}\u{200B}\u{200C}\u{200D}\u{FEFF}]/
 
+  VULGAR_FRACTION_REPLACEMENTS = {
+    '¼' => '\\textonequarter{}',
+    '½' => '\\textonehalf{}',
+    '¾' => '\\textthreequarters{}',
+    '⅐' => '\\ensuremath{\\frac{1}{7}}',
+    '⅑' => '\\ensuremath{\\frac{1}{9}}',
+    '⅒' => '\\ensuremath{\\frac{1}{10}}',
+    '⅓' => '\\ensuremath{\\frac{1}{3}}',
+    '⅔' => '\\ensuremath{\\frac{2}{3}}',
+    '⅕' => '\\ensuremath{\\frac{1}{5}}',
+    '⅖' => '\\ensuremath{\\frac{2}{5}}',
+    '⅗' => '\\ensuremath{\\frac{3}{5}}',
+    '⅘' => '\\ensuremath{\\frac{4}{5}}',
+    '⅙' => '\\ensuremath{\\frac{1}{6}}',
+    '⅚' => '\\ensuremath{\\frac{5}{6}}',
+    '⅛' => '\\ensuremath{\\frac{1}{8}}',
+    '⅜' => '\\ensuremath{\\frac{3}{8}}',
+    '⅝' => '\\ensuremath{\\frac{5}{8}}',
+    '⅞' => '\\ensuremath{\\frac{7}{8}}'
+  }.freeze
+
   # Manually catch unsupported control_sequence that got through our parser
   UNSUPPORTED_LATEX_COMMANDS = [
     'unclear'
@@ -43,7 +64,7 @@ class Work::Export::Lib::Utils
       '_'  => '\\_',
       '~'  => '\\textasciitilde{}',
       '^'  => '\\textasciicircum{}'
-    }
+    }.merge(VULGAR_FRACTION_REPLACEMENTS)
 
     command_regex = /\\[a-zA-Z]+(?:\{[^}]*\})?/
 

--- a/spec/interactors/work/export/lib/utils_spec.rb
+++ b/spec/interactors/work/export/lib/utils_spec.rb
@@ -36,6 +36,11 @@ describe Work::Export::Lib::Utils do
       expect(described_class.latex_escape(rights_statement)).to eq('NO COPYRIGHT - UNITED STATES')
     end
 
+    it 'escapes Unicode vulgar fractions to LaTeX-safe equivalents' do
+      expect(described_class.latex_escape('1⅛ cups')).to eq('1\ensuremath{\frac{1}{8}} cups')
+      expect(described_class.latex_escape('¼ ½ ¾')).to eq('\textonequarter{} \textonehalf{} \textthreequarters{}')
+    end
+
     it 'returns empty string for blank input' do
       expect(described_class.latex_escape('')).to eq('')
       expect(described_class.latex_escape(nil)).to eq('')
@@ -73,6 +78,15 @@ describe Work::Export::Lib::Utils do
       result = described_class.xml_to_latex(page: page, xml_text: xml)
 
       expect(result).to match(/A & B \\\\\s*\nC & D \\\\\s*\n\\midrule/)
+    end
+
+    it 'escapes Unicode vulgar fractions in generated LaTeX' do
+      xml = '<page><p>Use ⅛ cup sugar.</p></page>'
+
+      result = described_class.xml_to_latex(page: page, xml_text: xml)
+
+      expect(result).not_to include('⅛')
+      expect(result).to include('\ensuremath{\frac{1}{8}}')
     end
   end
 end


### PR DESCRIPTION
### Motivation
- LaTeX export can emit raw Unicode vulgar fraction characters which TeX engines or downstream filters may not handle correctly. 
- Map common vulgar fraction code points to LaTeX-safe commands to ensure generated printable/Pandoc LaTeX contains safe markup.

### Description
- Add `VULGAR_FRACTION_REPLACEMENTS` mapping covering requested characters (¼, ½, ¾, ⅐, ⅑, ⅒, ⅓, ⅔, ⅕, ⅖, ⅗, ⅘, ⅙, ⅚, ⅛, ⅜, ⅝, ⅞) in `Work::Export::Lib::Utils` and merge it into the existing `replacements` hash used by `latex_escape`.
- Use `\textonequarter{}`, `\textonehalf{}`, and `\textthreequarters{}` for ¼/½/¾ and `\ensuremath{\frac{n}{d}}` for the other fractions to avoid adding a new LaTeX package dependency.
- Preserve existing behavior for control-sequence passthrough by keeping the command regex and applying the replacements only to non-command chunks.
- Add spec coverage that verifies `latex_escape` converts `⅛` (and other fractions) and that `xml_to_latex` output does not contain raw U+215B characters.

### Testing
- Ran `git diff --check` to ensure no whitespace or diff issues and it reported clean results. 
- Performed syntax checks with `ruby -c app/interactors/work/export/lib/utils.rb` and `ruby -c spec/interactors/work/export/lib/utils_spec.rb`, both of which returned OK. 
- Added RSpec examples to `spec/interactors/work/export/lib/utils_spec.rb` to validate `latex_escape` and `xml_to_latex` behavior for vulgar fractions. 
- Attempted to run `rspec` (`bundle _2.7.2_ exec rspec ...`) but execution was blocked by missing bundle dependencies / environment Ruby version mismatch, so full test suite was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e9f24fe408322bd889b1681e52b08)