### PR TITLE
Add AI draft button for field-based transcription

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -272,6 +272,12 @@ class Page < ApplicationRecord
     self.collection.field_based
   end
 
+  def field_ai_draft_available?
+    field_based &&
+      finished_ai_transcription.present? &&
+      !collection.transcription_fields.where(input_type: 'spreadsheet').exists?
+  end
+
   def articles_with_text
     articles conditions: ['articles.source_text is not null']
   end

--- a/app/views/transcribe/_save_buttons.html.slim
+++ b/app/views/transcribe/_save_buttons.html.slim
@@ -5,6 +5,8 @@
     -else
       -if @page && !@page.ai_plaintext.blank? && @collection.text_entry?
         =button_tag t('.copy_ai_plaintext'), type: 'button', id: 'copy-ai-plaintext', title: "#{t('.copy_ai_plaintext_tooltip')}"
+      -if @page && @page.field_ai_draft_available?
+        =button_tag t('.ai_draft_fields'), type: 'button', id: 'ai-draft-fields', title: "#{t('.ai_draft_fields_tooltip')}"
       =button_tag t('.preview'), name: 'preview', type: 'submit', title: "#{t('.preview_tooltip')}"
   -if !@collection.subjects_disabled && !@collection.field_based && @preview_xml.blank?
     =button_tag t('.autolink'), name: 'autolink', type: 'submit', title: "#{t('.autolink_tooltip')}"

--- a/app/views/transcribe/_save_buttons.html.slim
+++ b/app/views/transcribe/_save_buttons.html.slim
@@ -3,7 +3,7 @@
     -if @preview_xml.present?
       =button_tag t('.edit'), :name => 'edit', type: 'submit', title: "#{t('.edit_tooltip')}"
     -else
-      -if @page && !@page.ai_plaintext.blank? && @collection.text_entry?
+      -if @page && !@collection.field_based && !@page.ai_plaintext.blank? && @collection.text_entry?
         =button_tag t('.copy_ai_plaintext'), type: 'button', id: 'copy-ai-plaintext', title: "#{t('.copy_ai_plaintext_tooltip')}"
       -if @page && @page.field_ai_draft_available?
         =button_tag t('.ai_draft_fields'), type: 'button', id: 'ai-draft-fields', title: "#{t('.ai_draft_fields_tooltip')}"

--- a/app/views/transcription_field/_field_layout.html.slim
+++ b/app/views/transcription_field/_field_layout.html.slim
@@ -4,6 +4,24 @@
       .field-wrapper[style="width: #{formatted_field[:width]}%"]
         =@field_presenter.generate_field_input(field_id: formatted_field[:field].id, content: formatted_field[:values])
 
+-if @page&.field_ai_draft_available?
+  -content_for :javascript
+    javascript:
+      var aiTranscriptionFields = #{{@page.finished_ai_transcription.transcription_json.to_json}};
+
+      document.getElementById('ai-draft-fields').addEventListener('click', function() {
+        $('.field-wrapper .field-input').each(function() {
+          var match = /^fields\[(\d+)\]/.exec($(this).attr('name'));
+          if (!match) return;
+          var fieldId = match[1];
+          if (Object.prototype.hasOwnProperty.call(aiTranscriptionFields, fieldId) && aiTranscriptionFields[fieldId] !== null) {
+            $(this).val(aiTranscriptionFields[fieldId]).trigger('input').trigger('change');
+          }
+        });
+        $('#ai-draft-fields').prop('disabled', true);
+        $('#ai_draft_used').val('true');
+      });
+
 -content_for :javascript
   javascript:
     function countChars() {

--- a/config/locales/transcribe/transcribe-de.yml
+++ b/config/locales/transcribe/transcribe-de.yml
@@ -49,6 +49,8 @@ de:
       saved_and_next_notice: Gespeichert. Zur nächsten Seite wechseln.
       saved_notice: Gespeichert
     save_buttons:
+      ai_draft_fields: KI-Entwurf
+      ai_draft_fields_tooltip: KI-generierten Text in die Felder kopieren
       approve: Freigeben
       approve_to_transcribed_tooltip: Diese Seite speichern und freigeben
       autolink: Autolink

--- a/config/locales/transcribe/transcribe-en.yml
+++ b/config/locales/transcribe/transcribe-en.yml
@@ -49,6 +49,8 @@ en:
       saved_and_next_notice: Saved. Moving to the next page.
       saved_notice: Saved
     save_buttons:
+      ai_draft_fields: AI Draft
+      ai_draft_fields_tooltip: Copy AI-generated text into the fields
       approve: Approve
       approve_to_transcribed_tooltip: Save and approve this page
       autolink: Autolink

--- a/config/locales/transcribe/transcribe-es.yml
+++ b/config/locales/transcribe/transcribe-es.yml
@@ -49,6 +49,8 @@ es:
       saved_and_next_notice: Guardado. Pasando a la siguiente página.
       saved_notice: Guardado
     save_buttons:
+      ai_draft_fields: Borrador de IA
+      ai_draft_fields_tooltip: Copie el texto generado por IA en los campos
       approve: Aprobar
       approve_to_transcribed_tooltip: Guardar y aprobar esta página
       autolink: Enlace automático

--- a/config/locales/transcribe/transcribe-fr.yml
+++ b/config/locales/transcribe/transcribe-fr.yml
@@ -49,6 +49,8 @@ fr:
       saved_and_next_notice: Enregistré. Passage à la page suivante.
       saved_notice: Enregistré
     save_buttons:
+      ai_draft_fields: Brouillon IA
+      ai_draft_fields_tooltip: Copiez le texte généré par l'IA dans les champs
       approve: Approuver
       approve_to_transcribed_tooltip: Enregistrer et approuver cette page
       autolink: Lien automatique

--- a/config/locales/transcribe/transcribe-pt.yml
+++ b/config/locales/transcribe/transcribe-pt.yml
@@ -49,6 +49,8 @@ pt:
       saved_and_next_notice: Salvo. Passando para a próxima página.
       saved_notice: Guardada
     save_buttons:
+      ai_draft_fields: Rascunho de IA
+      ai_draft_fields_tooltip: Copie o texto gerado pela IA para os campos
       approve: Confirmar
       approve_to_transcribed_tooltip: Salve e aprove esta página
       autolink: Autolink

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -373,4 +373,65 @@ describe Page do
       end
     end
   end
+
+  describe '#field_ai_draft_available?' do
+    let(:page) { build_stubbed(:page) }
+    let(:collection) { build_stubbed(:collection) }
+
+    before do
+      allow(page).to receive(:collection).and_return(collection)
+    end
+
+    context 'when the collection is not field based' do
+      before do
+        allow(page).to receive(:field_based).and_return(false)
+      end
+
+      it 'returns false' do
+        expect(page.field_ai_draft_available?).to be false
+      end
+    end
+
+    context 'when the collection is field based' do
+      before do
+        allow(page).to receive(:field_based).and_return(true)
+      end
+
+      context 'when there is no finished ai transcription' do
+        before do
+          allow(page).to receive(:finished_ai_transcription).and_return(nil)
+        end
+
+        it 'returns false' do
+          expect(page.field_ai_draft_available?).to be false
+        end
+      end
+
+      context 'when there is a finished ai transcription' do
+        before do
+          allow(page).to receive(:finished_ai_transcription).and_return(build_stubbed(:ai_transcription, status: :finished))
+        end
+
+        context 'when the collection has a spreadsheet field' do
+          before do
+            allow(collection).to receive_message_chain(:transcription_fields, :where, :exists?).and_return(true)
+          end
+
+          it 'returns false' do
+            expect(page.field_ai_draft_available?).to be false
+          end
+        end
+
+        context 'when the collection has no spreadsheet field' do
+          before do
+            allow(collection).to receive_message_chain(:transcription_fields, :where, :exists?).and_return(false)
+          end
+
+          it 'returns true' do
+            expect(page.field_ai_draft_available?).to be true
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Shows an "AI Draft" button on the transcribe tab when a page has a finished AI transcription and its field-based collection has no spreadsheet-type field. Clicking it populates the field inputs from finished_ai_transcription.transcription_json, mirroring the existing plain-text AI Draft flow (reuses the ai_draft_used hidden field so deed recording and the flag-ai-use job keep working unchanged).