### PR TITLE
Add noindex headers and auth to version controllers; update robots.txt and tests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -359,7 +359,6 @@ class ApplicationController < ActionController::Base
 
     authenticate_user!
   end
-
 end
 
 def page_params(page)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -349,6 +349,17 @@ class ApplicationController < ActionController::Base
     # Override in controller for custom defaults
     DEFAULT_PER_PAGE
   end
+
+  def noindex_headers
+    response.set_header('X-Robots-Tag', 'noindex, nofollow, noarchive')
+  end
+
+  def authenticate_registered_or_guest_user!
+    return if current_user.present?
+
+    authenticate_user!
+  end
+
 end
 
 def page_params(page)

--- a/app/controllers/article_version_controller.rb
+++ b/app/controllers/article_version_controller.rb
@@ -1,5 +1,7 @@
 class ArticleVersionController < ApplicationController
+  prepend_before_action :authenticate_registered_or_guest_user!
   before_action :set_versions
+  before_action :noindex_headers
 
   def set_versions
     @selected_version = @article_version.present? ? @article_version : @article.article_versions.first

--- a/app/controllers/page_version_controller.rb
+++ b/app/controllers/page_version_controller.rb
@@ -1,6 +1,7 @@
 class PageVersionController < ApplicationController
   prepend_before_action :authenticate_registered_or_guest_user!
   before_action :set_versions
+  before_action :noindex_headers
 
   def set_versions
     @page_versions = []
@@ -15,13 +16,5 @@ class PageVersionController < ApplicationController
 
   def list
     render 'show'
-  end
-
-  private
-
-  def authenticate_registered_or_guest_user!
-    return if current_user.present?
-
-    authenticate_user!
   end
 end

--- a/app/views/shared/_article_tabs.html.slim
+++ b/app/views/shared/_article_tabs.html.slim
@@ -16,6 +16,7 @@
     :name => t('.versions'),
     :selected => 2,
     :path => "#{collection_article_version_path(@collection.owner, @collection, @article)}",
+    :opts => { :rel => 'nofollow' },
   }]
 
 -description = cached_article_xml_to_html(@article, collection: @collection)
@@ -27,7 +28,7 @@ h1[*language_attrs(@collection)] =@article.title
 .tabs
   -for tab in tabs
     -if tab[:path]
-      =link_to_unless tab[:selected] == selected, tab[:name], tab[:path]
+      =link_to_unless tab[:selected] == selected, tab[:name], tab[:path], tab[:opts]
         a.active =tab[:name]
     -else
       =link_to_unless tab[:selected] == selected, tab[:name], tab[:options].merge(:article_id => article_id)

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,6 +4,8 @@
 User-agent: *
 Disallow: /display/search
 Disallow: /*?*search*
+Disallow: /page_version/
+Disallow: /article_version/
 
 # Allow crawling of transcripts and other content for archival purposes
 Allow: /*/display/*

--- a/spec/requests/article_version_controller_spec.rb
+++ b/spec/requests/article_version_controller_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 
 RSpec.describe ArticleVersionController do
   let(:owner) { create(:unique_user, :owner) }
-
-  before { login_as owner }
   let(:collection) { create(:collection, owner_user_id: owner.id, works: []) }
   let(:article) { create(:article, collection: collection, title: 'Current Article') }
   let!(:first_version) do
@@ -13,15 +11,48 @@ RSpec.describe ArticleVersionController do
     create(:article_version, article: article, user: owner, title: 'Version 2', source_text: 'second', created_on: 1.day.ago)
   end
 
-  it 'lists article versions for an article' do
-    get collection_article_version_path(owner, collection, article)
+  context 'when logged in' do
+    before { login_as owner }
 
-    expect(response).to have_http_status(:ok)
+    it 'lists article versions for an article with robots noindex headers' do
+      get collection_article_version_path(owner, collection, article)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers['X-Robots-Tag']).to eq('noindex, nofollow, noarchive')
+    end
+
+    it 'uses the selected article version from params with robots noindex headers' do
+      get article_version_list_path, params: { article_version_id: second_version.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers['X-Robots-Tag']).to eq('noindex, nofollow, noarchive')
+    end
+
+    it 'uses robots noindex headers on direct article version show routes' do
+      get article_version_show_path, params: { article_version_id: second_version.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers['X-Robots-Tag']).to eq('noindex, nofollow, noarchive')
+    end
   end
 
-  it 'uses the selected article version from params' do
-    get article_version_list_path, params: { article_version_id: second_version.id }
+  context 'when logged out' do
+    it 'redirects the collection article versions tab to sign in' do
+      get collection_article_version_path(owner, collection, article)
 
-    expect(response).to have_http_status(:ok)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it 'redirects the direct article version list route to sign in' do
+      get article_version_list_path, params: { article_version_id: second_version.id }
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it 'redirects the direct article version show route to sign in' do
+      get article_version_show_path, params: { article_version_id: second_version.id }
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
   end
 end

--- a/spec/requests/page_version_controller_spec.rb
+++ b/spec/requests/page_version_controller_spec.rb
@@ -17,10 +17,11 @@ RSpec.describe PageVersionController do
       login_as(owner, scope: :user)
     end
 
-    it 'lists page versions for a page' do
+    it 'lists page versions for a page with robots noindex headers' do
       get collection_page_version_path(owner, collection, work, page)
 
       expect(response).to have_http_status(:ok)
+      expect(response.headers['X-Robots-Tag']).to eq('noindex, nofollow, noarchive')
     end
 
     it 'uses the requested comparison version' do
@@ -29,10 +30,18 @@ RSpec.describe PageVersionController do
       expect(response).to have_http_status(:ok)
     end
 
-    it 'uses the selected page version from params' do
+    it 'uses the selected page version from params with robots noindex headers' do
       get page_version_list_path, params: { page_version_id: second_version.id }
 
       expect(response).to have_http_status(:ok)
+      expect(response.headers['X-Robots-Tag']).to eq('noindex, nofollow, noarchive')
+    end
+
+    it 'uses robots noindex headers on direct page version show routes' do
+      get page_version_show_path, params: { page_version_id: second_version.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers['X-Robots-Tag']).to eq('noindex, nofollow, noarchive')
     end
   end
 

--- a/spec/requests/robots_txt_spec.rb
+++ b/spec/requests/robots_txt_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+RSpec.describe 'robots.txt' do
+  let(:robots_txt) { Rails.root.join('public/robots.txt').read }
+
+  it 'blocks version-history endpoints from crawler discovery' do
+    expect(robots_txt).to include("Disallow: /page_version/\n")
+    expect(robots_txt).to include("Disallow: /article_version/\n")
+  end
+
+  it 'keeps public display URLs crawlable' do
+    expect(robots_txt).to include("Allow: /*/display/*\n")
+    expect(robots_txt).to include("Allow: /*/*/*/display/*\n")
+  end
+end


### PR DESCRIPTION
### Motivation

- Prevent search engines from indexing version-history pages and ensure only authenticated users (or guests redirected to sign-in) can access version views.
- Centralize authentication helper and response header logic to avoid duplication across controllers.
- Make robots rules explicit to block `page_version` and `article_version` endpoints from crawlers.

### Description

- Added `noindex_headers` to `ApplicationController` to set the `X-Robots-Tag` header to `noindex, nofollow, noarchive` and added `authenticate_registered_or_guest_user!` helper to centralize auth checks.
- Applied `prepend_before_action :authenticate_registered_or_guest_user!` and `before_action :noindex_headers` to `ArticleVersionController` and `PageVersionController` to require authentication and attach noindex headers to responses.
- Removed duplicate `authenticate_registered_or_guest_user!` implementation from `PageVersionController` and moved it to `ApplicationController`.
- Updated `public/robots.txt` to `Disallow: /page_version/` and `Disallow: /article_version/` while keeping public display URLs allowed for crawling.
- Added `:opts => { :rel => 'nofollow' }` to the versions tab link in `shared/_article_tabs.html.slim` to include `rel="nofollow"` on the versions tab link.
- Updated request specs for `PageVersionController` and `ArticleVersionController` to assert authentication behavior and presence of the `X-Robots-Tag` header, and added a new `spec/requests/robots_txt_spec.rb` to validate `robots.txt` entries.

### Testing

- Ran `spec/requests/page_version_controller_spec.rb` and the updated examples passed and confirmed `X-Robots-Tag` is present for logged-in requests and redirects occur for anonymous requests.
- Ran `spec/requests/article_version_controller_spec.rb` and the updated examples passed and confirmed `X-Robots-Tag` is present for logged-in requests and redirects occur for anonymous requests.
- Ran the new `spec/requests/robots_txt_spec.rb` and it passed, verifying the added `Disallow` rules and retained `Allow` rules in `public/robots.txt`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a530936582c8322b000688de59425ed)