### PR TITLE
Add X-Robots-Tag:noindex to IIIF support and image-service endpoints

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -5,6 +5,7 @@ class IiifController < ApplicationController
   include ActionController::HttpAuthentication::Token::ControllerMethods
 
   before_action :set_cors_headers
+  before_action :set_iiif_support_noindex_header, only: [:canvas, :canvas_status, :list, :notes]
   before_action :set_api_user
   before_action :load_objects_from_ids
   before_action :check_api_access, except: [:collections, :contributions, :for, :collection_for_domain]
@@ -17,6 +18,10 @@ class IiifController < ApplicationController
         end
       end
     end
+  end
+
+  def set_iiif_support_noindex_header
+    response.headers['X-Robots-Tag'] = 'noindex'
   end
 
   def collections

--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -6,7 +6,13 @@ ActiveSupport::Reloader.to_prepare do
 end
 
 module RiiifImagesControllerRedirectPatch
+  def info
+    response.headers['X-Robots-Tag'] = 'noindex'
+    super
+  end
+
   def redirect
+    response.headers['X-Robots-Tag'] = 'noindex'
     redirect_to "/image-service/#{ERB::Util.url_encode(params[:id].to_s)}/info.json"
   end
 end

--- a/spec/requests/iiif_ai_annotations_spec.rb
+++ b/spec/requests/iiif_ai_annotations_spec.rb
@@ -23,6 +23,13 @@ describe 'IIIF AI Annotations' do
   end
 
   describe 'Canvas with AI annotations' do
+    it 'marks the canvas response as noindex without blocking IIIF link traversal' do
+      get iiif_canvas_path(work.id, page.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers['X-Robots-Tag']).to eq('noindex')
+    end
+
     context 'when page has no human-transcribed source text' do
       it 'includes AI text annotation in canvas' do
         get iiif_canvas_path(work.id, page.id)
@@ -338,6 +345,7 @@ describe 'IIIF AI Annotations' do
       get iiif_page_annotation_list_for_type_path(page.id, 'ai_text')
 
       expect(response).to have_http_status(:ok)
+      expect(response.headers['X-Robots-Tag']).to eq('noindex')
       json = JSON.parse(response.body)
 
       expect(json['resources']).to be_present

--- a/spec/requests/riiif_redirect_spec.rb
+++ b/spec/requests/riiif_redirect_spec.rb
@@ -6,4 +6,10 @@ RSpec.describe 'Riiif image service redirects' do
 
     expect(response).to redirect_to('/image-service/32407848/info.json')
   end
+
+  it 'marks bare image service redirects as noindex without blocking link traversal' do
+    get '/image-service/32407848'
+
+    expect(response.headers['X-Robots-Tag']).to eq('noindex')
+  end
 end


### PR DESCRIPTION
### Motivation
- Prevent search engines from indexing IIIF support JSON and image-routing endpoints while keeping them accessible to IIIF clients, viewers, and aggregators.
- Ensure downstream IIIF clients can still follow links by not adding `nofollow` and only sending `X-Robots-Tag: noindex` for API-style responses.
- Keep image file delivery unblocked for public display pages while marking expensive or support endpoints as non-indexable.

### Description
- Add a `before_action :set_iiif_support_noindex_header` to `IIIF` responses and implement `set_iiif_support_noindex_header` to set `response.headers['X-Robots-Tag'] = 'noindex'` for `canvas`, `canvas_status`, `list`, and `notes` in `app/controllers/iiif_controller.rb`.
- Prepend a patch module in `config/initializers/riiif.rb` to set `X-Robots-Tag: noindex` on the Riiif image `info` response and on the bare `/image-service/:id` redirect handler, while still redirecting to the `info.json` endpoint.
- Add request-spec assertions in `spec/requests/iiif_ai_annotations_spec.rb` and `spec/requests/riiif_redirect_spec.rb` that verify the `X-Robots-Tag` header is present and equals `noindex` for the patched endpoints.
- Intentionally only sends `noindex` (not `nofollow`) to avoid breaking IIIF link traversal by clients.

### Testing
- Ran syntax checks with `ruby -c` on the modified files (`app/controllers/iiif_controller.rb` and `config/initializers/riiif.rb`) which returned `Syntax OK`.
- Installed gems with `bundle install` to enable the test environment and confirmed bundler completed successfully in the environment used for local runs.
- Attempted to run the related specs with `bundle exec rspec spec/requests/riiif_redirect_spec.rb spec/requests/iiif_ai_annotations_spec.rb`, but the test run was blocked by an environment-level `before(:suite)` database connection error (MySQL unreachable at `127.0.0.1:3306`), so the examples could not be executed to completion.
- Performed local file validations (`ruby -c` for specs) which succeeded, and the new spec expectations are present to validate behavior when run in a fully configured test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5389eb017483229f30fdb7d49b3ee3)