### PR TITLE
Solution (#3620): marking pages inactive doesn't affect page counts

### DIFF
--- a/path/to/app/controllers/pages_controller.rb
+++ b/path/to/app/controllers/pages_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class PagesController < ApplicationController
+  # ...
+
+  def mark_inactive
+    page = Page.find(params[:id])
+    page.mark_inactive
+    redirect_to pages_path
+  end
+end

--- a/path/to/app/models/page.rb
+++ b/path/to/app/models/page.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Page < ApplicationRecord
+  # ...
+
+  def inactive
+    update(page_count: page_count - 1)
+  end
+
+  def mark_inactive
+    inactive
+  end
+
+  private
+
+  def page_count
+    # Assume this method is implemented elsewhere
+  end
+end

--- a/path/to/app/services/page_count_calculator.rb
+++ b/path/to/app/services/page_count_calculator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class PageCountCalculator
+  def calculate_page_count(pages)
+    active_pages = pages.select(&:active?)
+    inactive_pages = pages.select { |page| !page.active? }
+
+    active_pages.size + inactive_pages.size
+  end
+
+  def update_page_count(page, new_status)
+    if new_status
+      page.update(page_count: page.page_count - 1)
+    else
+      page.update(page_count: page.page_count + 1)
+    end
+  end
+end

--- a/path/to/lib/tasks/update_page_counts.rake
+++ b/path/to/lib/tasks/update_page_counts.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :update_page_counts do
+  desc 'Update page counts for all pages'
+  task update: :environment do
+    Page.all.each do |page|
+      PageCountCalculator.new.update_page_count(page, false)
+    end
+  end
+end

--- a/path/to/spec/controllers/pages_controller_spec.rb
+++ b/path/to/spec/controllers/pages_controller_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PagesController, type: :controller do
+  it 'marks page as inactive' do
+    page = create(:page)
+    expect { post :mark_inactive, params: { id: page.id } }.to change { page.reload.inactive? }.from(false).to(true)
+  end
+end

--- a/path/to/spec/models/page_spec.rb
+++ b/path/to/spec/models/page_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Page, type: :model do
+  it 'decrements page count when marked inactive' do
+    page = create(:page)
+    expect { page.mark_inactive }.to change { page.page_count }.by(-1)
+  end
+
+  it 'does not decrement page count when not marked inactive' do
+    page = create(:page)
+    expect { page.update(page_count: page.page_count + 1) }.not_to change { page.page_count }
+  end
+end

--- a/path/to/spec/services/page_count_calculator_spec.rb
+++ b/path/to/spec/services/page_count_calculator_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PageCountCalculator, type: :model do
+  let(:pages) { create_list(:page, 5) }
+
+  it 'calculates page count correctly' do
+    expect(PageCountCalculator.new.calculate_page_count(pages)).to eq(5)
+  end
+
+  it 'updates page count correctly' do
+    page = create(:page)
+    expect { PageCountCalculator.new.update_page_count(page, true) }.to change { page.page_count }.by(-1)
+  end
+end


### PR DESCRIPTION
This pull request fixes the issue of marking pages as inactive not affecting page counts. To test this change, run `rails db:migrate` and then `rails spec` to ensure all specs pass. Additionally, run `rake update_page_counts:update` to update page counts for all pages in the database. This change is essential for maintaining accurate page counts, which is crucial for various use cases in the application.