### PR TITLE
Active storage variant bottleneck fix

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -346,7 +346,7 @@ class Page < ApplicationRecord
 
     if image.attached?
       return Rails.application.routes.url_helpers.url_for(
-        image.variant(resize_to_limit: [nil, 400]).processed
+        image.variant(resize_to_limit: [nil, 400])
       )
     end
 


### PR DESCRIPTION
## Change
This change removes the explicit `.processed` call when generating thumbnail URLs.

## Why
According to the (Active Storage documentation)[https://api.rubyonrails.org/classes/ActiveStorage/Variant.html], variants should generally not be processed inline while rendering templates. Creating a variant requires downloading the original blob, performing the image transformation, and uploading the resulting variant. Calling `.processed` during view rendering forces all of that work to happen synchronously as part of the page request if the variant does not already exist.

I misunderstood the `.processed` function and thought this ensures the caching of thumbnail blobs. `variant` calls with or without the `.processed` should cache the thumbnail, instead the `.processed` called inline templates caused the image to be loaded synchronously.

## DId this cause server performance issues?
While I currently do not have data to back it up, tracing when the performance issues started and the deployment of (ActiveStorage Migration PR)[https://github.com/benwbrum/fromthepage/pull/5531] lines up with @benwbrum 's estimate of when the issue started. I think there could be correlation.

It is worth noting that we are also having server storage problems during this time, thus requiring the AS migration. This also should have impact on server performance, although I believe outtages could have been caused by simultaneous synchronous `.processed` calls.

## What to do next?
This should be relatively safe to merge and deploy ASAP. Once deployed we should observe if outtages/performance issues continue to happen and if so, direct our attention somewhere else. I do believe this will help server performance drastically, but is not the sole reason for our performance issues recently.