### PR TITLE
Use real name (with fallback) in volunteer hours letter and add specs

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -381,18 +381,22 @@ class DashboardController < ApplicationController
       \n#{generated_format_date(Time.now.to_date)}\n
       &nbsp; &nbsp;
       \n#{I18n.t('dashboard.hours_letter.to_whom_it_may_concern')}\n
-      #{I18n.t('dashboard.hours_letter.certification_text', user_name: current_user.real_name, time_duration: @time_duration, start_date: generated_format_date(@start_date_hours), end_date: generated_format_date(@end_date_hours))}\n
-      #{I18n.t('dashboard.hours_letter.worked_on_collections', user_name: current_user.real_name)}\n
+      #{I18n.t('dashboard.hours_letter.certification_text', user_name: volunteer_hours_letter_name, time_duration: @time_duration, start_date: generated_format_date(@start_date_hours), end_date: generated_format_date(@end_date_hours))}\n
+      #{I18n.t('dashboard.hours_letter.worked_on_collections', user_name: volunteer_hours_letter_name)}\n
       #{I18n.t('dashboard.hours_letter.institutions_header')}
       #{I18n.t('dashboard.hours_letter.institutions_separator')}
       #{generate_collection_rows(@user_collections)}
-      #{I18n.t('dashboard.hours_letter.volunteer_text', user_display_name: current_user.display_name)}\n
+      #{I18n.t('dashboard.hours_letter.volunteer_text', user_display_name: volunteer_hours_letter_name)}\n
       |
       #{I18n.t('dashboard.hours_letter.regards_text')}\n
       |
       | Sara Brumfield
       | Partner, FromThePage
     MARKDOWN
+  end
+
+  def volunteer_hours_letter_name
+    current_user.real_name.presence || current_user.display_name
   end
 
   def generate_collection_rows(user_collections)

--- a/spec/requests/dashboard_controller_spec.rb
+++ b/spec/requests/dashboard_controller_spec.rb
@@ -163,6 +163,42 @@ describe DashboardController do
     end
   end
 
+  describe '#generate_markdown_text' do
+    before do
+      allow(controller).to receive(:current_user).and_return(user)
+      controller.instance_variable_set(:@time_duration, '12 hours and 44 minutes')
+      controller.instance_variable_set(:@start_date_hours, Date.new(2026, 2, 1))
+      controller.instance_variable_set(:@end_date_hours, Date.new(2026, 7, 22))
+      controller.instance_variable_set(:@user_collections, [])
+      controller.instance_variable_set(:@collection_id_to_page_count, {})
+    end
+
+    it 'uses the real name throughout the volunteer hours letter when present' do
+      user.real_name = 'Avery Example'
+      user.login = 'ArchiveOtter42'
+      user.display_name = 'ArchiveOtter42'
+
+      markdown_text = controller.send(:generate_markdown_text)
+
+      expect(markdown_text).to include('Avery Example has contributed 12 hours and 44 minutes')
+      expect(markdown_text).to include('Avery Example has worked on the following collections')
+      expect(markdown_text).to include("We appreciate Avery Example\'s contribution")
+      expect(markdown_text).not_to include('ArchiveOtter42')
+    end
+
+    it 'falls back to the display name when no real name is present' do
+      user.real_name = nil
+      user.login = 'ArchiveOtter42'
+      user.display_name = 'ArchiveOtter42'
+
+      markdown_text = controller.send(:generate_markdown_text)
+
+      expect(markdown_text).to include('ArchiveOtter42 has contributed 12 hours and 44 minutes')
+      expect(markdown_text).to include('ArchiveOtter42 has worked on the following collections')
+      expect(markdown_text).to include("We appreciate ArchiveOtter42\'s contribution")
+    end
+  end
+
   describe '#owner' do
     let(:action_path) { dashboard_owner_path }
 

--- a/spec/requests/dashboard_controller_spec.rb
+++ b/spec/requests/dashboard_controller_spec.rb
@@ -163,39 +163,46 @@ describe DashboardController do
     end
   end
 
-  describe '#generate_markdown_text' do
+  describe '#download_hours_letter' do
+    let(:action_path) do
+      dashboard_download_hours_letter_path(
+        start_date: '2026-02-01',
+        end_date: '2026-07-22',
+        time_duration: '12 hours and 44 minutes'
+      )
+    end
+    let(:generated_markdown) { [] }
+
     before do
-      allow(controller).to receive(:current_user).and_return(user)
-      controller.instance_variable_set(:@time_duration, '12 hours and 44 minutes')
-      controller.instance_variable_set(:@start_date_hours, Date.new(2026, 2, 1))
-      controller.instance_variable_set(:@end_date_hours, Date.new(2026, 7, 22))
-      controller.instance_variable_set(:@user_collections, [])
-      controller.instance_variable_set(:@collection_id_to_page_count, {})
+      allow_any_instance_of(DashboardController).to receive(:generate_pdf) do |_controller, _input_path, _output_path, markdown_text|
+        generated_markdown << markdown_text
+      end
+      allow_any_instance_of(DashboardController).to receive(:send_generated_pdf) do |controller, _output_path|
+        controller.render plain: 'PDF generated'
+      end
     end
 
     it 'uses the real name throughout the volunteer hours letter when present' do
-      user.real_name = 'Avery Example'
-      user.login = 'ArchiveOtter42'
-      user.display_name = 'ArchiveOtter42'
+      user.update!(real_name: 'Avery Example', login: 'ArchiveOtter42')
+      login_as user
 
-      markdown_text = controller.send(:generate_markdown_text)
+      get action_path
 
-      expect(markdown_text).to include('Avery Example has contributed 12 hours and 44 minutes')
-      expect(markdown_text).to include('Avery Example has worked on the following collections')
-      expect(markdown_text).to include("We appreciate Avery Example\'s contribution")
-      expect(markdown_text).not_to include('ArchiveOtter42')
+      expect(generated_markdown.first).to include('Avery Example has contributed 12 hours and 44 minutes')
+      expect(generated_markdown.first).to include('Avery Example has worked on the following collections')
+      expect(generated_markdown.first).to include("We appreciate Avery Example\'s contribution")
+      expect(generated_markdown.first).not_to include('ArchiveOtter42')
     end
 
     it 'falls back to the display name when no real name is present' do
-      user.real_name = nil
-      user.login = 'ArchiveOtter42'
-      user.display_name = 'ArchiveOtter42'
+      user.update!(real_name: nil, login: 'ArchiveOtter42')
+      login_as user
 
-      markdown_text = controller.send(:generate_markdown_text)
+      get action_path
 
-      expect(markdown_text).to include('ArchiveOtter42 has contributed 12 hours and 44 minutes')
-      expect(markdown_text).to include('ArchiveOtter42 has worked on the following collections')
-      expect(markdown_text).to include("We appreciate ArchiveOtter42\'s contribution")
+      expect(generated_markdown.first).to include('ArchiveOtter42 has contributed 12 hours and 44 minutes')
+      expect(generated_markdown.first).to include('ArchiveOtter42 has worked on the following collections')
+      expect(generated_markdown.first).to include("We appreciate ArchiveOtter42\'s contribution")
     end
   end
 

--- a/spec/requests/dashboard_controller_spec.rb
+++ b/spec/requests/dashboard_controller_spec.rb
@@ -190,19 +190,19 @@ describe DashboardController do
 
       expect(generated_markdown.first).to include('Avery Example has contributed 12 hours and 44 minutes')
       expect(generated_markdown.first).to include('Avery Example has worked on the following collections')
-      expect(generated_markdown.first).to include("We appreciate Avery Example\'s contribution")
+      expect(generated_markdown.first).to include("We appreciate Avery Example\\'s contribution")
       expect(generated_markdown.first).not_to include('ArchiveOtter42')
     end
 
     it 'falls back to the display name when no real name is present' do
-      user.update!(real_name: nil, login: 'ArchiveOtter42')
+      user.update!(real_name: nil, login: 'CatalogFox17')
       login_as user
 
       get action_path
 
-      expect(generated_markdown.first).to include('ArchiveOtter42 has contributed 12 hours and 44 minutes')
-      expect(generated_markdown.first).to include('ArchiveOtter42 has worked on the following collections')
-      expect(generated_markdown.first).to include("We appreciate ArchiveOtter42\'s contribution")
+      expect(generated_markdown.first).to include('CatalogFox17 has contributed 12 hours and 44 minutes')
+      expect(generated_markdown.first).to include('CatalogFox17 has worked on the following collections')
+      expect(generated_markdown.first).to include("We appreciate CatalogFox17\\'s contribution")
     end
   end
 


### PR DESCRIPTION
### Motivation
- Ensure the volunteer hours letter uses the user's real name when available and falls back to the display name otherwise to present a consistent public-facing name.
- Centralize the name selection logic to avoid repeating conditional logic and to prevent exposing internal login identifiers in generated letters.

### Description
- Replaced direct uses of `current_user.real_name`/`current_user.display_name` in `generate_markdown_text` with a call to a new helper method `volunteer_hours_letter_name`.
- Added the `volunteer_hours_letter_name` method which returns `current_user.real_name.presence || current_user.display_name`.
- Updated the markdown generation to use `volunteer_hours_letter_name` for the certification, collections header, and volunteer text.
- Added request specs in `spec/requests/dashboard_controller_spec.rb` to verify that `generate_markdown_text` uses the real name when present and falls back to the display name when not.

### Testing
- Ran the updated request spec file with `bundle exec rspec spec/requests/dashboard_controller_spec.rb`, and the tests passed.
- Ran the full test suite with `bundle exec rspec`, and the suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60eab1dcf48322a78d6a17dd44a3b3)