### PR TITLE
Add field-based prompt building, use in bulk/create flows, and show AI error diagnostics

### DIFF
--- a/app/interactors/ai_transcription/bulk_create.rb
+++ b/app/interactors/ai_transcription/bulk_create.rb
@@ -16,7 +16,7 @@ class AiTranscription::BulkCreate < ApplicationInteractor
     check_user_permission
 
     @sanitized_model = sanitize_model
-    @sanitized_prompt = sanitize_prompt
+    @sanitized_prompt = build_prompt
 
     ai_transcription_records = []
 

--- a/app/interactors/ai_transcription/create.rb
+++ b/app/interactors/ai_transcription/create.rb
@@ -48,11 +48,6 @@ class AiTranscription::Create < ApplicationInteractor
 
   private
 
-  def build_prompt
-    return sanitize_prompt if @prompt_file.present? || !@collection.field_based
-    AiTranscription::Lib::FieldBasedPromptBuilder.new(collection: @collection).build
-  end
-
   def find_or_generate_ai_transcription
     ai_transcription = latest_ai_transcription_for_model_engine
 

--- a/app/interactors/ai_transcription/lib/common.rb
+++ b/app/interactors/ai_transcription/lib/common.rb
@@ -17,6 +17,14 @@ module AiTranscription::Lib::Common
     'Do not add any commentary or explanations - only provide the transcribed text.'
   end
 
+  def build_prompt
+    return sanitize_prompt if @prompt_file.present? || !@collection.field_based
+
+    AiTranscription::Lib::FieldBasedPromptBuilder
+      .new(collection: @collection)
+      .build
+  end
+
   def check_user_permission
     return if @user.admin?
 

--- a/app/views/ai_transcriptions/_error_details.html.slim
+++ b/app/views/ai_transcriptions/_error_details.html.slim
@@ -19,6 +19,22 @@ p
   strong Error:
 pre =ai_transcription.error_message.presence || 'Error details not provided'
 
+details
+  summary Prompt
+  pre =ai_transcription.prompt.presence || 'Not provided'
+
+details
+  summary Returned text
+  pre =ai_transcription.source_text.presence || 'Not provided'
+
+details
+  summary Reasoning
+  pre =ai_transcription.reasoning.presence || 'Not provided'
+
+details
+  summary Metadata
+  pre =ai_transcription.metadata.present? ? JSON.pretty_generate(ai_transcription.metadata) : 'Not provided'
+
 -if provider_details.present?
   h4 Provider details
   table.collection-settings

--- a/spec/interactors/ai_transcription/bulk_create_spec.rb
+++ b/spec/interactors/ai_transcription/bulk_create_spec.rb
@@ -9,12 +9,14 @@ describe AiTranscription::BulkCreate do
 
   let(:user) { owner }
   let(:scope) { nil }
+  let(:prompt_file) { nil }
 
   let(:result) do
     described_class.new(
       collection: collection,
       user: user,
-      scope: scope
+      scope: scope,
+      prompt_file: prompt_file
     ).call
   end
 
@@ -52,6 +54,40 @@ describe AiTranscription::BulkCreate do
       ai_transcriptions = collection.pages.includes(:ai_transcription).map(&:ai_transcription).compact
       expect(ai_transcriptions.size).to eq(2)
       expect(ai_transcriptions.pluck(:status).uniq).to eq(['processing'])
+    end
+  end
+
+  context 'when collection is field_based' do
+    let!(:collection) { create(:collection, :field_based, owner_user_id: owner.id, works: []) }
+    let!(:text_field) do
+      create(:transcription_field, :text_field,
+             label: 'Name', collection: collection, position: 1, line_number: 1)
+    end
+    let!(:select_field) do
+      create(:transcription_field, :select_field,
+             label: 'County', options: 'Beaver;Box Elder',
+             collection: collection, position: 2, line_number: 2)
+    end
+
+    it 'builds a field-based prompt for every transcription' do
+      expect(result.success?).to be_truthy
+
+      prompts = collection.pages.includes(:ai_transcription).map { |page| page.ai_transcription.prompt }
+      expect(prompts.uniq.one?).to be_truthy
+      expect(prompts.first).to include(text_field.id.to_s, 'Name', select_field.id.to_s, 'County')
+      expect(prompts.first).not_to include('Preserve the original formatting')
+    end
+
+    context 'when a custom prompt_file is supplied' do
+      let(:prompt_file) { 'test_data/ai_transcriptions/custom_prompt.txt' }
+
+      it 'uses the custom prompt instead of the field-based prompt' do
+        expect(result.success?).to be_truthy
+
+        prompts = collection.pages.includes(:ai_transcription).map { |page| page.ai_transcription.prompt }
+        expect(prompts).to all(eq("This is a custom prompt\n"))
+        expect(prompts.none? { |prompt| prompt.include?(text_field.id.to_s) }).to be_truthy
+      end
     end
   end
 end

--- a/spec/requests/admin/ai/errors_controller_spec.rb
+++ b/spec/requests/admin/ai/errors_controller_spec.rb
@@ -7,7 +7,15 @@ describe Admin::Ai::ErrorsController do
   let!(:collection) { create(:collection, owner_user_id: owner.id) }
   let!(:work) { create(:work, collection: collection) }
   let!(:page) { create(:page, work: work) }
-  let!(:ai_transcription_error) { create(:ai_transcription, page_id: page.id, status: :error, metadata: { 'error_message' => 'Test error' }) }
+  let!(:ai_transcription_error) do
+    create(:ai_transcription,
+           page_id: page.id,
+           status: :error,
+           prompt: 'Test prompt',
+           source_text: 'Returned transcription',
+           reasoning: 'Test reasoning',
+           metadata: { 'error_message' => 'Test error', 'prompt_token_count' => 123 })
+  end
   let!(:ai_transcription_finished) { create(:ai_transcription, page_id: page.id, status: :finished) }
 
   describe '#index' do
@@ -79,6 +87,16 @@ describe Admin::Ai::ErrorsController do
       expect(assigns(:page)).to eq(page)
       expect(assigns(:work)).to eq(work)
       expect(assigns(:collection)).to eq(collection)
+    end
+
+    it 'shows collapsible diagnostic details' do
+      login_as admin
+      subject
+
+      expect(response.body).to include('<summary>Prompt</summary>', 'Test prompt')
+      expect(response.body).to include('<summary>Returned text</summary>', 'Returned transcription')
+      expect(response.body).to include('<summary>Reasoning</summary>', 'Test reasoning')
+      expect(response.body).to include('<summary>Metadata</summary>', '&quot;prompt_token_count&quot;: 123')
     end
 
     context 'when record is not an error' do


### PR DESCRIPTION
### Motivation
- Ensure AI transcription prompt selection supports field-based collections and custom prompt files uniformly across bulk and single creation flows.
- Centralize prompt building logic to avoid duplication and make behavior consistent between `BulkCreate` and `Create` flows.
- Improve admin error diagnostics by exposing prompt, returned text, reasoning, and metadata in the error details view.

### Description
- Move `build_prompt` into `AiTranscription::Lib::Common` and keep `sanitize_prompt` as the file-read/fallback implementation, then use `build_prompt` from both `AiTranscription::BulkCreate` and `AiTranscription::Create`.
- Update `AiTranscription::BulkCreate` to accept and pass `prompt_file` and to use `build_prompt` for prompt generation when creating/importing records.
- Update the error partial `app/views/ai_transcriptions/_error_details.html.slim` to render collapsible `details` sections for `Prompt`, `Returned text`, `Reasoning`, and pretty-printed `Metadata`.
- Expand specs to cover field-based prompt building and custom `prompt_file` behavior in `spec/interactors/ai_transcription/bulk_create_spec.rb`, and to assert the new diagnostic sections render in `spec/requests/admin/ai/errors_controller_spec.rb`.

### Testing
- Ran `bundle exec rspec spec/interactors/ai_transcription/bulk_create_spec.rb` and the spec scenarios (field-based prompt and custom `prompt_file`) passed.
- Ran `bundle exec rspec spec/requests/admin/ai/errors_controller_spec.rb` and the new assertions for collapsible diagnostic details passed.
- Updated specs were executed as part of the CI test run and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67967661048328b3f2f9291964a49a)