### PR TITLE
Allow punctuation in ContentDM collection aliases and validate /id/ item paths

### DIFF
--- a/lib/contentdm_translator.rb
+++ b/lib/contentdm_translator.rb
@@ -271,7 +271,11 @@ module ContentdmTranslator
     server = get_cdm_host_from_url("#{uri.scheme}://#{uri.host}")
     raise 'ContentDM URLs must be of the form http://cdmNNNNN.contentdm.oclc.org/...' if server.nil?
 
-    matches = uri.path.match(/.*collection\/(\w+)(?:\/id\/(\d+))?/)
+    matches = uri.path.match(%r{.*collection/([^/]+)(?:/id/(\d+)(?:/.*)?)?\z})
+
+    if uri.path.include?('/id/') && (!matches || matches[2].nil?)
+      raise ArgumentError, "ContentDM item URL contains /id/ but no valid numeric record ID: #{url}"
+    end
 
     if matches
       collection = matches[1]

--- a/spec/models/contentdm_translator_spec.rb
+++ b/spec/models/contentdm_translator_spec.rb
@@ -134,6 +134,31 @@ RSpec.describe ContentdmTranslator do
     let(:vanity_collection_2) { 'http://www.digitalindy.org/cdm/search/collection/ahs' }
     let(:vanity_repository) { 'http://www.digitalindy.org' }
 
+    context 'when collection aliases contain punctuation' do
+      before do
+        allow(ContentdmTranslator).to receive(:get_cdm_host_from_url).and_return('kdl')
+        allow(URI).to receive(:open).and_return(StringIO.new('{}'))
+      end
+
+      it 'translates a hyphenated item alias and permits trailing routes' do
+        url = ContentdmTranslator.cdm_url_to_iiif('https://kdl.contentdm.oclc.org/digital/collection/tu-medtheses/id/4805/rec/1')
+
+        expect(url).to eq('https://kdl.contentdm.oclc.org/iiif/info/tu-medtheses/4805/manifest.json')
+      end
+
+      it 'translates a hyphenated collection alias' do
+        url = ContentdmTranslator.cdm_url_to_iiif('https://kdl.contentdm.oclc.org/digital/collection/tu-medtheses')
+
+        expect(url).to eq('https://kdl.contentdm.oclc.org/iiif/info/tu-medtheses/manifest.json')
+      end
+
+      it 'does not treat a malformed item path as a collection URL' do
+        expect do
+          ContentdmTranslator.cdm_url_to_iiif('https://kdl.contentdm.oclc.org/digital/collection/tu-medtheses/id/not-a-record')
+        end.to raise_error(ArgumentError, %r{/id/ but no valid numeric record ID})
+      end
+    end
+
     context 'default' do
       around(:each) do |example|
         VCR.use_cassette('cdm/digital-alabama', record: :none) do


### PR DESCRIPTION
### Motivation
- Improve robustness of `cdm_url_to_iiif` so collection aliases containing punctuation (e.g. hyphens) are recognized correctly.
- Prevent silently treating malformed item paths as collection URLs when a path contains `/id/` but no valid numeric record identifier.

### Description
- Tighten the collection/item path parsing by replacing the simple `match` with a more explicit regex: `%r{.*collection/([^/]+)(?:/id/(\d+)(?:/.*)?)?\z}` to allow punctuation in collection aliases and ignore trailing route segments.
- Add an explicit validation that raises `ArgumentError` when the URL contains `/id/` but the captured record ID is missing or non-numeric.
- Update specs to cover hyphenated collection aliases and trailing routes, and add a test asserting that malformed `/id/` paths raise the new `ArgumentError` while mocking host resolution and `URI.open` responses.

### Testing
- Ran the test suite with `bundle exec rspec`, including the new `cdm_url_to_iiif` examples, and all specs succeeded.
- Existing VCR-backed tests for remote ContentDM endpoints were preserved and executed under their cassettes without failures.
- New unit tests that mock `get_cdm_host_from_url` and `URI.open` for punctuation cases passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67b88d3fb88328b8195a799e9e4126)