### PR TITLE
Enhance AI disagreement report metrics

### DIFF
--- a/lib/tasks/ai_disagreement_report.rake
+++ b/lib/tasks/ai_disagreement_report.rake
@@ -53,7 +53,7 @@ namespace :fromthepage do
     filename = "ai_disagreement_#{slug}.csv"
 
     CSV.open(filename, 'wb') do |csv|
-      csv << ['Work Title', 'Page Title', 'Page ID', 'AI Tab URL', 'Transcribe Tab URL', 'Character Disagreement Rate', 'Case-insensitive CDR', *field_headers, 'Missing Models']
+      csv << ['Work Title', 'Page Title', 'Page ID', 'AI Tab URL', 'Transcribe Tab URL', 'Character Disagreement Rate', 'Misplaced FIelds', 'Case-insensitive CDR', 'Claude Text-only CER', 'Gemini Text-only CER', *field_headers, 'Missing Models']
 
       pages.each do |page|
         page_work = page.work
@@ -86,6 +86,7 @@ namespace :fromthepage do
             [nil, nil]
           end
         end
+        misplaced_fields = field_disagreement_rates.each_slice(2).any? { |_cdr, text_only_cdr| text_only_cdr == 100.0 } ? 'yes' : 'no'
 
         csv << [
           page_work.title,
@@ -94,7 +95,10 @@ namespace :fromthepage do
           Rails.application.routes.url_helpers.collection_ai_text_page_url(page_collection.owner, page_collection, page_work, page),
           "#{Rails.application.routes.url_helpers.collection_transcribe_page_url(page_collection.owner, page_collection, page_work, page)}?ai_draft=1",
           disagreement_rate,
+          misplaced_fields,
           ci_disagreement_rate,
+          claude_transcription&.text_cer,
+          gemini_transcription&.text_cer,
           *field_disagreement_rates,
           missing_models.join(' ')
         ]

--- a/spec/tasks/ai_disagreement_report_spec.rb
+++ b/spec/tasks/ai_disagreement_report_spec.rb
@@ -38,7 +38,7 @@ describe 'fromthepage:ai_disagreement_report' do
     misplaced_page = create(:page, work: work)
     aligned_page = create(:page, work: work)
     create_transcription(page: misplaced_page, model: 'claude-sonnet', field_text: 'alpha', text_cer: 12)
-    create_transcription(page: misplaced_page, model: 'gemini-pro', field_text: 'omega', text_cer: 57)
+    create_transcription(page: misplaced_page, model: 'gemini-pro', field_text: 'zzzzz', text_cer: 57)
     create_transcription(page: aligned_page, model: 'claude-sonnet', field_text: 'same')
     create_transcription(page: aligned_page, model: 'gemini-pro', field_text: 'same')
 
@@ -50,6 +50,7 @@ describe 'fromthepage:ai_disagreement_report' do
     expect(rows.headers.index('Misplaced FIelds')).to eq(rows.headers.index('Character Disagreement Rate') + 1)
     expect(misplaced_row['Claude Text-only CER']).to eq('12')
     expect(misplaced_row['Gemini Text-only CER']).to eq('57')
+    expect(misplaced_row['Body Text-only CDR']).to eq('100.0')
     expect(misplaced_row['Misplaced FIelds']).to eq('yes')
     expect(aligned_row['Claude Text-only CER']).to be_nil
     expect(aligned_row['Gemini Text-only CER']).to be_nil

--- a/spec/tasks/ai_disagreement_report_spec.rb
+++ b/spec/tasks/ai_disagreement_report_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+require 'rake'
+
+describe 'fromthepage:ai_disagreement_report' do
+  before(:all) do
+    Rake.application = Rake::Application.new
+    Rails.application.load_tasks
+  end
+
+  let(:owner) { create(:unique_user, :owner) }
+  let(:collection) { create(:collection, :field_based, owner_user_id: owner.id, works: []) }
+  let(:work) { create(:work, collection: collection) }
+  let(:field) { create(:transcription_field, :as_transcription, :text_field, collection: collection, label: 'Body') }
+
+  def create_transcription(page:, model:, field_text:, text_cer: nil)
+    create(
+      :ai_transcription,
+      page: page,
+      model: model,
+      status: :finished,
+      source_text: field_text,
+      transcription_json: { field.id.to_s => field_text },
+      text_cer: text_cer
+    )
+  end
+
+  def run_report
+    Rake::Task['fromthepage:ai_disagreement_report'].reenable
+    Dir.mktmpdir do |directory|
+      Dir.chdir(directory) do
+        Rake::Task['fromthepage:ai_disagreement_report'].invoke(work.slug)
+        return CSV.read("ai_disagreement_#{work.slug}.csv", headers: true)
+      end
+    end
+  end
+
+  it 'reports each model text-only CER and identifies fields with 100% text-only disagreement' do
+    misplaced_page = create(:page, work: work)
+    aligned_page = create(:page, work: work)
+    create_transcription(page: misplaced_page, model: 'claude-sonnet', field_text: 'alpha', text_cer: 12.34)
+    create_transcription(page: misplaced_page, model: 'gemini-pro', field_text: 'omega', text_cer: 56.78)
+    create_transcription(page: aligned_page, model: 'claude-sonnet', field_text: 'same')
+    create_transcription(page: aligned_page, model: 'gemini-pro', field_text: 'same')
+
+    rows = run_report
+    misplaced_row = rows.find { |row| row['Page ID'] == misplaced_page.id.to_s }
+    aligned_row = rows.find { |row| row['Page ID'] == aligned_page.id.to_s }
+
+    expect(rows.headers).to include('Claude Text-only CER', 'Gemini Text-only CER')
+    expect(rows.headers.index('Misplaced FIelds')).to eq(rows.headers.index('Character Disagreement Rate') + 1)
+    expect(misplaced_row['Claude Text-only CER']).to eq('12.34')
+    expect(misplaced_row['Gemini Text-only CER']).to eq('56.78')
+    expect(misplaced_row['Misplaced FIelds']).to eq('yes')
+    expect(aligned_row['Claude Text-only CER']).to be_nil
+    expect(aligned_row['Gemini Text-only CER']).to be_nil
+    expect(aligned_row['Misplaced FIelds']).to eq('no')
+  end
+end

--- a/spec/tasks/ai_disagreement_report_spec.rb
+++ b/spec/tasks/ai_disagreement_report_spec.rb
@@ -37,8 +37,8 @@ describe 'fromthepage:ai_disagreement_report' do
   it 'reports each model text-only CER and identifies fields with 100% text-only disagreement' do
     misplaced_page = create(:page, work: work)
     aligned_page = create(:page, work: work)
-    create_transcription(page: misplaced_page, model: 'claude-sonnet', field_text: 'alpha', text_cer: 12.34)
-    create_transcription(page: misplaced_page, model: 'gemini-pro', field_text: 'omega', text_cer: 56.78)
+    create_transcription(page: misplaced_page, model: 'claude-sonnet', field_text: 'alpha', text_cer: 12)
+    create_transcription(page: misplaced_page, model: 'gemini-pro', field_text: 'omega', text_cer: 57)
     create_transcription(page: aligned_page, model: 'claude-sonnet', field_text: 'same')
     create_transcription(page: aligned_page, model: 'gemini-pro', field_text: 'same')
 
@@ -48,8 +48,8 @@ describe 'fromthepage:ai_disagreement_report' do
 
     expect(rows.headers).to include('Claude Text-only CER', 'Gemini Text-only CER')
     expect(rows.headers.index('Misplaced FIelds')).to eq(rows.headers.index('Character Disagreement Rate') + 1)
-    expect(misplaced_row['Claude Text-only CER']).to eq('12.34')
-    expect(misplaced_row['Gemini Text-only CER']).to eq('56.78')
+    expect(misplaced_row['Claude Text-only CER']).to eq('12')
+    expect(misplaced_row['Gemini Text-only CER']).to eq('57')
     expect(misplaced_row['Misplaced FIelds']).to eq('yes')
     expect(aligned_row['Claude Text-only CER']).to be_nil
     expect(aligned_row['Gemini Text-only CER']).to be_nil


### PR DESCRIPTION
### Motivation

- Surface per-model text-only CERs for Claude and Gemini so the CSV shows model-level text-only accuracy in addition to page-wide disagreement. 
- Flag pages whose individual fields exhibit complete text-only mismatch (100% CER) so misplaced-field cases are easy to spot in the report.

### Description

- Modify `lib/tasks/ai_disagreement_report.rake` to add CSV columns `'Misplaced FIelds'`, `'Claude Text-only CER'`, and `'Gemini Text-only CER'`, with the `Misplaced FIelds` column placed immediately after the record-wide Character Disagreement Rate. 
- Populate the Claude/Gemini CER columns using the latest finished `ai_transcription` per engine and compute `misplaced_fields` by checking whether any field-level text-only CDR equals `100.0` (sets value to `yes` or `no`). 
- Keep existing field-level CDR and case-insensitive CDR columns intact and append the new columns into the CSV row output. 
- Add `spec/tasks/ai_disagreement_report_spec.rb` to cover header ordering, presence of the Claude/Gemini text-only CER values, and both `yes` and `no` outcomes for the `Misplaced FIelds` column.

### Testing

- `git diff --check` completed successfully.
- `ruby -c lib/tasks/ai_disagreement_report.rake` returned `Syntax OK`.
- `ruby -c spec/tasks/ai_disagreement_report_spec.rb` returned `Syntax OK`.
- `bundle exec rspec spec/tasks/ai_disagreement_report_spec.rb` was not executed due to a Ruby version mismatch in the environment (Ruby `3.4.4` vs Gemfile-specified `3.3.5`), so the spec file could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67db58edb08322ba84ffa473d42f34)