### PR TITLE
Upgrade retired Gemini transcription model

### DIFF
--- a/app/interactors/ai_transcription/bulk_create.rb
+++ b/app/interactors/ai_transcription/bulk_create.rb
@@ -32,11 +32,13 @@ class AiTranscription::BulkCreate < ApplicationInteractor
         )
       elsif ai_transcription.status_new?
         ai_transcription.status = :processing
+        ai_transcription.model = @sanitized_model
+        ai_transcription.prompt = @sanitized_prompt
         ai_transcription_records << ai_transcription
       end
     end
 
-    AiTranscription.import! ai_transcription_records, on_duplicate_key_update: [:status], batch_size: BATCH_SIZE
+    AiTranscription.import! ai_transcription_records, on_duplicate_key_update: [:status, :model, :prompt], batch_size: BATCH_SIZE
   end
 
   private

--- a/app/interactors/ai_transcription/lib/gemini/transcribe_handler.rb
+++ b/app/interactors/ai_transcription/lib/gemini/transcribe_handler.rb
@@ -3,13 +3,11 @@ class AiTranscription::Lib::Gemini::TranscribeHandler < AiTranscription::Lib::Ba
   # Add custom handling here if the model you are using
   # does not use `v1`
   VERSION_MAP = {
-    'gemini-3-pro-preview' => 'v1beta',
     'gemini-3.1-pro-preview' => 'v1beta',
     'gemini-3-flash-preview' => 'v1beta'
   }.freeze
 
   REASONING_MAP = {
-    'gemini-3-pro-preview' => true,
     'gemini-3.1-pro-preview' => true
   }
 

--- a/app/jobs/ai_transcription/bulk_retry_job.rb
+++ b/app/jobs/ai_transcription/bulk_retry_job.rb
@@ -9,6 +9,7 @@ class AiTranscription::BulkRetryJob < ApplicationJob
     ai_transcriptions = AiTranscription.where(id: ai_transcription_ids)
 
     ai_transcriptions.each do |ai_transcription|
+      ai_transcription.normalize_model!
       AiTranscription::GenerateJob.perform_later(
         ai_transcription_id: ai_transcription.id,
         user_id: user.id

--- a/app/jobs/ai_transcription/generate_job.rb
+++ b/app/jobs/ai_transcription/generate_job.rb
@@ -23,6 +23,7 @@ class AiTranscription::GenerateJob < ApplicationJob
       raise ArgumentError, error_message
     end
 
+    ai_transcription.normalize_model!
     result = AiTranscription::Generate.new(ai_transcription: ai_transcription).call
 
     if result.success?

--- a/app/models/ai_transcription.rb
+++ b/app/models/ai_transcription.rb
@@ -95,6 +95,10 @@ class AiTranscription < ApplicationRecord
     self.class.engine_for_model(model)
   end
 
+  def normalize_model!
+    update!(model: DEFAULT_MODEL) if model == 'gemini-3-pro-preview'
+  end
+
   def self.engine_for_model(model)
     model.to_s.start_with?('claude') ? 'claude' : 'gemini'
   end

--- a/doc/GEMINI_AI_TRANSCRIPTION.md
+++ b/doc/GEMINI_AI_TRANSCRIPTION.md
@@ -27,7 +27,7 @@ To obtain a Gemini API key:
 
 ### 3. (Optional) Configure Model
 
-By default, the integration uses `gemini-3-pro-preview`. You can override this by setting:
+By default, the integration uses `gemini-3.1-pro-preview`. You can override this by setting:
 
 ```bash
 export GEMINI_MODEL='gemini-1.5-pro'
@@ -38,7 +38,7 @@ Available models include:
 - `gemini-1.5-pro` (stable, more accurate, slower)
 - `gemini-pro-vision` (older model with vision capabilities)
 - `gemini-2.5-pro`
-- `gemini-3-pro-preview` (default model with reasoning capabilities)
+- `gemini-3.1-pro-preview` (default model with reasoning capabilities)
 - `gemini-3-flash-preview` (optional, available via rake task model argument)
 
 ## Usage

--- a/lib/gemini/text_transcriber.rb
+++ b/lib/gemini/text_transcriber.rb
@@ -8,33 +8,29 @@ module Gemini
     # Add custom handling here if the model you are using
     # does not use `v1`
     VERSION_MAP = {
-      'gemini-3-pro-preview' => 'v1beta',
       'gemini-3.1-pro-preview' => 'v1beta',
       'gemini-3-flash-preview' => 'v1beta'
     }.freeze
 
     REASONING_MAP = {
-      'gemini-3-pro-preview' => true,
       'gemini-3.1-pro-preview' => true
     }
 
     # Transcribes text from a page image using Google's Gemini multi-modal model
-    # Defaults to gemini-3-pro-preview but can be configured via model parameter
-    # Note: The issue mentions Gemini 2.5, but we use gemini-3-pro-preview as default.
-    # This can be updated when other models are released.
+    # Defaults to AiTranscription::DEFAULT_MODEL but can be configured via model parameter
     #
     # Implements exponential backoff retry logic for 503 errors (server overload) and 429 errors (rate limit)
     #
     # @param image_url [String] The URL of the page image to transcribe
     # @param prompt [String] Optional custom prompt for transcription
-    # @param model [String] Optional custom model to use. Defaults to gemini-3-pro-preview
+    # @param model [String] Optional custom model to use. Defaults to AiTranscription::DEFAULT_MODEL
     # @param max_retries [Integer] Maximum number of retry attempts for 503/429 errors
     # @return [String] The transcribed text from the image
-    def self.transcribe_image(image_url, prompt: nil, model: 'gemini-3-pro-preview', max_retries: 5)
+    def self.transcribe_image(image_url, prompt: nil, model: AiTranscription::DEFAULT_MODEL, max_retries: 5)
       api_key = ENV['GEMINI_API_KEY']
       raise ArgumentError, 'GEMINI_API_KEY environment variable is not set' if api_key.blank?
 
-      model ||= 'gemini-3-pro-preview'
+      model ||= AiTranscription::DEFAULT_MODEL
 
       client = ::Gemini.new(
         credentials: {

--- a/spec/interactors/ai_transcription/bulk_create_spec.rb
+++ b/spec/interactors/ai_transcription/bulk_create_spec.rb
@@ -30,7 +30,10 @@ describe AiTranscription::BulkCreate do
   end
 
   context 'when ai_transcription for page exist' do
-    let!(:ai_transcription) { create(:ai_transcription, page_id: page_1.id, source_text: nil, status: :new) }
+    let!(:ai_transcription) do
+      create(:ai_transcription, page_id: page_1.id, model: 'gemini-3-pro-preview', prompt: 'Old prompt',
+                                source_text: nil, status: :new)
+    end
 
     it 'initializes processing ai_transcription records' do
       expect(result.success?).to be_truthy
@@ -38,6 +41,10 @@ describe AiTranscription::BulkCreate do
       expect(ai_transcriptions.size).to eq(2)
       expect(ai_transcriptions.pluck(:id)).to include(ai_transcription.id)
       expect(ai_transcriptions.pluck(:status).uniq).to eq(['processing'])
+      expect(ai_transcription.reload).to have_attributes(
+        model: AiTranscription::DEFAULT_MODEL,
+        prompt: File.read(Rails.root.join('lib/transcription_prompt.txt'))
+      )
     end
   end
 

--- a/spec/jobs/ai_transcription/bulk_retry_job_spec.rb
+++ b/spec/jobs/ai_transcription/bulk_retry_job_spec.rb
@@ -22,4 +22,20 @@ describe AiTranscription::BulkRetryJob do
 
     perform_worker
   end
+
+  it 'upgrades the retired model before enqueueing generation' do
+    ai_transcription.update!(model: 'gemini-3-pro-preview', status: :error)
+
+    perform_worker
+
+    expect(ai_transcription.reload.model).to eq(AiTranscription::DEFAULT_MODEL)
+  end
+
+  it 'preserves supported non-default models' do
+    ai_transcription.update!(model: 'gemini-3-flash-preview', status: :error)
+
+    perform_worker
+
+    expect(ai_transcription.reload.model).to eq('gemini-3-flash-preview')
+  end
 end

--- a/spec/jobs/ai_transcription/generate_job_spec.rb
+++ b/spec/jobs/ai_transcription/generate_job_spec.rb
@@ -51,6 +51,18 @@ describe AiTranscription::GenerateJob do
       )
     end
 
+    context 'with the retired model persisted' do
+      let(:model) { 'gemini-3-pro-preview' }
+
+      it 'invokes Gemini with the default model' do
+        VCR.use_cassette('ai_transcriptions/generate', record: :none, allow_playback_repeats: false) do
+          perform_worker
+        end
+
+        expect(ai_transcription.reload.model).to eq('gemini-3.1-pro-preview')
+      end
+    end
+
     context 'when user is admin' do
       let!(:admin) { create(:unique_user, :admin) }
 


### PR DESCRIPTION
### Motivation

- Migrate persisted records using the retired `gemini-3-pro-preview` value to the current `AiTranscription::DEFAULT_MODEL` and ensure the retry/generation path does not re-enqueue work using the retired model. 
- Ensure bulk creation reuses `new` records with the intended sanitized `model` and `prompt` values so re-used records receive the same generation inputs as new ones. 

### Description

- When reusing an existing `status_new?` record in `AiTranscription::BulkCreate`, assign `@sanitized_model` and `@sanitized_prompt` to the record and include `:model` and `:prompt` in `on_duplicate_key_update`. (updated `app/interactors/ai_transcription/bulk_create.rb`)  
- Add `AiTranscription#normalize_model!` which upgrades `model == 'gemini-3-pro-preview'` to `AiTranscription::DEFAULT_MODEL`, and invoke it from the retry and generation boundaries so persisted retired models are normalized before enqueueing or calling generation. (updated `app/models/ai_transcription.rb`, `app/jobs/ai_transcription/bulk_retry_job.rb`, and `app/jobs/ai_transcription/generate_job.rb`)  
- Remove the retired `gemini-3-pro-preview` entries from `VERSION_MAP` and `REASONING_MAP` in the active Gemini handlers and update the legacy `Gemini::TextTranscriber` to default to `AiTranscription::DEFAULT_MODEL`. (updated `app/interactors/ai_transcription/lib/gemini/transcribe_handler.rb` and `lib/gemini/text_transcriber.rb`)  
- Update documentation to identify `gemini-3.1-pro-preview` as the default and add specs that cover reusing `new` records, retry normalization, preservation of supported non-default models, and generation behavior when a retired model is persisted. (updated `doc/GEMINI_AI_TRANSCRIPTION.md` and specs in `spec/.../bulk_create_spec.rb`, `spec/.../bulk_retry_job_spec.rb`, `spec/.../generate_job_spec.rb`) 

### Testing

- Ran `git diff --check` and it reported no whitespace or index errors.  
- Ran Ruby syntax checks with `ruby -c` on all changed Ruby files and they passed.  
- Attempted to run the updated spec subset with `bundle exec rspec spec/interactors/ai_transcription/bulk_create_spec.rb spec/jobs/ai_transcription/bulk_retry_job_spec.rb spec/jobs/ai_transcription/generate_job_spec.rb` but the environment lacked the `rspec` executable so the suite could not be executed.  
- Ran `bundle check` and it failed due to a Ruby version mismatch in the environment (local Ruby 3.4.4 vs Gemfile-specified Ruby 3.3.5), preventing a full bundle/rspec run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68c268f3508328887895881e871a8b)