### PR TITLE
Sanitize credentials in AI provider errors

### DIFF
--- a/app/interactors/ai_transcription/lib/error_message_sanitizer.rb
+++ b/app/interactors/ai_transcription/lib/error_message_sanitizer.rb
@@ -1,0 +1,9 @@
+class AiTranscription::Lib::ErrorMessageSanitizer
+  CREDENTIAL_PARAMETER = /([?&](?:key|api_key|token|access_token)=)[^&#\s]+/i
+
+  def self.sanitize(message)
+    return if message.nil?
+
+    message.to_s.gsub(CREDENTIAL_PARAMETER, '\\1[FILTERED]')
+  end
+end

--- a/app/interactors/ai_transcription/lib/gemini/transcribe_handler.rb
+++ b/app/interactors/ai_transcription/lib/gemini/transcribe_handler.rb
@@ -42,16 +42,20 @@ class AiTranscription::Lib::Gemini::TranscribeHandler < AiTranscription::Lib::Ba
         end
 
         # If not a 503 or out of retries, raise the error
-        Rails.logger.error("Gemini API error: #{e.message}")
+        Rails.logger.error("Gemini API error: #{sanitized_message(e)}")
         raise e
       end
     end
   rescue => e
-    Rails.logger.error("Gemini API error: #{e.message}")
+    Rails.logger.error("Gemini API error: #{sanitized_message(e)}")
     raise e
   end
 
   private
+
+  def sanitized_message(error)
+    AiTranscription::Lib::ErrorMessageSanitizer.sanitize(error.message)
+  end
 
   def api_key
     return @api_key if defined?(@api_key)

--- a/app/jobs/ai_transcription/generate_job.rb
+++ b/app/jobs/ai_transcription/generate_job.rb
@@ -38,7 +38,7 @@ class AiTranscription::GenerateJob < ApplicationJob
 
   def store_error!(ai_transcription, error_message)
     metadata = ai_transcription.metadata.is_a?(Hash) ? ai_transcription.metadata.dup : {}
-    metadata['error_message'] = error_message
+    metadata['error_message'] = AiTranscription::Lib::ErrorMessageSanitizer.sanitize(error_message)
     ai_transcription.update!(status: :error, metadata: metadata)
   end
 end

--- a/app/models/ai_transcription.rb
+++ b/app/models/ai_transcription.rb
@@ -102,7 +102,7 @@ class AiTranscription < ApplicationRecord
   def error_message
     return if metadata.blank? || !metadata.is_a?(Hash)
 
-    metadata['error_message']
+    AiTranscription::Lib::ErrorMessageSanitizer.sanitize(metadata['error_message'])
   end
 
   def provider_error_details

--- a/spec/interactors/ai_transcription/lib/gemini/transcribe_handler_spec.rb
+++ b/spec/interactors/ai_transcription/lib/gemini/transcribe_handler_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe AiTranscription::Lib::Gemini::TranscribeHandler do
+  subject(:handler) do
+    described_class.new(prompt: 'Transcribe', model: 'gemini-test', image_url: 'https://example.com/image.jpg')
+  end
+
+  it 'redacts credentials from provider errors before logging' do
+    error = StandardError.new(
+      'the server responded with status 429 for URL https://provider.example/generate?token=fake-secret&alt=json'
+    )
+    allow(handler).to receive(:client).and_return(double(generate_content: nil))
+    allow(handler.client).to receive(:generate_content).and_raise(error)
+    logged_messages = []
+    allow(Rails.logger).to receive(:error) { |message| logged_messages << message }
+
+    expect { handler.perform }.to raise_error(error)
+
+    expect(logged_messages).to all(include('status 429'))
+    expect(logged_messages).to all(include('provider.example/generate?token=[FILTERED]&alt=json'))
+    expect(logged_messages.join).not_to include('fake-secret')
+  end
+end

--- a/spec/interactors/ai_transcription/lib/gemini/transcribe_handler_spec.rb
+++ b/spec/interactors/ai_transcription/lib/gemini/transcribe_handler_spec.rb
@@ -12,6 +12,7 @@ describe AiTranscription::Lib::Gemini::TranscribeHandler do
     client = double
     allow(client).to receive(:generate_content).and_raise(error)
     allow(handler).to receive(:client).and_return(client)
+    allow(handler).to receive(:payload).and_return({})
     logged_messages = []
     allow(Rails.logger).to receive(:error) { |message| logged_messages << message }
 

--- a/spec/interactors/ai_transcription/lib/gemini/transcribe_handler_spec.rb
+++ b/spec/interactors/ai_transcription/lib/gemini/transcribe_handler_spec.rb
@@ -9,8 +9,9 @@ describe AiTranscription::Lib::Gemini::TranscribeHandler do
     error = StandardError.new(
       'the server responded with status 429 for URL https://provider.example/generate?token=fake-secret&alt=json'
     )
-    allow(handler).to receive(:client).and_return(double(generate_content: nil))
-    allow(handler.client).to receive(:generate_content).and_raise(error)
+    client = double
+    allow(client).to receive(:generate_content).and_raise(error)
+    allow(handler).to receive(:client).and_return(client)
     logged_messages = []
     allow(Rails.logger).to receive(:error) { |message| logged_messages << message }
 

--- a/spec/jobs/ai_transcription/generate_job_spec.rb
+++ b/spec/jobs/ai_transcription/generate_job_spec.rb
@@ -103,6 +103,21 @@ describe AiTranscription::GenerateJob do
         expect(ai_transcription.reload.status).to eq('error')
         expect(ai_transcription.error_message).to eq('RECITATION')
       end
+
+      context 'when the provider error includes a credential' do
+        let(:error) do
+          StandardError.new('the server responded with status 429 for URL https://provider.example/v1/models?alt=json&api_key=fake-secret&format=text')
+        end
+
+        it 'stores a useful error without the credential' do
+          expect { perform_worker }.to raise_error(StandardError)
+
+          message = ai_transcription.reload.metadata['error_message']
+          expect(message).to include('status 429')
+          expect(message).to include('provider.example/v1/models?alt=json&api_key=[FILTERED]&format=text')
+          expect(message).not_to include('fake-secret')
+        end
+      end
     end
 
     context 'API returns blank source_text and reasoning' do

--- a/spec/models/ai_transcription_spec.rb
+++ b/spec/models/ai_transcription_spec.rb
@@ -25,6 +25,19 @@ RSpec.describe AiTranscription, type: :model do
     end
   end
 
+  describe '#error_message' do
+    it 'redacts credentials from historical error metadata' do
+      ai_transcription.metadata = {
+        'error_message' => 'status 403: https://another-provider.example/path?access_token=fake-secret&key=another-secret'
+      }
+
+      expect(ai_transcription.error_message).to eq(
+        'status 403: https://another-provider.example/path?access_token=[FILTERED]&key=[FILTERED]'
+      )
+      expect(ai_transcription.error_message).not_to include('fake-secret', 'another-secret')
+    end
+  end
+
   describe '#normalize_source_text' do
     it 'replaces non-breaking spaces with regular spaces' do
       ai_transcription.source_text = 'Hello&nbsp;World'


### PR DESCRIPTION
### Motivation

- Prevent AI-provider credentials from being persisted to metadata, written to logs, or displayed in historical records by redacting common credential query params. 
- Ensure sanitization is hostname- and position-independent so secrets in any URL/query position are removed while preserving useful context like HTTP status and redacted URL. 
- Apply defense-in-depth so both runtime logging and persisted/presented error text are protected.

### Description

- Add a centralized sanitizer `AiTranscription::Lib::ErrorMessageSanitizer` that redacts `key`, `api_key`, `token`, and `access_token` query parameters wherever they appear. 
- Use the sanitizer in `AiTranscription::GenerateJob#store_error!` to sanitize messages before assigning `metadata['error_message']`. 
- Sanitize error messages before logging in the Gemini handler `AiTranscription::Lib::Gemini::TranscribeHandler` so credentials are not written to application logs. 
- Add defense-in-depth in `AiTranscription#error_message` to sanitize historical error metadata before presentation and add/modify specs covering job storage, handler logging, and model presentation to assert secrets are removed but status and redacted URL remain useful.

### Testing

- Ran `ruby -c` syntax checks on the changed Ruby files and specs which all reported `Syntax OK`.
- Executed a standalone Ruby check that called `AiTranscription::Lib::ErrorMessageSanitizer.sanitize(...)` to verify `key`, `api_key`, `token`, and `access_token` are redacted and it passed. 
- Ran `git diff --check` which passed without issues. 
- Attempted to run `bundle exec rspec ...` for the new/updated specs but the environment does not have the `rspec` executable available from the bundle, so the full RSpec suite could not be executed in this run (environment warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68c26a5ad48328949bc33ca4cb3f3d)