### PR TITLE
Fix PDF export title/lang metadata and restore strikethrough markup

### DIFF
--- a/app/interactors/work/export/printable.rb
+++ b/app/interactors/work/export/printable.rb
@@ -40,6 +40,8 @@ class Work::Export::Printable < ApplicationInteractor
       "--to=#{@format}",
       "--pdf-engine=#{PDF_ENGINE}",
       "--lua-filter=#{Rails.root.join('lib', 'pandoc', 'ftp_filters.lua')}",
+      '--metadata', "title=#{@work.title}",
+      '--metadata', 'lang=en',
       '--verbose'
     ]
 

--- a/lib/pandoc/ftp_filters.lua
+++ b/lib/pandoc/ftp_filters.lua
@@ -118,6 +118,9 @@ function handle_meta(meta)
 \usepackage{xltabular}
 \usepackage{booktabs}
 \usepackage[margin=0.75in]{geometry}
+
+% For strikethrough (deletion/strike-out markup from transcriptions)
+\usepackage[normalem]{ulem}
 ]]
 
   table.insert(meta['header-includes'], pandoc.RawBlock('latex', header))


### PR DESCRIPTION
## Summary
- Printable PDF exports were failing WCAG 2.1 checks PDF18 (missing document Title) and PDF16 (missing /Lang catalog entry). Root cause: pandoc discards the custom LaTeX preamble (`\hypersetup`, `\DocumentMetadata`, package list) when it re-renders the parsed document through its own template on the way to PDF, so those settings never reached the compiled PDF even though they were present in the generated `.tex` source. Fixed by passing `--metadata title=... --metadata lang=en` to pandoc, which does survive the round-trip.
- The same discarding mechanism was also dropping the `ulem` package, which silently degraded encoded strikethrough/deletion markup (TEI `<hi rend="str">`, `<strike>`, `<del>`) to plain, un-struck text. A `\providecommand{\sout}[1]{#1}` fallback in `printable.rb` was masking this by making `\sout` a no-op instead of failing loudly. Restored real `ulem` support via the Lua filter's `header-includes` injection — the one mechanism that does survive pandoc's rewrite.

## Test plan
- [x] Regenerated the `.tex` source for a real, complex multi-page work and compiled it through the actual `pandoc`/`lualatex` pipeline used in production.
- [x] Confirmed via `pdfinfo`/`mutool` that Title and `/Lang` now populate correctly in the output PDF.
- [x] Confirmed `ulem.sty` genuinely loads (per the compile log) rather than falling back to the no-op `\sout` definition, with no compile errors/warnings introduced.
- [ ] Existing spec suite (`spec/interactors/work/export/printable_spec.rb`) — could not run locally due to a pre-existing local MySQL credentials issue unrelated to this change; the modified code path (`perform`'s pandoc command array) isn't covered by that spec's assertions, which only exercise `tex_string`/`tex_string_for_conversion`.

Note: this does **not** address WCAG PDF9 (heading tags) or PDF3 (reading/tab order), which require a real tagged-PDF structure tree. That's tracked separately — see follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)