### PR TITLE
Rebuild prompt on bulk AI transcription create/retry for stale records

### DIFF
--- a/app/interactors/ai_transcription/bulk_create.rb
+++ b/app/interactors/ai_transcription/bulk_create.rb
@@ -32,11 +32,13 @@ class AiTranscription::BulkCreate < ApplicationInteractor
         )
       elsif ai_transcription.status_new?
         ai_transcription.status = :processing
+        ai_transcription.model = @sanitized_model
+        ai_transcription.prompt = @sanitized_prompt
         ai_transcription_records << ai_transcription
       end
     end
 
-    AiTranscription.import! ai_transcription_records, on_duplicate_key_update: [:status], batch_size: BATCH_SIZE
+    AiTranscription.import! ai_transcription_records, on_duplicate_key_update: [:status, :model, :prompt], batch_size: BATCH_SIZE
   end
 
   private

--- a/app/interactors/ai_transcription/bulk_retry.rb
+++ b/app/interactors/ai_transcription/bulk_retry.rb
@@ -16,6 +16,9 @@ class AiTranscription::BulkRetry < ApplicationInteractor
   def perform
     check_user_permission
 
+    @sanitized_model = sanitize_model
+    @sanitized_prompt = build_prompt
+
     ai_transcription_records = []
 
     pages.find_each do |page|
@@ -24,10 +27,12 @@ class AiTranscription::BulkRetry < ApplicationInteractor
       next unless ai_transcription.status_error?
 
       ai_transcription.status = :processing
+      ai_transcription.model = @sanitized_model
+      ai_transcription.prompt = @sanitized_prompt
       ai_transcription_records << ai_transcription
     end
 
-    AiTranscription.import! ai_transcription_records, on_duplicate_key_update: [:status], batch_size: BATCH_SIZE
+    AiTranscription.import! ai_transcription_records, on_duplicate_key_update: [:status, :model, :prompt], batch_size: BATCH_SIZE
 
     @ai_transcription_ids = ai_transcription_records.pluck(:id)
   end

--- a/spec/interactors/ai_transcription/bulk_create_spec.rb
+++ b/spec/interactors/ai_transcription/bulk_create_spec.rb
@@ -89,5 +89,20 @@ describe AiTranscription::BulkCreate do
         expect(prompts.none? { |prompt| prompt.include?(text_field.id.to_s) }).to be_truthy
       end
     end
+
+    context 'when a stale ai_transcription with a non-field-based prompt is still status new' do
+      let!(:ai_transcription) do
+        create(:ai_transcription, page_id: page_1.id, source_text: nil, status: :new, prompt: 'Please transcribe all the text you see in this image.')
+      end
+
+      it 'rebuilds the field-based prompt instead of reusing the stale one' do
+        expect(result.success?).to be_truthy
+
+        ai_transcription.reload
+        expect(ai_transcription.status_processing?).to be_truthy
+        expect(ai_transcription.prompt).to include(text_field.id.to_s, 'Name', select_field.id.to_s, 'County')
+        expect(ai_transcription.prompt).not_to include('Please transcribe all the text you see in this image.')
+      end
+    end
   end
 end

--- a/spec/interactors/ai_transcription/bulk_retry_spec.rb
+++ b/spec/interactors/ai_transcription/bulk_retry_spec.rb
@@ -44,4 +44,20 @@ describe AiTranscription::BulkRetry do
       expect(ai_transcription_2.reload.status_processing?).to be_truthy
     end
   end
+
+  context 'when the collection is field_based' do
+    let!(:collection) { create(:collection, :field_based, owner_user_id: owner.id, works: []) }
+    let!(:text_field) do
+      create(:transcription_field, :text_field,
+             label: 'Name', collection: collection, position: 1, line_number: 1)
+    end
+
+    it 'rebuilds the field-based prompt instead of reusing the stale errored prompt' do
+      expect(result.success?).to be_truthy
+
+      ai_transcription_2.reload
+      expect(ai_transcription_2.status_processing?).to be_truthy
+      expect(ai_transcription_2.prompt).to include(text_field.id.to_s, 'Name')
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- `AiTranscription::BulkCreate` (status `new` branch) and `AiTranscription::BulkRetry` were re-queuing existing `ai_transcription` records by only flipping `status` back to `processing`, without rebuilding `model`/`prompt`.
- For field-based collections, records that were created before the field-based prompt fix (#5738) landed still have the plain-text transcription prompt baked in. Retrying (or re-triggering create on a still-`new` record) kept reusing that stale prompt instead of the field-based one, so AI drafts kept failing with the wrong prompt even after #5738 was deployed.
- Both interactors now call `build_prompt` and write the fresh `model`/`prompt` onto each record before re-queuing, and the `import!` upsert now updates `:model, :prompt` in addition to `:status`.

## Test plan
- [x] `bundle exec rspec spec/interactors/ai_transcription/bulk_create_spec.rb spec/interactors/ai_transcription/bulk_retry_spec.rb` — 9 examples, 0 failures (includes two new regression tests covering a stale non-field-based prompt on a field-based collection getting rebuilt on create/retry).