### PR TITLE
Use IIIF info.json to request full-resolution images for AI when safe

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -42,6 +42,8 @@ require 'search_translator'
 require 'transkribus/page_processor'
 
 class Page < ApplicationRecord
+  AI_FULL_RESOLUTION_LIMIT = 8000
+
   ActiveRecord::Base.lock_optimistically = false
 
   include XmlSourceProcessor
@@ -667,7 +669,24 @@ class Page < ApplicationRecord
     size = "!#{max_dim},#{max_dim}"
     if sc_canvas
       if sc_canvas.sc_service_id.present?
-        "#{sc_canvas.sc_service_id.sub(/\/$/, '')}/full/#{size}/0/default.jpg"
+        service_id = sc_canvas.sc_service_id.sub(/\/$/, '')
+        begin
+          info = JSON.parse(URI.open("#{service_id}/info.json").read)
+          advertised_sizes = [info, *Array(info['sizes'])].filter_map do |image_info|
+            width, height = image_info.values_at('width', 'height').map(&:to_i)
+            [width, height] if width.positive? && height.positive?
+          end
+          maximum_width = advertised_sizes.map(&:first).max
+          maximum_height = advertised_sizes.map(&:last).max
+          dimensions_are_small = maximum_width.present? && maximum_height.present? &&
+                                 maximum_width < AI_FULL_RESOLUTION_LIMIT &&
+                                 maximum_height < AI_FULL_RESOLUTION_LIMIT
+          size = 'full' if dimensions_are_small
+        rescue StandardError => e
+          Rails.logger.warn("Unable to read IIIF image dimensions from #{service_id}/info.json: #{e.message}")
+        end
+
+        "#{service_id}/full/#{size}/0/default.jpg"
       else
         sc_canvas.sc_resource_id
       end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -279,6 +279,73 @@ describe Page do
     end
   end
 
+  describe '#image_url_for_ai' do
+    let(:service_id) { 'https://iiif.example.com/image/1' }
+    let(:sc_canvas) { double('sc_canvas', sc_service_id: service_id, sc_resource_id: "#{service_id}/full/full/0/default.jpg") }
+    let(:page) { build_stubbed(:page) }
+
+    before do
+      allow(page).to receive(:sc_canvas).and_return(sc_canvas)
+      stub_request(:get, "#{service_id}/info.json").to_return(
+        status: 200,
+        body: image_info.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+    end
+
+    context 'when the IIIF image is smaller than 8000 pixels in both dimensions' do
+      let(:image_info) do
+        {
+          width: 1651,
+          height: 2551,
+          sizes: [
+            { width: 103, height: 159 },
+            { width: 826, height: 1276 },
+            { width: 1651, height: 2551 }
+          ]
+        }
+      end
+
+      it 'requests the full-resolution image rather than a smaller advertised size' do
+        expect(page.image_url_for_ai).to eq("#{service_id}/full/full/0/default.jpg")
+      end
+    end
+
+    context 'when any advertised IIIF resolution is at least 8000 pixels' do
+      let(:image_info) do
+        {
+          width: 4000,
+          height: 6000,
+          sizes: [{ width: 5334, height: 8000 }]
+        }
+      end
+
+      it 'requests an image constrained to the AI maximum dimensions' do
+        expect(page.image_url_for_ai).to eq("#{service_id}/full/!7900,7900/0/default.jpg")
+      end
+    end
+
+    context 'when an IIIF image dimension is at least 8000 pixels' do
+      let(:image_info) { { width: 8000, height: 5000 } }
+
+      it 'requests an image constrained to the AI maximum dimensions' do
+        expect(page.image_url_for_ai).to eq("#{service_id}/full/!7900,7900/0/default.jpg")
+      end
+    end
+
+    context 'when the IIIF image information cannot be fetched' do
+      let(:image_info) { {} }
+
+      before do
+        stub_request(:get, "#{service_id}/info.json").to_return(status: 403)
+      end
+
+      it 'falls back to requesting an image constrained to the AI maximum dimensions' do
+        expect(page.image_url_for_ai).to eq("#{service_id}/full/!7900,7900/0/default.jpg")
+      end
+    end
+  end
+
   describe '#thumbnail_url' do
     context 'when page has base_image with special characters' do
       let(:page) { build_stubbed(:page) }


### PR DESCRIPTION
### Motivation

- Ensure AI requests fetch the true full-resolution IIIF image when the image's maximum advertised dimensions are below a safe threshold to avoid unnecessary downscaling.

### Description

- Add `AI_FULL_RESOLUTION_LIMIT = 8000` to `Page` to centralize the threshold for when to request full-resolution IIIF images.
- Update `image_url_for_ai` to fetch and parse the IIIF `info.json` for `sc_canvas.sc_service_id`, inspect `width`, `height`, and advertised `sizes`, and use `full` if both maximum width and height are below the `AI_FULL_RESOLUTION_LIMIT`.
- Fall back to the previous constrained size (`!{max_dim},{max_dim}`) when any advertised dimension meets or exceeds the limit, or when the `info.json` request fails, and log a warning on fetch errors.
- Refactor to store `service_id` in a local variable before use to avoid repeated `sub` calls.

### Testing

- Added RSpec examples in `spec/models/page_spec.rb` covering scenarios where IIIF `info.json` indicates small images, large advertised sizes, a large single dimension, and an inaccessible `info.json`, using `stub_request` for HTTP responses, and these tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6bb2bcf6c483229fab488071e4eb22)