### PR TITLE
Resolve parent record for compound CONTENTdm items when building IIIF URLs

### DIFF
--- a/lib/contentdm_translator.rb
+++ b/lib/contentdm_translator.rb
@@ -282,6 +282,8 @@ module ContentdmTranslator
       record = matches[2]
     end
 
+    record = cdm_parent_record(server, collection, record) || record if record
+
     # support back-level CONTENTdm IIIF presentation implementation
     if server && collection && record
       new_uri = "https://#{server}.contentdm.oclc.org/iiif/info/#{collection}/#{record}/manifest.json"
@@ -311,6 +313,23 @@ module ContentdmTranslator
 
     new_uri
   end
+
+  def self.cdm_parent_record(server, collection, record)
+    collection_path = URI.encode_www_form_component(collection)
+    item_url = "https://#{server}.contentdm.oclc.org/digital/api/singleitem/collection/#{collection_path}/id/#{record}"
+    item = JSON.parse(URI.open(item_url).read)
+    parent_id = item['parentId'] || item.dig('objectInfo', 'parentId')
+    return if parent_id.blank?
+
+    parent_id = parent_id.to_s
+    unless parent_id.match?(/\A-?\d+\z/)
+      raise ArgumentError, "CONTENTdm returned an invalid parent ID for record #{record}"
+    end
+    return unless parent_id.to_i.positive?
+
+    parent_id
+  end
+  private_class_method :cdm_parent_record
 
   def self.sample_manifest(collection)
     imported_work = collection.works.joins(:sc_manifest).last

--- a/spec/features/import_data_spec.rb
+++ b/spec/features/import_data_spec.rb
@@ -21,6 +21,9 @@ describe 'import data' do
     let(:bad_item_url) { 'https://hrc.contentdm.oclc.org/digital/collection/p15878coll90/id/41/rec/3' }
 
     it 'browses a single record' do
+      stub_request(:get, 'https://cdm16488.contentdm.oclc.org/digital/api/singleitem/collection/MPD01/id/2')
+        .to_return(body: '{"parentId":-1}')
+
       VCR.use_cassette('cdm/midpoint-shelwater-item', record: :none) do
         browse_contentdm(item_url)
 
@@ -45,6 +48,9 @@ describe 'import data' do
     end
 
     it 'gives an error for a well-formed CONTENTdm URL with an empty IIIF manifest' do
+      stub_request(:get, 'https://cdm15878.contentdm.oclc.org/digital/api/singleitem/collection/p15878coll90/id/41')
+        .to_return(body: '{"parentId":-1}')
+
       VCR.use_cassette('cdm/bad_iiif_manifest', record: :none) do
         browse_contentdm(bad_item_url)
 

--- a/spec/models/contentdm_translator_spec.rb
+++ b/spec/models/contentdm_translator_spec.rb
@@ -215,6 +215,12 @@ RSpec.describe ContentdmTranslator do
           example.run
         end
       end
+
+      before do
+        stub_request(:get, 'https://cdm17217.contentdm.oclc.org/digital/api/singleitem/collection/supreme_court/id/7076')
+          .to_return(body: '{"parentId":-1}')
+      end
+
       it "returns a message for a bad URL" do
         expect { ContentdmTranslator.cdm_url_to_iiif('BadUrl') }.to raise_error StandardError
       end
@@ -236,6 +242,11 @@ RSpec.describe ContentdmTranslator do
         VCR.use_cassette('cdm/digitalindy.org', record: :none) do
           example.run
         end
+      end
+
+      before do
+        stub_request(:get, 'https://cdm17308.contentdm.oclc.org/digital/api/singleitem/collection/ahs/id/200')
+          .to_return(body: '{"parentId":-1}')
       end
 
       it "item" do

--- a/spec/models/contentdm_translator_spec.rb
+++ b/spec/models/contentdm_translator_spec.rb
@@ -159,6 +159,56 @@ RSpec.describe ContentdmTranslator do
       end
     end
 
+    context 'when an item belongs to a compound object' do
+      let(:item_api_url) do
+        'https://kdl.contentdm.oclc.org/digital/api/singleitem/collection/tu-medtheses/id/4805'
+      end
+
+      before do
+        allow(ContentdmTranslator).to receive(:get_cdm_host_from_url).and_return('kdl')
+        allow(URI).to receive(:open).and_return(StringIO.new('{}'))
+      end
+
+      it 'uses the parent record manifest' do
+        allow(URI).to receive(:open).with(item_api_url).and_return(StringIO.new('{"parentId":"5000"}'))
+
+        url = ContentdmTranslator.cdm_url_to_iiif('https://kdl.contentdm.oclc.org/digital/collection/tu-medtheses/id/4805')
+
+        expect(url).to eq('https://kdl.contentdm.oclc.org/iiif/info/tu-medtheses/5000/manifest.json')
+      end
+
+      it 'supports parent IDs nested in object information' do
+        response = { objectInfo: { parentId: 5000 } }.to_json
+        allow(URI).to receive(:open).with(item_api_url).and_return(StringIO.new(response))
+
+        url = ContentdmTranslator.cdm_url_to_iiif('https://kdl.contentdm.oclc.org/digital/collection/tu-medtheses/id/4805')
+
+        expect(url).to eq('https://kdl.contentdm.oclc.org/iiif/info/tu-medtheses/5000/manifest.json')
+      end
+
+      it 'uses the requested record when it has no parent' do
+        allow(URI).to receive(:open).with(item_api_url).and_return(StringIO.new('{"parentId":-1}'))
+
+        url = ContentdmTranslator.cdm_url_to_iiif('https://kdl.contentdm.oclc.org/digital/collection/tu-medtheses/id/4805')
+
+        expect(url).to eq('https://kdl.contentdm.oclc.org/iiif/info/tu-medtheses/4805/manifest.json')
+      end
+
+      it 'rejects an invalid parent ID' do
+        allow(URI).to receive(:open).with(item_api_url).and_return(StringIO.new('{"parentId":"not-an-id"}'))
+
+        expect do
+          ContentdmTranslator.cdm_url_to_iiif('https://kdl.contentdm.oclc.org/digital/collection/tu-medtheses/id/4805')
+        end.to raise_error(ArgumentError, /invalid parent ID/)
+      end
+
+      it 'does not request item information for collection URLs' do
+        ContentdmTranslator.cdm_url_to_iiif('https://kdl.contentdm.oclc.org/digital/collection/tu-medtheses')
+
+        expect(URI).not_to have_received(:open).with(%r{/digital/api/singleitem/})
+      end
+    end
+
     context 'default' do
       around(:each) do |example|
         VCR.use_cassette('cdm/digital-alabama', record: :none) do


### PR DESCRIPTION
### Motivation

- Ensure ITEM-level CONTENTdm URLs that are part of compound objects return the parent object's IIIF manifest rather than the child record when appropriate.

### Description

- Add `cdm_parent_record` to call the CONTENTdm singleitem API, parse JSON for `parentId` (or nested `objectInfo.parentId`), validate it is a positive integer, and return it for use as the manifest record ID. 
- Invoke `cdm_parent_record` from `cdm_url_to_iiif` to replace the requested `record` with its parent when applicable without changing behavior for collection or repository URLs. 
- Make `cdm_parent_record` a private class method and add input validation that raises `ArgumentError` for invalid parent IDs. 
- Add RSpec tests covering parent ID resolution, nested `objectInfo` parent IDs, negative/no-parent handling, invalid parent ID rejection, and ensuring no API call is made for collection-only URLs.

### Testing

- Ran `bundle exec rspec spec/models/contentdm_translator_spec.rb` which executed the new compound-object examples and existing `cdm_url_to_iiif` specs. 
- All examples in `ContentdmTranslator` spec passed. 
- Mocked `URI.open` calls exercised both success and error paths for parent ID resolution and did not regress existing IIIF URL generation behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6bc6b89ef083229abc263aa609b206)