### PR TITLE
Segmentation UI: non-reflowing confirm popover + HITL split control

### DIFF
--- a/app/assets/images/symbols.svg
+++ b/app/assets/images/symbols.svg
@@ -133,6 +133,10 @@
     <polygon fill="currentColor" points="14,7 5.41,7 9.71,2.71 8.29,1.29 1.59,8 8.29,14.71 9.71,13.29 5.41,9 14,9"/>
   </symbol>
 
+  <symbol id="icon-scissors" viewBox="0 0 24 24" fill="none">
+    <g stroke-width="0"></g><g stroke-linecap="round" stroke-linejoin="round"></g><g > <circle cx="6" cy="6" r="3" stroke="currentColor" stroke-width="2"></circle><circle cx="6" cy="18" r="3" stroke="currentColor" stroke-width="2"></circle><line x1="20" y1="4" x2="8.12" y2="15.88" stroke="currentColor" stroke-width="2" stroke-linecap="round"></line><line x1="14.47" y1="14.48" x2="20" y2="20" stroke="currentColor" stroke-width="2" stroke-linecap="round"></line><line x1="8.12" y1="8.12" x2="12" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"></line> </g>
+  </symbol>
+
   <symbol id="icon-arrow-undo" viewBox="0 0 24 24" fill="none">
     <g stroke-width="0"></g><g stroke-linecap="round" stroke-linejoin="round"></g><g > <path d="M4 7H15C16.8692 7 17.8039 7 18.5 7.40193C18.9561 7.66523 19.3348 8.04394 19.5981 8.49999C20 9.19615 20 10.1308 20 12C20 13.8692 20 14.8038 19.5981 15.5C19.3348 15.9561 18.9561 16.3348 18.5 16.5981C17.8039 17 16.8692 17 15 17H8.00001M4 7L7 4M4 7L7 10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path> </g>
   </symbol>

--- a/app/assets/javascripts/transcribe.js.erb
+++ b/app/assets/javascripts/transcribe.js.erb
@@ -159,24 +159,56 @@ document.addEventListener('click', function(e) {
   }
 });
 
-// Segmentation banner toggle
+// Segmentation: AI-detected confirm popover (1a)
 window.addEventListener('DOMContentLoaded', function() {
   var toggleBtn = document.querySelector('[data-segmentation-toggle]');
+  var popover = document.querySelector('[data-segmentation-popover]');
   var cancelBtn = document.querySelector('[data-segmentation-cancel]');
-  var form = document.querySelector('[data-segmentation-form]');
 
-  if (toggleBtn && form) {
-    toggleBtn.addEventListener('click', function() {
-      form.style.display = 'block';
-      toggleBtn.closest('.segmentation-banner-actions').style.display = 'none';
-    });
+  if (!toggleBtn || !popover) { return; }
+
+  function handleOutsideClick(e) {
+    if (!popover.contains(e.target) && e.target !== toggleBtn) { closePopover(); }
   }
 
-  if (cancelBtn && form) {
-    cancelBtn.addEventListener('click', function() {
-      form.style.display = 'none';
-      var actions = document.querySelector('.segmentation-banner-actions');
-      if (actions) { actions.style.display = ''; }
-    });
+  function handleEscape(e) {
+    if (e.key === 'Escape') { closePopover(); }
   }
+
+  function openPopover() {
+    popover.classList.add('open');
+    document.addEventListener('click', handleOutsideClick);
+    document.addEventListener('keydown', handleEscape);
+  }
+
+  function closePopover() {
+    popover.classList.remove('open');
+    document.removeEventListener('click', handleOutsideClick);
+    document.removeEventListener('keydown', handleEscape);
+  }
+
+  toggleBtn.addEventListener('click', function(e) {
+    e.stopPropagation();
+    if (popover.classList.contains('open')) {
+      closePopover();
+    } else {
+      openPopover();
+    }
+  });
+
+  if (cancelBtn) {
+    cancelBtn.addEventListener('click', closePopover);
+  }
+});
+
+// Segmentation: human-in-the-loop split control (1b)
+window.addEventListener('DOMContentLoaded', function() {
+  var splitToggleBtn = document.querySelector('[data-segmentation-split-toggle]');
+  var splitStrip = document.querySelector('[data-segmentation-split-strip]');
+
+  if (!splitToggleBtn || !splitStrip) { return; }
+
+  splitToggleBtn.addEventListener('click', function() {
+    splitStrip.classList.toggle('open');
+  });
 });

--- a/app/assets/stylesheets/sections/page.scss
+++ b/app/assets/stylesheets/sections/page.scss
@@ -960,35 +960,73 @@
     display: flex;
     gap: 0.5rem;
   }
+}
 
-  .segmentation-split-form {
-    margin-top: 0.75rem;
-    padding-top: 0.75rem;
-    border-top: 1px solid #f0c040;
+// Segmentation: human-in-the-loop split control (1b)
+.segmentation-split-strip {
+  display: none;
 
-    .segmentation-split-form-row {
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
-      flex-wrap: wrap;
-      margin-bottom: 0.5rem;
+  &.open {
+    display: block;
+    animation: segmentation-split-strip-in 0.15s ease-out;
+  }
+}
 
-      label {
-        font-weight: normal;
-        white-space: nowrap;
-      }
+@keyframes segmentation-split-strip-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
 
-      .segmentation-title-input {
-        flex: 1;
-        min-width: 200px;
-      }
+// Segmentation: AI confirm popover (1a)
+.segmentation-popover-anchor {
+  position: relative;
+  display: inline-block;
+}
 
-      input[type="submit"], button {
-        flex-shrink: 0;
-        white-space: nowrap;
-        width: auto;
-        padding: 0 1.25em;
-      }
-    }
+.segmentation-popover {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 20;
+  width: 300px;
+  margin-top: 0.5rem;
+  padding: 0.875rem;
+  background: #fff;
+  border-radius: 6px;
+  border: 1px solid rgba(#000, 0.15);
+  box-shadow: 0 8px 24px rgba(#000, 0.2);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-4px);
+  transition: opacity 0.15s, visibility 0.15s, transform 0.15s;
+
+  &.open {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+  }
+
+  form { margin: 0; }
+
+  .segmentation-popover-label {
+    display: block;
+    margin-bottom: 0.375rem;
+    font-weight: bold;
+    font-size: 0.85em;
+    color: $bodyFgDark;
+  }
+
+  .segmentation-title-input {
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .segmentation-popover-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 0.625rem;
+
+    button { flex-shrink: 0; width: auto; padding: 0 1.25em; }
   }
 }

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -502,6 +502,10 @@ class Work < ApplicationRecord
     next_untranscribed_page.present?
   end
 
+  def segmentation_candidates?
+    pages.where(is_first_page_candidate: true).exists?
+  end
+
   def process_fields(field_cells)
     metadata_fields = []
     # new_table_cells = []

--- a/app/views/transcribe/_segmentation_banner.html.slim
+++ b/app/views/transcribe/_segmentation_banner.html.slim
@@ -5,18 +5,17 @@
         p.segmentation-banner-message =t('transcribe.display_page.segmentation_candidate')
 
         .segmentation-banner-actions
-          button.button.action-btn(data-segmentation-toggle)
-            =t('transcribe.display_page.segmentation_yes')
+          .segmentation-popover-anchor
+            button.button.action-btn(type='button' data-segmentation-toggle)
+              =t('transcribe.display_page.segmentation_yes')
+            .segmentation-popover(data-segmentation-popover)
+              =form_with(url: split_page_collection_work_path(collection.owner, collection, work), method: :post) do |f|
+                =hidden_field_tag :page_id, page.id
+                =label_tag :new_work_title, t('transcribe.display_page.previous_work_title', n: page.position - 1), class: 'segmentation-popover-label'
+                =text_field_tag :new_work_title, default_split_title(work), class: 'segmentation-title-input'
+                .segmentation-popover-actions
+                  button.button.outline(type='button' data-segmentation-cancel)
+                    =t('transcribe.display_page.segmentation_cancel')
+                  =f.submit t('transcribe.display_page.segmentation_confirm'), class: 'button action-btn'
           =link_to(dismiss_segmentation_collection_work_path(collection.owner, collection, work, page_id: page.id), class: 'button outline', data: { turbo: true, turbo_method: :patch })
             =t('transcribe.display_page.segmentation_no')
-
-      .segmentation-split-form[style='display:none' data-segmentation-form]
-        =form_with(url: split_page_collection_work_path(collection.owner, collection, work), method: :post) do |f|
-          =hidden_field_tag :page_id, page.id
-          .segmentation-split-form-row
-            =label_tag :new_work_title, t('transcribe.display_page.previous_work_title')
-            =text_field_tag :new_work_title, default_split_title(work), class: 'segmentation-title-input'
-          .segmentation-split-form-row
-            =f.submit t('transcribe.display_page.segmentation_confirm'), class: 'button action-btn'
-            button.button.outline(type='button' data-segmentation-cancel)
-              =t('transcribe.display_page.segmentation_cancel')

--- a/app/views/transcribe/_segmentation_split_strip.html.slim
+++ b/app/views/transcribe/_segmentation_split_strip.html.slim
@@ -1,0 +1,6 @@
+= turbo_frame_tag "segmentation-split-strip-#{page.id}"
+  .segmentation-banner.segmentation-split-strip(data-segmentation-split-strip)
+    .segmentation-banner-content
+      p.segmentation-banner-message =t('transcribe.display_page.segmentation_split_confirm_message')
+      .segmentation-banner-actions
+        =link_to(t('transcribe.display_page.segmentation_split_confirm_button'), split_page_collection_work_path(collection.owner, collection, work, page_id: page.id), class: 'button action-btn', data: { turbo: true, turbo_method: :post })

--- a/app/views/transcribe/_segmentation_success.html.slim
+++ b/app/views/transcribe/_segmentation_success.html.slim
@@ -1,4 +1,4 @@
-.segmentation-banner[id="segmentation-banner-#{page.id}"]
+.segmentation-banner
   .segmentation-banner-content
     p.segmentation-banner-message =t('transcribe.display_page.segmentation_success', title: new_work_title, count: count)
     .segmentation-banner-actions

--- a/app/views/transcribe/display_page.html.slim
+++ b/app/views/transcribe/display_page.html.slim
@@ -65,7 +65,15 @@
           =f.label 'needs_review', t('.needs_review')
           =f.check_box('needs_review', {checked: @page.status_needs_review?})
 
+      -if @page.position > 1 && @work.segmentation_candidates?
+        .flex-toolbar_group
+          button.button.outline(type='button' data-segmentation-split-toggle title=t('.split_into_new_work') aria-label=t('.split_into_new_work'))
+            =svg_symbol "#icon-scissors", class: 'icon'
+
       =render partial: 'save_buttons'
+
+  -if @page.position > 1 && @work.segmentation_candidates?
+    =render partial: 'transcribe/segmentation_split_strip', locals: { page: @page, work: @work, collection: @collection }
 
   -if @page.status_needs_review? && current_user.can_review?(@collection)
     .page-review

--- a/app/views/work/split_page.html.slim
+++ b/app/views/work/split_page.html.slim
@@ -1,8 +1,5 @@
 = turbo_frame_tag "segmentation-banner-#{@split_page.id}"
-  .segmentation-banner
-    .segmentation-banner-content
-      p.segmentation-banner-message =t('transcribe.display_page.segmentation_success', title: @new_work_title, count: @split_count)
-      .segmentation-banner-actions
-        =link_to(t('transcribe.display_page.segmentation_view_work'), collection_read_work_path(@collection.owner, @collection, @new_work), class: 'button outline', data: { turbo_frame: '_top' })
-        button.button.outline(type='button' data-segmentation-dismiss)
-          =t('transcribe.display_page.segmentation_dismiss')
+  =render partial: 'transcribe/segmentation_success', locals: { page: @split_page, new_work_title: @new_work_title, count: @split_count, collection: @collection, new_work: @new_work }
+
+= turbo_frame_tag "segmentation-split-strip-#{@split_page.id}"
+  =render partial: 'transcribe/segmentation_success', locals: { page: @split_page, new_work_title: @new_work_title, count: @split_count, collection: @collection, new_work: @new_work }

--- a/config/locales/transcribe/transcribe-en.yml
+++ b/config/locales/transcribe/transcribe-en.yml
@@ -38,12 +38,15 @@ en:
       segmentation_candidate: This looks like a new document. Separate this into a new work?
       segmentation_yes: 'Yes, split here'
       segmentation_no: 'No'
-      segmentation_confirm: Create new work with previous pages
+      segmentation_confirm: Split
       segmentation_cancel: Cancel
-      previous_work_title: Work title for the previous segment of pages
+      previous_work_title: 'Title for pages 1–%{n}'
       segmentation_success: 'Created "%{title}" with %{count} pages.'
       segmentation_view_work: View new work
       segmentation_dismiss: Dismiss
+      split_into_new_work: Split into new work
+      segmentation_split_confirm_message: Split this into a new work starting here?
+      segmentation_split_confirm_button: Confirm split
     goto_next_untranscribed_page:
       another_page_notice: Here's another page in this work.
       no_more_pages_notice: There are no more pages to transcribe in this work. Here's another page in this collection.

--- a/spec/features/segmentation_spec.rb
+++ b/spec/features/segmentation_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'work segmentation UI' do
+  let(:owner) { create(:unique_user, :owner) }
+  let(:collection) { create(:collection, owner_user_id: owner.id, works: []) }
+  let(:work) { create(:work, collection: collection, owner: owner) }
+
+  before do
+    login_as(owner, scope: :user)
+  end
+
+  after do
+    Collection.where(owner_user_id: owner.id).find_each(&:destroy!) if owner&.persisted?
+  end
+
+  describe 'AI-detected split confirmation popover (1a)', js: true do
+    let!(:first_page) { create(:page, work: work, position: 1, title: 'Letters to Rosannah, part one') }
+    let!(:flagged_page) { create(:page, work: work, position: 2, is_first_page_candidate: true) }
+
+    it 'opens a non-reflowing popover instead of expanding the banner in place' do
+      visit collection_transcribe_page_path(owner, collection, work, flagged_page)
+
+      expect(page).to have_content('This looks like a new document. Separate this into a new work?')
+      expect(page).to have_no_css('.segmentation-popover.open')
+
+      page.find('[data-segmentation-toggle]').click
+      expect(page).to have_css('.segmentation-popover.open')
+      expect(page.find('.segmentation-popover-label')).to have_content('Title for pages 1–1')
+      expect(page.find_field('new_work_title').value).to eq('Letters to Rosannah, part one')
+
+      within('.segmentation-popover') { click_button 'Cancel' }
+      expect(page).to have_no_css('.segmentation-popover.open')
+      expect(work.reload.pages.count).to eq(2)
+
+      page.find('[data-segmentation-toggle]').click
+      within('.segmentation-popover') { click_button 'Split' }
+
+      expect(page).to have_content('Created "Letters to Rosannah, part one" with 1 pages.')
+      expect(work.reload.pages.count).to eq(1)
+    end
+  end
+
+  describe 'human-in-the-loop split control (1b)', js: true do
+    context 'when nothing in the work has been AI-flagged' do
+      let!(:first_page) { create(:page, work: work, position: 1) }
+      let!(:second_page) { create(:page, work: work, position: 2) }
+
+      it 'does not show the scissors icon' do
+        visit collection_transcribe_page_path(owner, collection, work, second_page)
+
+        expect(page).to have_no_css('[data-segmentation-split-toggle]')
+      end
+    end
+
+    context 'when another page in the work was flagged but the current page was not' do
+      let!(:first_page) { create(:page, work: work, position: 1, title: 'Letter one') }
+      let!(:second_page) { create(:page, work: work, position: 2) }
+      let!(:third_page) { create(:page, work: work, position: 3, is_first_page_candidate: true) }
+
+      it 'shows a quiet scissors control that confirms a split without the AI banner' do
+        visit collection_transcribe_page_path(owner, collection, work, second_page)
+
+        expect(page).to have_no_content('This looks like a new document.')
+        expect(page).to have_css('[data-segmentation-split-toggle]')
+        expect(page).to have_no_css('.segmentation-split-strip')
+
+        page.find('[data-segmentation-split-toggle]').click
+        expect(page).to have_css('.segmentation-split-strip')
+        expect(page).to have_content('Split this into a new work starting here?')
+
+        within('.segmentation-split-strip') { click_link 'Confirm split' }
+
+        expect(page).to have_content('Created "Letter one" with 1 pages.')
+        expect(work.reload.pages.count).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -22,6 +22,24 @@ describe Work do
       expect(work.supports_indexing?).to be false
     end
   end
+  describe '#segmentation_candidates?' do
+    let(:work) { create(:work, owner_user_id: 1) }
+
+    it "returns false when no pages have been flagged as first-page candidates" do
+      create(:page, work_id: work.id, position: 1, is_first_page_candidate: false)
+      create(:page, work_id: work.id, position: 2, is_first_page_candidate: nil)
+
+      expect(work.segmentation_candidates?).to be false
+    end
+
+    it "returns true when at least one page is flagged as a first-page candidate" do
+      create(:page, work_id: work.id, position: 1, is_first_page_candidate: false)
+      create(:page, work_id: work.id, position: 2, is_first_page_candidate: true)
+
+      expect(work.segmentation_candidates?).to be true
+    end
+  end
+
   describe '#set/update_next_untranscribed_page' do
     let(:work) { create(:work, owner_user_id: 1) }
     it "sets nil with no pages" do


### PR DESCRIPTION
## Summary
Implements the two UI changes from the design handoff (`Work segmentation UI options.zip`):

- **1a — AI confirm popover**: clicking "Yes, split here" on the AI-detected banner now opens a small floating popover (anchored to the Yes button) instead of expanding the banner in place and pushing page content down. Title input is prefilled via the existing `default_split_title` convention, labeled "Title for pages 1–N". The only commit verb used throughout is "Split". Closes on Cancel, outside click, or Escape.
- **1b — Human-in-the-loop split control**: adds a quiet scissors icon button to the transcription toolbar (after "Needs Review", before Save/Done). Per feedback during review, this only appears on works where segmentation is already "in play" — i.e. `Work#segmentation_candidates?` is true for at least one page in the work — rather than on every page, so it doesn't add noise to unrelated works. Clicking it toggles a confirm strip reusing the same banner visual language; confirming posts to the existing `split_page` action.

## Notable implementation details
- The 1b confirm strip is rendered inside `display_page.html.slim`'s outer transcription `form_for` block. A nested `<form>` there gets silently dropped by the browser's HTML parser (forms can't nest), so the confirm action uses a Turbo `data-turbo-method="post"` link instead — same pattern already used by the existing "No" dismiss link.
- The strip lives in its own `turbo-frame` (`segmentation-split-strip-#{page.id}`) since `Turbo.session.drive = false` is set app-wide, which disables the app-level fallback that would otherwise let an out-of-frame form target a frame via `data-turbo-frame`.
- `split_page.html.slim` now renders the (previously unused) `_segmentation_success` partial into both the AI-banner frame and the split-strip frame, so either trigger path shows the same success confirmation.

## Test plan
- [x] New model spec: `Work#segmentation_candidates?`
- [x] New JS feature spec (`spec/features/segmentation_spec.rb`, real Chrome driver via existing Capybara/Selenium setup) covering both flows end-to-end, including the "no scissors icon when nothing is flagged" case
- [x] `spec/features/editor_actions_spec.rb` (existing transcribe-page suite) still passes — no regressions in the surrounding toolbar
- [x] Slim templates, SCSS, and JS syntax-checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)