### PR TITLE
Escape invalid XML in spreadsheet transcription cells

### DIFF
--- a/spec/interactors/transcription_field/lib/utils_spec.rb
+++ b/spec/interactors/transcription_field/lib/utils_spec.rb
@@ -31,7 +31,7 @@ describe TranscriptionField::Lib::Utils do
 
       parsed_page = described_class.parse_fields(page: page, field_cells: field_cells)
 
-      expect(parsed_page.transcription_json[spreadsheet_field.id].first[text_column.id])
+      expect(parsed_page.transcription_json[spreadsheet_field.id.to_s].first[text_column.id.to_s])
         .to eq('&lt;test&gt;')
       expect(parsed_page.source_text).to include('&lt;test&gt;')
     end
@@ -45,7 +45,7 @@ describe TranscriptionField::Lib::Utils do
 
       parsed_page = described_class.parse_fields(page: page, field_cells: field_cells)
 
-      expect(parsed_page.transcription_json[spreadsheet_field.id].first[text_column.id])
+      expect(parsed_page.transcription_json[spreadsheet_field.id.to_s].first[text_column.id.to_s])
         .to eq('<hi>ok</hi>')
       expect(parsed_page.source_text).to include('<hi>ok</hi>')
     end


### PR DESCRIPTION
### Motivation
- Spreadsheet cell values that resemble XML must be validated so that malformed tags are escaped while well-formed inline XML is preserved. 
- The `transcription_json` is serialized with string keys, so tests must assert using string IDs to match the stored format.

### Description
- Added `sanitize_spreadsheet_cell` which attempts to parse a `<cell>...</cell>` wrapper with `REXML::Document` and returns the original value or HTML-escapes it on `REXML::ParseException` via `ERB::Util.html_escape`.
- Updated `parse_spreadsheet` to call `sanitize_spreadsheet_cell` for nonblank cell values before boolean casting and JSON/HTML output.
- Adjusted test assertions to access `transcription_json` using string keys (`field.id.to_s` and `column.id.to_s`) to match the serialized JSON representation and added specs that verify escaping of invalid XML-like content and preservation of valid inline XML.

### Testing
- `git diff --check` passed with no whitespace errors.
- `ruby -c spec/interactors/transcription_field/lib/utils_spec.rb` returned `Syntax OK` for the spec file.
- `ruby -c app/interactors/transcription_field/lib/utils.rb` returned `Syntax OK` for the updated code.
- `bundle exec rspec spec/interactors/transcription_field/lib/utils_spec.rb` could not be executed in this environment because the `rspec` executable from the installed bundle was unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e552ed9d4832281c9dad53c335d7a)