### PR TITLE
Define composite primary key for DocumentSetWork to fix destroy predicate

### DIFF
--- a/app/models/document_set_work.rb
+++ b/app/models/document_set_work.rb
@@ -11,6 +11,7 @@
 #
 class DocumentSetWork < ApplicationRecord
   self.table_name = 'document_sets_works'
+  self.primary_key = [:document_set_id, :work_id]
 
   belongs_to :document_set, counter_cache: :works_count, optional: true
   belongs_to :work, optional: true


### PR DESCRIPTION
### Motivation
- ActiveRecord was generating an invalid `DELETE` predicate for `document_sets_works` because the join model had no primary key, causing `destroy_all` to fail and preventing `DocumentSet` callbacks that recalculate `next_untranscribed_page` from running.

### Description
- Add `self.primary_key = [:document_set_id, :work_id]` to `app/models/document_set_work.rb` so Active Record uses both columns when deleting join records.

### Testing
- Ran `ruby -c app/models/document_set_work.rb` which returned `Syntax OK`.
- Ran `git diff --check` with no issues reported.
- Attempted `bundle exec rspec spec/models/document_set_spec.rb:71` but it could not run here due to a Ruby version mismatch (environment has Ruby 3.4.4 while the `Gemfile` requires Ruby 3.3.5), so the failing spec was not re-executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f450edb8c8322bd0d87c7efdefbfb)