### PR TITLE
Add covering index for AI transcription dashboard aggregates

### DIFF
--- a/app/models/ai_transcription.rb
+++ b/app/models/ai_transcription.rb
@@ -29,6 +29,7 @@
 #
 # Indexes
 #
+#  idx_ai_transcriptions_dashboard                   (created_at,model,status)
 #  index_ai_transcriptions_on_page_id                (page_id)
 #  index_ai_transcriptions_on_page_id_and_id         (page_id,id)
 #  index_ai_transcriptions_on_status                 (status)

--- a/db/migrate/20260803000000_add_dashboard_index_to_ai_transcriptions.rb
+++ b/db/migrate/20260803000000_add_dashboard_index_to_ai_transcriptions.rb
@@ -1,0 +1,7 @@
+class AddDashboardIndexToAiTranscriptions < ActiveRecord::Migration[7.2]
+  def change
+    add_index :ai_transcriptions,
+              [:created_at, :model, :status],
+              name: 'idx_ai_transcriptions_dashboard'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_22_222940) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_03_000000) do
   create_table "active_storage_attachments", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -85,6 +85,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_22_222940) do
     t.decimal "text_wer_distance", precision: 10
     t.decimal "text_wer_length", precision: 10
     t.decimal "verbatim_non_stopword_accuracy", precision: 10
+    t.index ["created_at", "model", "status"], name: "idx_ai_transcriptions_dashboard"
     t.index ["page_id", "id"], name: "index_ai_transcriptions_on_page_id_and_id"
     t.index ["page_id"], name: "index_ai_transcriptions_on_page_id"
     t.index ["status", "updated_at"], name: "index_ai_transcriptions_on_status_and_updated_at"


### PR DESCRIPTION
### Motivation

- Dashboard aggregation queries group AI transcription rows by `created_at`, `model`, and `status`, and need a covering index to avoid full table scans on production-sized data.
- The change provides an explicit, concise index name to make DBA review and EXPLAIN comparisons easier.

### Description

- Add migration `db/migrate/20260803000000_add_dashboard_index_to_ai_transcriptions.rb` that creates a named composite index `idx_ai_transcriptions_dashboard` on `ai_transcriptions(created_at, model, status)`.
- Update `db/schema.rb` to record the new index and bump the schema version to `2026_08_03_000000`.
- Update the `AiTranscription` model file annotation to list the new `idx_ai_transcriptions_dashboard` index.

### Testing

- Ran `ruby -c db/migrate/20260803000000_add_dashboard_index_to_ai_transcriptions.rb` and `git diff --check`, both of which succeeded locally.
- Attempted the normal migrate workflow with `bin/rails db:migrate`, which initially failed due to a Ruby version mismatch and then the bundle install/migrate attempt failed because `rmagick` requires ImageMagick development libraries unavailable in this environment, so the migration could not be applied locally.
- Pre-deployment validation required: run `EXPLAIN` for the exact grouped dashboard query against production-like data and confirm an index range scan (not a full table scan), and compare the composite covering index against a `created_at`-only index using both `EXPLAIN` and measured query times before deciding to keep the wider index.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a700036f2dc83228ac8fdc2e8481e66)