### PR TITLE
Enhance the AI character disagreement report

### DIFF
--- a/lib/tasks/ai_disagreement_report.rake
+++ b/lib/tasks/ai_disagreement_report.rake
@@ -1,8 +1,8 @@
 namespace :fromthepage do
   desc 'Generate a CSV of Claude vs Gemini AI transcription disagreement rates for pages in a work or collection'
-  task :ai_disagreement_report, [:slug] => :environment do |_t, args|
+  task :ai_disagreement_report, [:slug, :ignored_fields] => :environment do |_t, args|
     unless args.slug
-      puts 'Usage: rake fromthepage:ai_disagreement_report[slug]'
+      puts 'Usage: rake fromthepage:ai_disagreement_report[slug,ignored_field_labels_or_ids]'
       puts 'Example: rake fromthepage:ai_disagreement_report[my-work-slug]'
       puts 'Example: rake fromthepage:ai_disagreement_report[my-collection-slug]'
       exit 1
@@ -24,6 +24,15 @@ namespace :fromthepage do
                                      .includes(:spreadsheet_columns)
                                      .order(:line_number, :position)
                                      .reject { |field| %w[description instruction].include?(field.input_type) }
+    ignored_field_identifiers = [args.ignored_fields, *args.extras]
+      .compact
+      .flat_map { |value| value.to_s.split(',') }
+      .map(&:strip)
+      .reject(&:blank?)
+    ignored_fields = report_fields.select do |field|
+      ignored_field_identifiers.include?(field.label) || ignored_field_identifiers.include?(field.id.to_s)
+    end
+    overall_fields = report_fields - ignored_fields
 
     field_value_for_comparison = lambda do |field, json|
       return '' if json.blank?
@@ -43,7 +52,13 @@ namespace :fromthepage do
     end
 
     normalize_text = lambda do |text|
-      text.to_s.gsub(/[[:punct:]]/, ' ').downcase.gsub(/\s+/, ' ').strip
+      text.to_s.gsub(/[[:punct:]]/, '').downcase.gsub(/\s+/, ' ').strip
+    end
+
+    labeled_text_for_comparison = lambda do |fields, transcription|
+      fields.map do |field|
+        "#{field.label}: #{field_value_for_comparison.call(field, transcription.transcription_json)}"
+      end.join("\n")
     end
 
     field_headers = report_fields.flat_map do |field|
@@ -53,7 +68,7 @@ namespace :fromthepage do
     filename = "ai_disagreement_#{slug}.csv"
 
     CSV.open(filename, 'wb') do |csv|
-      csv << ['Work Title', 'Page Title', 'Page ID', 'AI Tab URL', 'Transcribe Tab URL', 'Character Disagreement Rate', 'Misplaced FIelds', 'Case-insensitive CDR', 'Claude Text-only CER', 'Gemini Text-only CER', *field_headers, 'Missing Models']
+      csv << ['Work Title', 'Page Title', 'Page ID', 'Page Status', 'AI Tab URL', 'Transcribe Tab URL', 'Character Disagreement Rate', 'Misplaced FIelds', 'Case-insensitive CDR', 'Claude Text-only CER', 'Gemini Text-only CER', *field_headers, 'Missing Models']
 
       pages.each do |page|
         page_work = page.work
@@ -67,11 +82,11 @@ namespace :fromthepage do
         missing_models << 'Claude' if claude_transcription.nil?
         missing_models << 'Gemini' if gemini_transcription.nil?
 
-        disagreement_rate = if missing_models.empty?
-          page.send(:character_error_rate, claude_transcription.text_for_comparison, gemini_transcription.text_for_comparison)
-        end
-        ci_disagreement_rate = if missing_models.empty?
-          page.send(:character_error_rate, claude_transcription.text_for_comparison.downcase, gemini_transcription.text_for_comparison.downcase)
+        if missing_models.empty?
+          claude_labeled_text = labeled_text_for_comparison.call(overall_fields, claude_transcription)
+          gemini_labeled_text = labeled_text_for_comparison.call(overall_fields, gemini_transcription)
+          disagreement_rate = page.send(:character_error_rate, claude_labeled_text, gemini_labeled_text)
+          ci_disagreement_rate = page.send(:character_error_rate, claude_labeled_text.downcase, gemini_labeled_text.downcase)
         end
 
         field_disagreement_rates = report_fields.flat_map do |field|
@@ -86,12 +101,15 @@ namespace :fromthepage do
             [nil, nil]
           end
         end
-        misplaced_fields = field_disagreement_rates.each_slice(2).any? { |_cdr, text_only_cdr| text_only_cdr == 100.0 } ? 'yes' : 'no'
+        misplaced_fields = report_fields.zip(field_disagreement_rates.each_slice(2)).any? do |field, (_cdr, text_only_cdr)|
+          !ignored_fields.include?(field) && text_only_cdr == 100.0
+        end ? 'yes' : 'no'
 
         csv << [
           page_work.title,
           page.title,
           page.id,
+          page.status,
           Rails.application.routes.url_helpers.collection_ai_text_page_url(page_collection.owner, page_collection, page_work, page),
           "#{Rails.application.routes.url_helpers.collection_transcribe_page_url(page_collection.owner, page_collection, page_work, page)}?ai_draft=1",
           disagreement_rate,

--- a/spec/tasks/ai_disagreement_report_spec.rb
+++ b/spec/tasks/ai_disagreement_report_spec.rb
@@ -12,30 +12,30 @@ describe 'fromthepage:ai_disagreement_report' do
   let(:work) { create(:work, collection: collection) }
   let(:field) { create(:transcription_field, :as_transcription, :text_field, collection: collection, label: 'Body') }
 
-  def create_transcription(page:, model:, field_text:, text_cer: nil)
+  def create_transcription(page:, model:, field_text:, text_cer: nil, transcription_json: nil)
     create(
       :ai_transcription,
       page: page,
       model: model,
       status: :finished,
       source_text: field_text,
-      transcription_json: { field.id.to_s => field_text },
+      transcription_json: transcription_json || { field.id.to_s => field_text },
       text_cer: text_cer
     )
   end
 
-  def run_report
+  def run_report(*ignored_fields)
     Rake::Task['fromthepage:ai_disagreement_report'].reenable
     Dir.mktmpdir do |directory|
       Dir.chdir(directory) do
-        Rake::Task['fromthepage:ai_disagreement_report'].invoke(work.slug)
+        Rake::Task['fromthepage:ai_disagreement_report'].invoke(work.slug, *ignored_fields)
         return CSV.read("ai_disagreement_#{work.slug}.csv", headers: true)
       end
     end
   end
 
   it 'reports each model text-only CER and identifies fields with 100% text-only disagreement' do
-    misplaced_page = create(:page, work: work)
+    misplaced_page = create(:page, work: work, status: :needs_review)
     aligned_page = create(:page, work: work)
     create_transcription(page: misplaced_page, model: 'claude-sonnet', field_text: 'alpha', text_cer: 12)
     create_transcription(page: misplaced_page, model: 'gemini-pro', field_text: 'zzzzz', text_cer: 57)
@@ -47,6 +47,7 @@ describe 'fromthepage:ai_disagreement_report' do
     aligned_row = rows.find { |row| row['Page ID'] == aligned_page.id.to_s }
 
     expect(rows.headers).to include('Claude Text-only CER', 'Gemini Text-only CER')
+    expect(misplaced_row['Page Status']).to eq('needs_review')
     expect(rows.headers.index('Misplaced FIelds')).to eq(rows.headers.index('Character Disagreement Rate') + 1)
     expect(misplaced_row['Claude Text-only CER']).to eq('12')
     expect(misplaced_row['Gemini Text-only CER']).to eq('57')
@@ -55,5 +56,56 @@ describe 'fromthepage:ai_disagreement_report' do
     expect(aligned_row['Claude Text-only CER']).to be_nil
     expect(aligned_row['Gemini Text-only CER']).to be_nil
     expect(aligned_row['Misplaced FIelds']).to eq('no')
+  end
+
+  it 'removes punctuation and whitespace when calculating per-field text-only CDR' do
+    page = create(:page, work: work)
+    create_transcription(page: page, model: 'claude-sonnet', field_text: 'Hello, world!')
+    create_transcription(page: page, model: 'gemini-pro', field_text: "hello world")
+
+    row = run_report.first
+
+    expect(row['Body CDR']).not_to eq('0.0')
+    expect(row['Body Text-only CDR']).to eq('0.0')
+  end
+
+  it 'keeps ignored fields in per-field columns but excludes labels and ids from overall calculations' do
+    ignored_by_label = create(:transcription_field, :as_transcription, :text_field, collection: collection, label: 'Ignore Label')
+    ignored_by_id = create(:transcription_field, :as_transcription, :text_field, collection: collection, label: 'Ignore ID')
+    page = create(:page, work: work)
+    claude_json = { field.id.to_s => 'same', ignored_by_label.id.to_s => 'alpha', ignored_by_id.id.to_s => 'one' }
+    gemini_json = { field.id.to_s => 'same', ignored_by_label.id.to_s => 'zzzzz', ignored_by_id.id.to_s => 'two' }
+    create_transcription(page: page, model: 'claude-sonnet', field_text: 'unused', transcription_json: claude_json)
+    create_transcription(page: page, model: 'gemini-pro', field_text: 'unused', transcription_json: gemini_json)
+
+    row = run_report('Ignore Label', ignored_by_id.id.to_s).first
+
+    expect(row['Character Disagreement Rate']).to eq('0.0')
+    expect(row['Case-insensitive CDR']).to eq('0.0')
+    expect(row['Misplaced FIelds']).to eq('no')
+    expect(row['Ignore Label Text-only CDR']).to eq('100.0')
+    expect(row['Ignore ID CDR']).not_to be_nil
+  end
+
+  it 'includes field labels in overall case-sensitive and case-insensitive comparisons' do
+    second_field = create(:transcription_field, :as_transcription, :text_field, collection: collection, label: 'Other')
+    page = create(:page, work: work)
+    create_transcription(
+      page: page,
+      model: 'claude-sonnet',
+      field_text: 'same source text',
+      transcription_json: { field.id.to_s => 'alpha', second_field.id.to_s => 'beta' }
+    )
+    create_transcription(
+      page: page,
+      model: 'gemini-pro',
+      field_text: 'same source text',
+      transcription_json: { field.id.to_s => 'beta', second_field.id.to_s => 'alpha' }
+    )
+
+    row = run_report.first
+
+    expect(row['Character Disagreement Rate'].to_f).to be > 0
+    expect(row['Case-insensitive CDR'].to_f).to be > 0
   end
 end


### PR DESCRIPTION
### Motivation

- Allow callers to exclude specific transcription fields (by label or `transcription_field_id`) from the overall CDR and misplaced-field calculations while still showing per-field columns. 
- Make text-only CDR more robust by removing punctuation in addition to normalizing whitespace and case. 
- Surface each page's `status` in the CSV to provide context for disagreement metrics. 
- Compute overall (report-only) CDRs using field labels together with values so label/value misassignments are reflected in the overall disagreement metrics.

### Description

- Updated the rake task signature to `:ai_disagreement_report, [:slug, :ignored_fields]` and added parsing of comma-separated ignored field labels or ids into `ignored_fields` and `overall_fields`. 
- Changed `normalize_text` to strip punctuation (`gsub(/[[:punct:]]/, '')`) and added `labeled_text_for_comparison` to concatenate `field.label` with each field value for overall comparisons. 
- Replaced the overall CDR and case-insensitive CDR calculations to use labeled field text built from `overall_fields`, and adjusted `misplaced_fields` logic to ignore fields listed in `ignored_fields`. 
- Added `Page Status` as a column in the CSV output and retained per-field CDR and text-only CDR columns for all report fields. 
- Expanded specs in `spec/tasks/ai_disagreement_report_spec.rb` to cover punctuation normalization, page status column, ignored fields by label and id, and label-aware overall comparisons.

### Testing

- Ran `git diff --check` and it reported no issues. 
- Validated Ruby syntax for the task with `ruby -c lib/tasks/ai_disagreement_report.rake` and for the spec with `ruby -c spec/tasks/ai_disagreement_report_spec.rb`, both succeeded. 
- Attempted to run the spec suite with `bundle exec rspec spec/tasks/ai_disagreement_report_spec.rb`, but the test run could not be executed because the environment Ruby (3.4.4) does not match the project's Gemfile Ruby (3.3.5) so the bundle and `rspec` were unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70bcdd23548322a802157796eef034)