### PR TITLE
Expand Gemini usage metadata tracking

### DIFF
--- a/app/interactors/ai_transcription/lib/gemini/transcribe_handler.rb
+++ b/app/interactors/ai_transcription/lib/gemini/transcribe_handler.rb
@@ -11,6 +11,28 @@ class AiTranscription::Lib::Gemini::TranscribeHandler < AiTranscription::Lib::Ba
     'gemini-3.1-pro-preview' => true
   }
 
+  USAGE_METADATA_SCHEMA_VERSION = 2
+
+  NORMALIZED_USAGE_FIELDS = {
+    'promptTokenCount' => :prompt_token_count,
+    'candidatesTokenCount' => :candidates_token_count,
+    'thoughtsTokenCount' => :thoughts_token_count,
+    'toolUsePromptTokenCount' => :tool_use_prompt_token_count,
+    'cachedContentTokenCount' => :cached_content_token_count,
+    'totalTokenCount' => :total_token_count,
+    'promptTokensDetails' => :prompt_tokens_details,
+    'candidatesTokensDetails' => :candidates_tokens_details,
+    'cacheTokensDetails' => :cache_tokens_details,
+    'toolUsePromptTokensDetails' => :tool_use_prompt_tokens_details
+  }.freeze
+
+  ACCOUNTED_TOKEN_FIELDS = %i[
+    prompt_token_count
+    candidates_token_count
+    thoughts_token_count
+    tool_use_prompt_token_count
+  ].freeze
+
   def perform
     attempt = 0
     last_error = nil
@@ -137,12 +159,29 @@ class AiTranscription::Lib::Gemini::TranscribeHandler < AiTranscription::Lib::Ba
 
   def extract_usage_metadata(response)
     usage = response['usageMetadata'] || {}
+    metadata = NORMALIZED_USAGE_FIELDS.each_with_object({}) do |(provider_key, normalized_key), normalized|
+      normalized[normalized_key] = usage[provider_key] if usage.key?(provider_key)
+    end
 
-    {
-      prompt_token_count: usage['promptTokenCount'],
-      candidates_token_count: usage['candidatesTokenCount'],
-      thoughts_token_count: usage['thoughtsTokenCount'],
-      total_token_count: usage['totalTokenCount']
-    }.compact
+    # cachedContentTokenCount describes the cached portion of promptTokenCount,
+    # rather than another mutually exclusive category, so it is deliberately not
+    # included in this sum.
+    metadata[:accounted_token_count] = ACCOUNTED_TOKEN_FIELDS.sum { |key| metadata[key].to_i }
+    metadata[:unaccounted_token_count] = if metadata.key?(:total_token_count)
+      metadata[:total_token_count] - metadata[:accounted_token_count]
+    end
+    metadata[:usage_metadata_schema_version] = USAGE_METADATA_SCHEMA_VERSION
+    metadata[:usage_metadata_reconciliation_status] = reconciliation_status(metadata)
+    metadata[:provider_usage_metadata] = usage
+
+    metadata.compact
+  end
+
+  def reconciliation_status(metadata)
+    return 'total_unavailable' unless metadata.key?(:total_token_count)
+    return 'reconciled' if metadata[:unaccounted_token_count].zero?
+    return 'over_accounted' if metadata[:unaccounted_token_count].negative?
+
+    'unaccounted_tokens'
   end
 end

--- a/spec/interactors/ai_transcription/generate_spec.rb
+++ b/spec/interactors/ai_transcription/generate_spec.rb
@@ -77,6 +77,69 @@ describe AiTranscription::Generate do
       end
     end
 
+    context 'with expanded Gemini usage metadata' do
+      let(:usage_metadata) do
+        {
+          'promptTokenCount' => 100,
+          'candidatesTokenCount' => 30,
+          'thoughtsTokenCount' => 20,
+          'toolUsePromptTokenCount' => 10,
+          'cachedContentTokenCount' => 40,
+          'totalTokenCount' => 165,
+          'promptTokensDetails' => [{ 'modality' => 'TEXT', 'tokenCount' => 60 }],
+          'candidatesTokensDetails' => [{ 'modality' => 'TEXT', 'tokenCount' => 30 }],
+          'cacheTokensDetails' => [{ 'modality' => 'IMAGE', 'tokenCount' => 40 }],
+          'toolUsePromptTokensDetails' => [{ 'modality' => 'TEXT', 'tokenCount' => 10 }],
+          'unknownFutureField' => [{ 'providerValue' => 7 }]
+        }
+      end
+      let(:provider_response) do
+        {
+          'candidates' => [{
+            'content' => {
+              'parts' => [
+                { 'thought' => true, 'text' => 'Expanded reasoning' },
+                { 'text' => 'Expanded transcription' }
+              ]
+            }
+          }],
+          'usageMetadata' => usage_metadata
+        }
+      end
+
+      before do
+        handler = AiTranscription::Lib::Gemini::TranscribeHandler.new(
+          prompt: prompt,
+          model: model,
+          image_url: 'http://example.com/image.jpg'
+        )
+        allow(handler).to receive(:client).and_return(double(generate_content: provider_response))
+        allow(handler).to receive(:payload).and_return({})
+        allow_any_instance_of(AiTranscription::Lib::Gemini::TranscribeHandler).to receive(:perform) do
+          handler.perform
+        end
+      end
+
+      it 'persists raw and reconciled usage metadata without double-counting cached tokens' do
+        expect(result.success?).to be_truthy
+
+        metadata = result.ai_transcription.reload.metadata
+        expect(metadata['provider_usage_metadata']).to eq(usage_metadata)
+        expect(metadata).to include(
+          'tool_use_prompt_token_count' => 10,
+          'cached_content_token_count' => 40,
+          'accounted_token_count' => 160,
+          'unaccounted_token_count' => 5,
+          'usage_metadata_schema_version' => 2,
+          'usage_metadata_reconciliation_status' => 'unaccounted_tokens'
+        )
+        expect(metadata['prompt_tokens_details']).to eq(usage_metadata['promptTokensDetails'])
+        expect(metadata['candidates_tokens_details']).to eq(usage_metadata['candidatesTokensDetails'])
+        expect(metadata['cache_tokens_details']).to eq(usage_metadata['cacheTokensDetails'])
+        expect(metadata['tool_use_prompt_tokens_details']).to eq(usage_metadata['toolUsePromptTokensDetails'])
+      end
+    end
+
     context 'when 503 error' do
       before do
         stub_const('AiTranscription::Lib::BaseTranscribeHandler::MAX_RETRY', 1)

--- a/spec/interactors/ai_transcription/lib/gemini/transcribe_handler_spec.rb
+++ b/spec/interactors/ai_transcription/lib/gemini/transcribe_handler_spec.rb
@@ -22,4 +22,66 @@ describe AiTranscription::Lib::Gemini::TranscribeHandler do
     expect(logged_messages).to all(include('provider.example/generate?token=[FILTERED]&alt=json'))
     expect(logged_messages.join).not_to include('fake-secret')
   end
+
+  describe 'usage metadata' do
+    let(:usage_metadata) do
+      {
+        'promptTokenCount' => 100,
+        'candidatesTokenCount' => 30,
+        'thoughtsTokenCount' => 20,
+        'toolUsePromptTokenCount' => 10,
+        'cachedContentTokenCount' => 40,
+        'totalTokenCount' => 165,
+        'promptTokensDetails' => [{ 'modality' => 'TEXT', 'tokenCount' => 60 }],
+        'candidatesTokensDetails' => [{ 'modality' => 'TEXT', 'tokenCount' => 30 }],
+        'cacheTokensDetails' => [{ 'modality' => 'IMAGE', 'tokenCount' => 40 }],
+        'toolUsePromptTokensDetails' => [{ 'modality' => 'TEXT', 'tokenCount' => 10 }],
+        'futureProviderField' => { 'nested' => ['unchanged'] }
+      }
+    end
+
+    let(:response) do
+      {
+        'candidates' => [{
+          'content' => {
+            'parts' => [
+              { 'thought' => true, 'text' => 'Reasoning' },
+              { 'text' => 'Transcription' }
+            ]
+          }
+        }],
+        'usageMetadata' => usage_metadata
+      }
+    end
+
+    it 'preserves provider metadata and reconciles mutually exclusive token categories' do
+      client = double(generate_content: response)
+      allow(handler).to receive(:client).and_return(client)
+      allow(handler).to receive(:payload).and_return({})
+
+      transcription, reasoning, metadata, = handler.perform
+
+      expect(transcription).to eq('Transcription')
+      expect(reasoning).to eq('Reasoning')
+      expect(metadata).to include(
+        prompt_token_count: 100,
+        candidates_token_count: 30,
+        thoughts_token_count: 20,
+        tool_use_prompt_token_count: 10,
+        cached_content_token_count: 40,
+        total_token_count: 165,
+        accounted_token_count: 160,
+        unaccounted_token_count: 5,
+        usage_metadata_schema_version: 2,
+        usage_metadata_reconciliation_status: 'unaccounted_tokens'
+      )
+      expect(metadata).to include(
+        prompt_tokens_details: usage_metadata['promptTokensDetails'],
+        candidates_tokens_details: usage_metadata['candidatesTokensDetails'],
+        cache_tokens_details: usage_metadata['cacheTokensDetails'],
+        tool_use_prompt_tokens_details: usage_metadata['toolUsePromptTokensDetails']
+      )
+      expect(metadata[:provider_usage_metadata]).to eq(usage_metadata)
+    end
+  end
 end


### PR DESCRIPTION
### Motivation

- Preserve the full Gemini `usageMetadata` payload for future inspection while continuing to expose the existing normalized snake-case counters for compatibility.
- Capture additional token categories (`toolUsePromptTokenCount`, `cachedContentTokenCount`) and token-detail arrays returned by Gemini so downstream reporting and reconciliation can be more accurate.
- Provide explicit accounted/unaccounted token tallies and a schema/reconciliation marker so consumers can distinguish legacy records from the expanded format.

### Description

- Added `USAGE_METADATA_SCHEMA_VERSION`, `NORMALIZED_USAGE_FIELDS`, and `ACCOUNTED_TOKEN_FIELDS` constants and mapping to `AiTranscription::Lib::Gemini::TranscribeHandler` to drive normalization of provider fields into stable snake_case keys.
- Updated `extract_usage_metadata` to retain the original provider object under `:provider_usage_metadata`, normalize available counters and details arrays, compute `:accounted_token_count` and `:unaccounted_token_count` (excluding cached tokens from the mutually exclusive sum), and attach `:usage_metadata_schema_version` and `:usage_metadata_reconciliation_status` via a new `reconciliation_status` helper.
- Ensured cached tokens are not double-counted by treating `cachedContentTokenCount` as a sub-component of prompt tokens rather than another mutually exclusive bucket.
- Extended tests in `spec/interactors/ai_transcription/lib/gemini/transcribe_handler_spec.rb` and `spec/interactors/ai_transcription/generate_spec.rb` to include provider responses with thoughts, tool-use, cached-content, token-detail arrays, and unknown future fields, and to assert raw provider metadata preservation and correct reconciliation delta.

### Testing

- Ran syntax checks with `ruby -c` for `app/interactors/ai_transcription/lib/gemini/transcribe_handler.rb` and the modified specs, and they reported syntax OK.
- Executed a standalone Ruby assertion script that exercised `extract_usage_metadata` and verified raw `provider_usage_metadata` preservation, normalized detail fields, `accounted_token_count == 160`, and `unaccounted_token_count == 5`, which passed.
- Ran `git diff --check` to validate whitespace/format issues and found no problems.
- Attempted to run the specs with `bundle exec rspec ...` but the RSpec executable could not run in this environment due to a Ruby version mismatch (container Ruby 3.4.4 vs Gemfile-specified 3.3.5), so full RSpec runs were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7106b4ee748322b506e75521cc1a81)