### PR TITLE
Spreadsheet validator: fill missing spreadsheet cells with nil instead of erroring

### DIFF
--- a/app/interactors/ai_transcription/lib/field_based_response_validator.rb
+++ b/app/interactors/ai_transcription/lib/field_based_response_validator.rb
@@ -84,9 +84,8 @@ class AiTranscription::Lib::FieldBasedResponseValidator
         next
       end
 
-      missing = expected_col_ids.reject { |k| row.key?(k) }
-      if missing.any?
-        @errors << "Field \"#{field.label}\" (#{field.id}): row #{i + 1} missing columns: #{missing.join(', ')}"
+      expected_col_ids.each do |column_id|
+        row[column_id] = nil unless row.key?(column_id)
       end
     end
   end

--- a/spec/interactors/ai_transcription/lib/field_based_response_validator_spec.rb
+++ b/spec/interactors/ai_transcription/lib/field_based_response_validator_spec.rb
@@ -119,6 +119,12 @@ describe AiTranscription::Lib::FieldBasedResponseValidator do
         expect(validator_for(full_json(rows)).valid?).to be true
       end
 
+      it 'fills omitted blank cells with null' do
+        v = validator_for(full_json([{ col1.id.to_s => 'Jane' }]))
+        expect(v.valid?).to be true
+        expect(v.parsed_json[spreadsheet_field.id.to_s].first[col2.id.to_s]).to be_nil
+      end
+
       it 'accepts null for the spreadsheet field' do
         expect(validator_for(full_json(nil)).valid?).to be true
       end


### PR DESCRIPTION
### Motivation
- Ensure spreadsheet rows that omit some columns are normalized rather than treated as invalid so downstream code can handle empty cells consistently.

### Description
- Change `AiTranscription::Lib::FieldBasedResponseValidator#validate_spreadsheet` to populate any missing column keys in each row with `nil` instead of recording a missing-columns error.
- Add a spec that asserts omitted cells are filled with `null` (`nil`) in the parsed JSON.

### Testing
- Added `spec/interactors/ai_transcription/lib/field_based_response_validator_spec.rb` example `fills omitted blank cells with null` and ran the validator spec; the updated spec passed under `rspec`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b6de8f3608328a8b08e61dc13033b)