### PR TITLE
Preserve spreadsheet values in field-label backfill

### DIFF
--- a/lib/tasks/fix_field_label_dashes.rake
+++ b/lib/tasks/fix_field_label_dashes.rake
@@ -66,9 +66,9 @@ namespace :fromthepage do
                           value.map do |row|
                             columns.map { |column| row[column.id.to_s] }
                           end.to_json
-                        else
+          else
                           value.to_s
-                        end
+          end
 
           field_cells[field.id.to_s] = { 'value' => field_value }
         end

--- a/lib/tasks/fix_field_label_dashes.rake
+++ b/lib/tasks/fix_field_label_dashes.rake
@@ -61,9 +61,16 @@ namespace :fromthepage do
           value = page.transcription_json[field.id.to_s]
           next if value.nil?
 
-          field_cells[field.id.to_s] = {
-            'value' => field.input_type == 'spreadsheet' ? value.to_json : value.to_s
-          }
+          field_value = if field.input_type == 'spreadsheet'
+                          columns = field.spreadsheet_columns.order(:position)
+                          value.map do |row|
+                            columns.map { |column| row[column.id.to_s] }
+                          end.to_json
+                        else
+                          value.to_s
+                        end
+
+          field_cells[field.id.to_s] = { 'value' => field_value }
         end
 
         if field_cells.empty?

--- a/spec/tasks/fix_field_label_dashes_spec.rb
+++ b/spec/tasks/fix_field_label_dashes_spec.rb
@@ -67,6 +67,42 @@ describe 'Fix field label dashes rake task' do
       expect(PageVersion.where(page: page).count).to eq(version_count_before)
     end
 
+    it 'preserves spreadsheet cell values when rebuilding xml_text' do
+      spreadsheet_field = create(
+        :transcription_field, :as_transcription,
+        collection: collection, label: 'Register', input_type: 'spreadsheet', position: 2
+      )
+      first_column = create(
+        :spreadsheet_column,
+        transcription_field: spreadsheet_field, label: 'First Name', position: 1
+      )
+      last_column = create(
+        :spreadsheet_column,
+        transcription_field: spreadsheet_field, label: 'Last Name', position: 2
+      )
+      page.update!(
+        transcription_json: {
+          spreadsheet_field.id.to_s => [
+            { first_column.id.to_s => 'Jane', last_column.id.to_s => 'Doe' }
+          ]
+        },
+        source_text: '<table class="tabular"><thead><th>First Name</th><th>Last Name</th></thead>' \
+                     '<tbody><tr><td>Jane</td><td>Doe</td></tr></tbody></table>'
+      )
+
+      ENV['dry_run'] = 'false'
+      ENV['page_id'] = page.id.to_s
+      capture_stdout do
+        Rake::Task['fromthepage:fix_field_label_dashes'].invoke
+      end
+      ENV.delete('dry_run')
+      ENV.delete('page_id')
+
+      page.reload
+      expect(page.xml_text).to include('<td>Jane</td>')
+      expect(page.xml_text).to include('<td>Doe</td>')
+    end
+
     it 'does not touch pages updated before the bug was introduced' do
       page.update_column(:updated_at, Time.zone.parse('2025-11-01T00:00:00Z'))
 


### PR DESCRIPTION
### Motivation
- The backfill rake task that rebuilds `xml_text` for field-based pages was restoring field labels but lost spreadsheet cell values when reconstructing table-based transcriptions.  
- The intent is to regenerate page XML from the authoritative `transcription_json` while keeping spreadsheet cell contents intact so Overview/Read previews display correctly.  
- Add a regression test to ensure spreadsheet rows are reconstructed in column order during the backfill.

### Description
- Change `lib/tasks/fix_field_label_dashes.rake` to rebuild spreadsheet field values as ordered row arrays from `transcription_json` (using the field's `spreadsheet_columns` order) before calling `TranscriptionField::Lib::Utils.parse_fields`.  
- Replace the previous simplistic `value.to_json` handling with logic that maps column IDs to ordered arrays and stores that JSON under the expected `'value'` key.  
- Add a spec `spec/tasks/fix_field_label_dashes_spec.rb` that creates a spreadsheet field with columns and asserts the backfill preserves spreadsheet cell values (e.g. `<td>Jane</td>` and `<td>Doe</td>`) in regenerated `xml_text`.

### Testing
- `ruby -c lib/tasks/fix_field_label_dashes.rake` succeeded (syntax OK).  
- `ruby -c spec/tasks/fix_field_label_dashes_spec.rb` succeeded (syntax OK).  
- Attempted to run the spec suite with `bundle exec rspec spec/tasks/fix_field_label_dashes_spec.rb` but the test runner could not be executed in this environment due to a Ruby/Bundler mismatch (environment Ruby 3.4.4 vs project Ruby 3.3.5), so the spec was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e201917c08322ab8a7f7eaa5447d1)