### PR TITLE
Enforce server-side owner/trial assignment and remove client-side owner fields

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -282,7 +282,7 @@ class ApplicationController < ActionController::Base
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up) { |u| u.permit(:login, :email, :password, :password_confirmation, :display_name, :owner, :paid_date, :activity_email) }
+    devise_parameter_sanitizer.permit(:sign_up) { |u| u.permit(:login, :email, :password, :password_confirmation, :display_name, :activity_email) }
     devise_parameter_sanitizer.permit(:sign_in) { |u| u.permit(:login_id, :login, :email, :password, :remember_me) }
     devise_parameter_sanitizer.permit(:account_update) { |u| u.permit(:login, :email, :password, :current_password, :password_confirmation, :real_name) }
   end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -21,6 +21,15 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   def create
+    create_registration(trial: false)
+  end
+
+  def create_trial
+    create_registration(trial: true)
+  end
+
+  def create_registration(trial:)
+    @trial_registration = trial
     @owner = User.find_by(slug: params[:owner_slug]) if params[:owner_slug].present?
 
     # Merge the new user information into the guest user id to change into normal user
@@ -31,6 +40,8 @@ class RegistrationsController < Devise::RegistrationsController
     else
       @user = build_resource(sign_up_params)
     end
+
+    set_registration_account_type
 
     @user.build_privacy_preference(recorded: cookies[:cookies_recorded]&.to_sym == :recorded)
 
@@ -60,9 +71,7 @@ class RegistrationsController < Devise::RegistrationsController
         session[:guest_user_id] = nil
       end
 
-      if @user.owner
-        @user.account_type = 'Trial'
-        @user.save
+      if @trial_registration
         alert_bento
       end
 
@@ -73,7 +82,7 @@ class RegistrationsController < Devise::RegistrationsController
         @minimum_password_length = resource_class.password_length.min
       end
 
-      after_failed_sign_up_action_for(params[:registration_type]&.to_sym)
+      after_failed_sign_up_action
     end
   end
 
@@ -130,9 +139,8 @@ class RegistrationsController < Devise::RegistrationsController
     edit_registration_path(resource)
   end
 
-  def after_failed_sign_up_action_for(registration_type)
-    case registration_type
-    when :free_trial
+  def after_failed_sign_up_action
+    if @trial_registration
       render :new_trial
     else
       render :new
@@ -147,7 +155,19 @@ class RegistrationsController < Devise::RegistrationsController
   private
 
   def sign_up_params
-    params.require(:user).permit(:login, :real_name, :owner, :activity_email, :paid_date, :display_name, :email, :password, :password_confirmation)
+    params.require(:user).permit(:login, :real_name, :activity_email, :display_name, :email, :password, :password_confirmation)
+  end
+
+  def set_registration_account_type
+    if @trial_registration
+      @user.owner = true
+      @user.account_type = 'Trial'
+      @user.paid_date = 2.weeks.from_now
+    else
+      @user.owner = false
+      @user.account_type = nil
+      @user.paid_date = nil
+    end
   end
 
   def saml_provider_param

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -24,9 +24,6 @@ section.signon
       =f.text_field :real_name
       small
         i= t('devise.real_name_message')
-    .signon_field
-      =f.hidden_field :owner
-      =f.hidden_field :paid_date
     -if RECAPTCHA_ENABLED
       .signon_field
         =recaptcha_tags

--- a/app/views/devise/registrations/new_trial.html.slim
+++ b/app/views/devise/registrations/new_trial.html.slim
@@ -8,7 +8,7 @@ section.signon
     ==t('.just_want_to_transcribe', sign_up_here: (link_to t('.sign_up_here'), new_user_registration_path))
 
 
-  =form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+  =form_for(resource, as: resource_name, url: users_new_trial_path) do |f|
     =devise_error_messages!
     .signon_field
       =f.label :login, t('.login')
@@ -25,10 +25,6 @@ section.signon
     .signon_field
       =f.label :display_name, t('devise.display_name')
       =f.text_field :real_name
-    .signon_field
-      =f.hidden_field :owner, value: true
-      =f.hidden_field :paid_date, value: 2.weeks.from_now
-      =hidden_field_tag :registration_type, :free_trial
     -if RECAPTCHA_ENABLED
       .signon_field
         =recaptcha_tags
@@ -41,4 +37,3 @@ section.signon
   javascript:  mixpanel.track("Sign Up");
 
   <script type="text/javascript" src="https://calendly.com/assets/external/widget.js"></script>
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Fromthepage::Application.routes.draw do
 
   devise_scope :user do
     get 'users/new_trial' => 'registrations#new_trial'
+    post 'users/new_trial' => 'registrations#create_trial'
     get ':user_slug/sign_up', to: 'registrations#owner_new', as: 'new_for_owner'
     post 'registrations/choose_provider', to: 'registrations#choose_saml'
     post 'registrations/set_provider', to: 'registrations#set_saml'

--- a/doc/REGISTRATION_SECURITY_TESTING.md
+++ b/doc/REGISTRATION_SECURITY_TESTING.md
@@ -1,0 +1,92 @@
+# Registration privilege-escalation regression test
+
+Use these steps only in a local, staging, or other environment where you are
+authorized to create test accounts. Use a new email address for each test.
+
+## Reproduce the original vulnerability
+
+These steps describe the behavior before the registration security fix.
+
+1. Open `/users/sign_up` in a browser.
+2. Fill in all required transcriber registration fields with a unique username
+   and email address.
+3. Open the browser developer tools and run this in the console:
+
+   ```javascript
+   const form = document.querySelector('form');
+   form.insertAdjacentHTML(
+     'beforeend',
+     '<input type="hidden" name="user[owner]" value="1">' +
+       '<input type="hidden" name="user[paid_date]" value="2099-12-31">'
+   );
+   ```
+
+4. Submit the registration form.
+5. Observe that the new account is sent to an owner dashboard rather than the
+   transcriber watchlist.
+6. In a Rails console, confirm the unauthorized values were persisted:
+
+   ```ruby
+   user = User.find_by!(email: 'the-test-email@example.com')
+   user.owner
+   user.paid_date
+   ```
+
+   On a vulnerable revision, `owner` is `true` and `paid_date` contains the
+   attacker-selected date.
+
+## Verify the fix
+
+1. Open `/users/sign_up` and fill in all required fields with another unique
+   username and email address.
+2. Use the same developer-tools snippet above to inject `user[owner]` and
+   `user[paid_date]` into the form.
+3. Submit the form.
+4. Confirm the new account is sent to the transcriber watchlist, not an owner
+   dashboard.
+5. In a Rails console, verify that the submitted privileged values were
+   ignored:
+
+   ```ruby
+   user = User.find_by!(email: 'the-second-test-email@example.com')
+   user.owner       # => false
+   user.account_type # => nil
+   user.paid_date   # => nil
+   ```
+
+## Verify legitimate trial registration
+
+The security fix must not prevent the intended trial-owner flow.
+
+1. Open `/users/new_trial` and fill in the required fields.
+2. Before submitting, inject attacker-selected values in the developer-tools
+   console:
+
+   ```javascript
+   const form = document.querySelector('form');
+   form.insertAdjacentHTML(
+     'beforeend',
+     '<input type="hidden" name="user[owner]" value="0">' +
+       '<input type="hidden" name="user[account_type]" value="Staff">' +
+       '<input type="hidden" name="user[paid_date]" value="2099-12-31">'
+   );
+   ```
+
+3. Submit the form and confirm the account reaches the trial-owner dashboard.
+4. In a Rails console, verify that the server, rather than the submitted
+   fields, selected the account properties:
+
+   ```ruby
+   user = User.find_by!(email: 'the-trial-test-email@example.com')
+   user.owner        # => true
+   user.account_type # => "Trial"
+   user.paid_date    # approximately two weeks after registration
+   ```
+
+## Automated regression test
+
+Run the request specs that submit the same malicious parameters directly:
+
+```shell
+bundle exec rspec spec/requests/registrations_controller_spec.rb
+```

--- a/spec/features/devise_spec.rb
+++ b/spec/features/devise_spec.rb
@@ -116,7 +116,7 @@ describe 'Devise' do
 
       expect(page).to have_content("Organization Name can't be blank")
       expect(page).to have_content('Sign Up for a Trial')
-      expect(page.current_path).to eq user_registration_path
+      expect(page.current_path).to eq users_new_trial_path
     end
   end
 

--- a/spec/requests/registrations_controller_spec.rb
+++ b/spec/requests/registrations_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+RSpec.describe RegistrationsController, type: :request do
+  let(:user_attributes) do
+    attributes_for(:unique_user).slice(:login, :email, :password, :password_confirmation).merge(
+      real_name: 'Registration Test'
+    )
+  end
+
+  describe 'POST /users' do
+    it 'does not allow registration parameters to create an owner account' do
+      attacker_selected_paid_date = 10.years.from_now
+
+      post user_registration_path, params: {
+        user: user_attributes.merge(owner: true, paid_date: attacker_selected_paid_date, account_type: 'Staff')
+      }
+
+      user = User.find_by!(email: user_attributes[:email])
+      expect(user).not_to be_owner
+      expect(user.account_type).to be_nil
+      expect(user.paid_date).to be_nil
+    end
+  end
+
+  describe 'POST /users/new_trial' do
+    it 'sets trial account privileges and expiration on the server' do
+      expected_paid_date = 2.weeks.from_now
+
+      post users_new_trial_path, params: {
+        user: user_attributes.merge(owner: false, paid_date: 10.years.from_now, account_type: 'Staff')
+      }
+
+      user = User.find_by!(email: user_attributes[:email])
+      expect(user).to be_owner
+      expect(user.account_type).to eq('Trial')
+      expect(user.paid_date).to be_within(1.minute).of(expected_paid_date)
+    end
+
+    it 'renders the trial form again when registration fails' do
+      post users_new_trial_path, params: {
+        user: user_attributes.merge(real_name: '')
+      }
+
+      expect(response).to render_template(:new_trial)
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

- Close a security/privilege escalation vector where the `owner`, `paid_date`, or `account_type` could be provided by a client during signup. 
- Ensure trial account properties are assigned by the server rather than via hidden form fields. 
- Simplify registration flow by centralizing signup logic and adding an explicit trial signup endpoint.

### Description

- Removed `:owner` and `:paid_date` from permitted signup parameters in `ApplicationController` and `sign_up_params` to prevent client-controlled elevation. 
- Refactored `RegistrationsController#create` into `create_registration(trial:)` and added `create_trial` to handle trial signups via a `@trial_registration` flag. 
- Added `set_registration_account_type` to set `@user.owner`, `@user.account_type`, and `@user.paid_date` on the server based on the `trial` flag. 
- Updated views to remove hidden `owner`/`paid_date` fields and changed the trial signup form to post to `users_new_trial_path`. 
- Added a POST route for `users/new_trial` mapped to `registrations#create_trial`. 
- Simplified failure handling by replacing `after_failed_sign_up_action_for` with `after_failed_sign_up_action`. 
- Updated Mixpanel/alert behavior to only trigger `alert_bento` for trial registrations. 
- Added `spec/requests/registrations_controller_spec.rb` with tests asserting that normal registration cannot create an owner and that trial registration sets server-side trial state, and adjusted `spec/features/devise_spec.rb` to assert the trial form path.

### Testing

- Ran the RSpec suite covering authentication and registration, including the updated `spec/features/devise_spec.rb` and the new `spec/requests/registrations_controller_spec.rb`. 
- The new request specs validate that attacker-supplied `owner`/`paid_date`/`account_type` params are ignored on standard signup and that `users/new_trial` assigns `owner`, `account_type = 'Trial'`, and a `paid_date` ~ 2 weeks in the future. 
- All related specs passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f37e7af34832285f9d49d6804e728)