### PR TITLE
Track and persist AI draft usage in transcribe flow

### DIFF
--- a/app/controllers/transcribe_controller.rb
+++ b/app/controllers/transcribe_controller.rb
@@ -15,6 +15,7 @@ class TranscribeController  < ApplicationController
   skip_around_action :switch_locale, only: [:still_editing, :active_editing]
 
   def display_page
+    @ai_draft_used = false
     rollback_article_categories(params[:rollback_delete_ids], params[:rollback_unset_ids])
 
     handle_display_page_data
@@ -46,13 +47,14 @@ class TranscribeController  < ApplicationController
     @quality_sampling = QualitySampling.find(params[:quality_sampling_id]) if params[:quality_sampling_id].present?
 
     @layout_mode = cookies[:transcribe_layout_mode] || @collection.default_orientation
+    @ai_draft_used = ActiveModel::Type::Boolean.new.cast(params[:ai_draft_used])
     @page.attributes = page_params unless page_params.empty?
-    @page.ai_draft_used = params[:ai_draft_used]
 
     if @page.field_based
       @field_cells = request.params[:fields]
       @page = TranscriptionField::Lib::Utils.parse_fields(page: @page, field_cells: @field_cells)
     end
+    @page.ai_draft_used = @ai_draft_used
 
     unless params[:page]['needs_review'] == '1'
       @page = Transcribe::Lib::MarkAsBlankHandler.new(

--- a/app/views/transcribe/display_page.html.slim
+++ b/app/views/transcribe/display_page.html.slim
@@ -20,7 +20,7 @@
   =hidden_field_tag(:page_id, @page.id)
   =hidden_field_tag(:flow, params[:flow])
   =hidden_field_tag(:quality_sampling_id, params[:quality_sampling_id])
-  =hidden_field_tag(:ai_draft_used, false)
+  =hidden_field_tag(:ai_draft_used, @ai_draft_used)
   =validation_summary @page.errors
 
   .page-toolbar

--- a/spec/requests/transcribe_controller_spec.rb
+++ b/spec/requests/transcribe_controller_spec.rb
@@ -176,6 +176,14 @@ describe TranscribeController do
       expect(response).to have_http_status(:ok)
       expect(response).to render_template(:display_page)
     end
+
+    it 'starts with AI draft use disabled' do
+      login_as owner
+      subject
+
+      ai_draft_field = response.parsed_body.at_css('input[name="ai_draft_used"]')
+      expect(ai_draft_field['value']).to eq('false')
+    end
   end
 
   describe '#save_transcription' do
@@ -273,6 +281,86 @@ describe TranscribeController do
     let(:params) { {} }
 
     let(:subject) { patch action_path, params: params }
+
+    context 'when an AI draft is used' do
+      let(:draft_text) { 'Text copied from an AI draft' }
+      let(:base_params) do
+        {
+          page_id: page.id,
+          ai_draft_used: 'true',
+          page: {
+            mark_blank: '0',
+            needs_review: '0',
+            source_text: draft_text
+          }
+        }
+      end
+
+      before { login_as owner }
+
+      def preserved_ai_draft_value
+        response.parsed_body.at_css('input[name="ai_draft_used"]')['value']
+      end
+
+      def expect_ai_draft_tracking
+        ai_deeds = Deed.where(page_id: page.id, user_id: owner.id, deed_type: DeedType::AI_DRAFT)
+        changed_version = page.reload.page_versions.find_by(transcription: draft_text)
+
+        expect(ai_deeds.count).to eq(1)
+        expect(changed_version).to be_present
+        expect(changed_version.ai_draft_used).to be(true)
+      end
+
+      it 'tracks an AI draft saved immediately' do
+        patch action_path, params: base_params.merge(save_to_incomplete: 'Save')
+
+        expect(response).to have_http_status(:redirect)
+        expect_ai_draft_tracking
+      end
+
+      it 'preserves AI draft use through preview and edit before saving' do
+        patch action_path, params: base_params.merge(preview: 'Preview')
+        expect(response).to have_http_status(:ok)
+        expect(preserved_ai_draft_value).to eq('true')
+
+        patch action_path, params: base_params.merge(ai_draft_used: preserved_ai_draft_value, edit: 'Edit')
+        expect(response).to have_http_status(:ok)
+        expect(preserved_ai_draft_value).to eq('true')
+
+        patch action_path,
+              params: base_params.merge(ai_draft_used: preserved_ai_draft_value, save_to_incomplete: 'Save')
+
+        expect(response).to have_http_status(:redirect)
+        expect_ai_draft_tracking
+      end
+
+      it 'preserves AI draft use through autolinking before saving' do
+        patch action_path, params: base_params.merge(autolink: 'Autolink')
+        expect(response).to have_http_status(:ok)
+        expect(preserved_ai_draft_value).to eq('true')
+
+        patch action_path,
+              params: base_params.merge(ai_draft_used: preserved_ai_draft_value, save_to_incomplete: 'Save')
+
+        expect(response).to have_http_status(:redirect)
+        expect_ai_draft_tracking
+      end
+
+      it 'preserves AI draft use through a failed submission and corrected save' do
+        invalid_params = base_params.deep_merge(page: { source_text: '<hi rend="bold">Unclosed' })
+        patch action_path, params: invalid_params.merge(save_to_incomplete: 'Save')
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(preserved_ai_draft_value).to eq('true')
+        expect(Deed.where(page_id: page.id, deed_type: DeedType::AI_DRAFT)).to be_empty
+
+        patch action_path,
+              params: base_params.merge(ai_draft_used: preserved_ai_draft_value, save_to_incomplete: 'Save')
+
+        expect(response).to have_http_status(:redirect)
+        expect_ai_draft_tracking
+      end
+    end
 
     context 'mark_blank_logic' do
       let!(:search_attempt) do


### PR DESCRIPTION
### Motivation
- Ensure the UI and controller consistently track whether a transcription was copied from an AI draft so that downstream bookkeeping can record it. 
- Preserve the AI-draft flag across preview/edit/autolink cycles and through validation failures so it isn't lost before the final save. 
- Surface the real AI-draft state to the form instead of always emitting a hard-coded `false` value.

### Description
- Initialize `@ai_draft_used` in `display_page` so the form has a defined value when rendering. 
- In `save_transcription`, cast the incoming `params[:ai_draft_used]` to a boolean using `ActiveModel::Type::Boolean.new.cast` and assign it to `@page.ai_draft_used` after applying `page_params`. 
- Change the transcription form hidden field to emit `ai_draft_used` as `@ai_draft_used` instead of a hard-coded `false`. 
- Add request specs in `spec/requests/transcribe_controller_spec.rb` to verify the hidden field default and to exercise AI-draft flows including immediate save, preserve-through-preview/edit, preserve-through-autolink, and handling a failed submission followed by a corrected save.

### Testing
- Ran the updated request specs in `spec/requests/transcribe_controller_spec.rb` which include new scenarios for AI-draft tracking and preservation, and they passed. 
- Existing transcribe request specs were also executed and passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c4bdc910c8322b431e922ec6bcb33)