### PR TITLE
Fix flaky race in document set works-editing spec

### DIFF
--- a/spec/features/document_sets_spec.rb
+++ b/spec/features/document_sets_spec.rb
@@ -94,6 +94,20 @@ describe 'document sets' do
       expect(checkbox).to be_checked
     end
 
+    # Each checkbox toggle above submits the works form in the background (see
+    # data-action="change->form#requestSubmit" in _works_table.html.slim), which persists
+    # via DocumentSetsController#update_works on its own DB connection. Wait for that
+    # in-flight request to land before reassigning work_ids directly below — otherwise the
+    # async request and this test's own ActiveRecord calls can race to insert the same
+    # document_sets_works row and raise ActiveRecord::RecordNotUnique.
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      loop do
+        break if doc_set.reload.work_ids.sort == works.map(&:id).sort
+
+        sleep 0.1
+      end
+    end
+
     work_ids += doc_set.work_ids
 
     doc_set.work_ids = []


### PR DESCRIPTION
## Summary
- The "edits a document set (start at collection level)" feature spec was intermittently failing in CI with `ActiveRecord::RecordNotUnique: Duplicate entry '26-1' for key index_document_sets_works_on_work_id_and_document_set_id`
- Root cause: each checkbox toggle in the works table auto-submits the form in the background (`data-action="change->form#requestSubmit"` in `_works_table.html.slim`), which persists via `DocumentSetsController#update_works` on its own DB connection (Selenium browser thread). The test immediately followed with its own direct `doc_set.work_ids=` reassignment on the RSpec thread, racing the in-flight background request to insert the same `document_sets_works` row.
- Fix waits for the background request to actually land (polls `doc_set.reload.work_ids` until it matches the expected "all works selected" state) before the test does its own direct model manipulation, removing the race.

## Test plan
- [x] Reproduced the failure locally against a freshly loaded test DB: ~40% failure rate over 5 runs before the fix
- [x] After the fix: 12/12 clean runs against fresh test DBs
- [x] Full `spec/features/document_sets_spec.rb` file run: 15/16 pass (one unrelated, pre-existing flaky example — "views document sets - regular user" — fails only when run after other examples in the file due to this spec file not resetting DB state between examples; passes in isolation and is unrelated to this fix)
- [x] `rubocop spec/features/document_sets_spec.rb` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)