### PR TITLE
Respect field position and include instruction guidance in FieldBasedPromptBuilder

### DIFF
--- a/app/interactors/ai_transcription/lib/field_based_prompt_builder.rb
+++ b/app/interactors/ai_transcription/lib/field_based_prompt_builder.rb
@@ -3,7 +3,9 @@ class AiTranscription::Lib::FieldBasedPromptBuilder
 
   def initialize(collection:)
     @collection = collection
-    @fields = collection.transcription_fields.reject { |f| SKIP_TYPES.include?(f.input_type) }
+    ordered_fields = collection.transcription_fields.order(:position)
+    @prompt_fields = ordered_fields.reject { |field| field.input_type == 'description' }
+    @fields = ordered_fields.reject { |field| SKIP_TYPES.include?(field.input_type) }
   end
 
   def build
@@ -18,6 +20,7 @@ class AiTranscription::Lib::FieldBasedPromptBuilder
       Rules:
       - Return ONLY a valid JSON object. Do not include any text, explanation, or markdown outside the JSON.
       - Use the numeric field ID as each key (as a string).
+      - Lines beginning with "Instruction:" are guidance for the fields that follow, not fields to include in the JSON.
       - If a field is not present or legible in the image, use null as the value.
       - For select fields, use one of the listed options exactly as shown, or null if none apply.
       - For spreadsheet fields, return an array of row objects using the column IDs as keys.
@@ -30,7 +33,13 @@ class AiTranscription::Lib::FieldBasedPromptBuilder
   private
 
   def field_list
-    @fields.map { |f| format_field(f) }.join("\n")
+    @prompt_fields.map { |field| format_prompt_field(field) }.join("\n")
+  end
+
+  def format_prompt_field(field)
+    return "- Instruction: #{field.label}" if field.input_type == 'instruction'
+
+    format_field(field)
   end
 
   def format_field(field)

--- a/spec/interactors/ai_transcription/lib/field_based_prompt_builder_spec.rb
+++ b/spec/interactors/ai_transcription/lib/field_based_prompt_builder_spec.rb
@@ -49,14 +49,47 @@ describe AiTranscription::Lib::FieldBasedPromptBuilder do
     expect(prompt).not_to include('Fill out carefully')
   end
 
-  it 'excludes instruction fields' do
-    expect(prompt).not_to include('Enter county name')
+  it 'includes instruction labels in the field list as guidance rather than extractable fields' do
+    field_section = prompt[/Fields to extract:\n(.*?)\n\nRules:/m, 1]
+
+    expect(field_section.lines.map(&:chomp)).to include('- Instruction: Enter county name')
+    expect(field_section).not_to include("Instruction field #{instruction_field.id}")
+    expect(described_class.new(collection: collection).instance_variable_get(:@fields)).not_to include(instruction_field)
   end
 
   it 'includes an example JSON structure keyed by field ID' do
     expect(prompt).to include("\"#{text_field.id}\"")
     expect(prompt).to include("\"#{select_field.id}\"")
     expect(prompt).to include("\"#{date_field.id}\"")
+  end
+
+  it 'does not add the instruction field ID to the expected JSON object' do
+    expected_json = JSON.parse(prompt.split("Expected JSON format:\n", 2).last)
+
+    expect(expected_json).not_to have_key(instruction_field.id.to_s)
+  end
+
+  context 'with multiple instructions' do
+    let!(:earlier_instruction) do
+      create(:transcription_field, :instruction_field,
+             label: 'Transcribe the location exactly', collection: collection,
+             position: 2, line_number: 2)
+    end
+
+    let!(:later_instruction) do
+      create(:transcription_field, :instruction_field,
+             label: 'Preserve original spelling', collection: collection,
+             position: 7, line_number: 7)
+    end
+
+    it 'interleaves instructions with extractable fields in transcription-field order' do
+      field_section = prompt[/Fields to extract:\n(.*?)\n\nRules:/m, 1]
+
+      expect(field_section.index('Name')).to be < field_section.index('Transcribe the location exactly')
+      expect(field_section.index('Transcribe the location exactly')).to be < field_section.index('County')
+      expect(field_section.index('Birth Date')).to be < field_section.index('Enter county name')
+      expect(field_section.index('Enter county name')).to be < field_section.index('Preserve original spelling')
+    end
   end
 
   context 'with a spreadsheet field' do


### PR DESCRIPTION
### Motivation
- Ensure transcription prompts present fields and inline instructions in the same order as configured and treat instruction fields as guidance rather than extractable JSON keys.
- Prevent instruction and description fields from being included in the expected JSON output while still surfacing instruction text to the transcriber.

### Description
- Order transcription fields by `position` and introduce `@prompt_fields` (ordered) while keeping `@fields` for values used in the example JSON.
- Render instruction fields into the prompt as `- Instruction: <label>` lines via a new `format_prompt_field` method and skip them when building the example JSON.
- Keep `description` fields excluded from the prompt and add a rule line clarifying that lines beginning with `Instruction:` are guidance and not JSON fields.
- Update `field_list` and `example_json` generation to use the appropriate field collections so instruction IDs are not added to the expected JSON.

### Testing
- Ran `rspec spec/interactors/ai_transcription/lib/field_based_prompt_builder_spec.rb` and the updated examples all passed.
- Verified that instruction labels appear in the `Fields to extract` section and instruction IDs are absent from the `Expected JSON format` output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ed1e1f8fc83228ac71003d36ac1c9)