### PR TITLE
Order AI prompt fields by form layout

### DIFF
--- a/app/interactors/ai_transcription/lib/field_based_prompt_builder.rb
+++ b/app/interactors/ai_transcription/lib/field_based_prompt_builder.rb
@@ -3,7 +3,7 @@ class AiTranscription::Lib::FieldBasedPromptBuilder
 
   def initialize(collection:)
     @collection = collection
-    ordered_fields = collection.transcription_fields.order(:position)
+    ordered_fields = collection.transcription_fields.order(:line_number, :position)
     @prompt_fields = ordered_fields.reject { |field| field.input_type == 'description' }
     @fields = ordered_fields.reject { |field| SKIP_TYPES.include?(field.input_type) }
   end

--- a/spec/interactors/ai_transcription/lib/field_based_prompt_builder_spec.rb
+++ b/spec/interactors/ai_transcription/lib/field_based_prompt_builder_spec.rb
@@ -92,6 +92,21 @@ describe AiTranscription::Lib::FieldBasedPromptBuilder do
     end
   end
 
+  context 'when field positions repeat across lines' do
+    before do
+      text_field.update!(position: 2, line_number: 1)
+      select_field.update!(position: 1, line_number: 2)
+      date_field.update!(position: 1, line_number: 1)
+    end
+
+    it 'lists fields in line order, then position order within each line' do
+      field_section = prompt[/Fields to extract:\n(.*?)\n\nRules:/m, 1]
+
+      expect(field_section.index('Birth Date')).to be < field_section.index('Name')
+      expect(field_section.index('Name')).to be < field_section.index('County')
+    end
+  end
+
   context 'with a spreadsheet field' do
     let!(:spreadsheet_field) do
       create(:transcription_field, :spreadsheet_field,


### PR DESCRIPTION
### Motivation

- The AI prompt field list was being generated by `position` alone which could produce a different reading order than the UI; prompts should follow the form layout (iterate by line, then by position) so instructions and fields appear in the same ordering users see.

### Description

- Change `AiTranscription::Lib::FieldBasedPromptBuilder` to order transcription fields by `line_number` then `position` instead of by `position` only (edited `app/interactors/ai_transcription/lib/field_based_prompt_builder.rb`).
- Add a regression spec to verify fields are listed in line order and then left-to-right within a line when positions repeat across lines (updated `spec/interactors/ai_transcription/lib/field_based_prompt_builder_spec.rb`).

### Testing

- Ran `git diff --check` which reported no problems.
- Attempted to run `bundle exec rspec spec/interactors/ai_transcription/lib/field_based_prompt_builder_spec.rb`, but the test runner could not be executed in this environment due to missing bundled executables (`bundler: command not found: rspec`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8f73774fa4832284ee7aa7f678aca3)