### PR TITLE
Fix AI metadata draft settings alignment under transcription controls

### DIFF
--- a/app/assets/stylesheets/sections/collection.scss
+++ b/app/assets/stylesheets/sections/collection.scss
@@ -470,6 +470,12 @@
   border-left: 1px solid rgba(#000, 0.15);
 }
 
+#ai-work-metadata-settings {
+  margin-top: $gapSize;
+  padding-top: $gapSize;
+  border-top: 2px solid rgba(#000, 0.15);
+}
+
 .collection-settings {
   border-collapse: separate;
   border-spacing: 0.25em 0.5em;

--- a/app/views/collection/ai_transcriptions/_form.html.slim
+++ b/app/views/collection/ai_transcriptions/_form.html.slim
@@ -65,3 +65,6 @@
                   =link_to ai_transcription.short_error_message, collection_ai_transcription_path(user_slug: collection.owner.to_param, collection_id: collection.to_param, id: ai_transcription.id)
             -if @failed_ai_transcriptions_hidden_count.positive?
               p =t('.failed_transcription_errors_hidden', count: @failed_ai_transcriptions_hidden_count)
+
+  #ai-work-metadata-settings
+    =render partial: 'collection/ai_work_metadata/form', locals: { collection: collection }

--- a/app/views/collection/ai_transcriptions/edit.html.slim
+++ b/app/views/collection/ai_transcriptions/edit.html.slim
@@ -3,5 +3,3 @@
   =render partial: 'collection/edit_tabs', locals: { selected: 7 }
   #collection-settings
     =render partial: 'form', locals: { collection: @collection }
-    #ai-work-metadata-settings
-      =render partial: 'collection/ai_work_metadata/form', locals: { collection: @collection }

--- a/app/views/collection/ai_work_metadata/_form.html.slim
+++ b/app/views/collection/ai_work_metadata/_form.html.slim
@@ -1,57 +1,56 @@
-.collection-settings-wrapper
-  table.form.collection-settings
-    -if collection.metadata_fields.exists?
-      tr
-        td(colspan="2")
-          h3 =t('.heading')
-          -if @not_started_work_metadata_count.positive? || @failed_work_metadata_count.positive?
-            p =t('.description')
-          -else
-            p =t('.description_complete')
-          div[style='margin: 5px 0']
-            =link_to(collection_ai_work_metadata_path(collection.owner, collection), class: 'button action-btn', data: { turbo: true, turbo_method: :post })
-              span =t('.generate')
+table.form.collection-settings
+  -if collection.metadata_fields.exists?
+    tr
+      td(colspan="2")
+        h3 =t('.heading')
+        -if @not_started_work_metadata_count.positive? || @failed_work_metadata_count.positive?
+          p =t('.description')
+        -else
+          p =t('.description_complete')
+        div[style='margin: 5px 0']
+          =link_to(collection_ai_work_metadata_path(collection.owner, collection), class: 'button action-btn', data: { turbo: true, turbo_method: :post })
+            span =t('.generate')
 
-      tr
-        td(colspan="2")
-          =fe_stacked_bar(title: 'Works', labels: [t('.finished'), t('.in_progress'), t('.failed'), t('.not_started')], \
-            values: [@finished_work_metadata_count, @queued_work_metadata_count, @failed_work_metadata_count, @not_started_work_metadata_count], colors: AiWorkMetadata::FE_COLOR_STATUSES.values, \
-            options: { legend_position: 'bottom', tooltip_enabled: true, border_radius: 20 })
+    tr
+      td(colspan="2")
+        =fe_stacked_bar(title: 'Works', labels: [t('.finished'), t('.in_progress'), t('.failed'), t('.not_started')], \
+          values: [@finished_work_metadata_count, @queued_work_metadata_count, @failed_work_metadata_count, @not_started_work_metadata_count], colors: AiWorkMetadata::FE_COLOR_STATUSES.values, \
+          options: { legend_position: 'bottom', tooltip_enabled: true, border_radius: 20 })
 
-      tr
-        td(colspan="2")
-          section.collection-stats
-            .collection-stats_counters
-              .counter [data-prefix=@works_count]
-                =t('.works')
-            .collection-stats_counters
-              .counter [data-prefix=@finished_work_metadata_count]
-                =t('.finished')
-              .counter [data-prefix=@queued_work_metadata_count]
-                =t('.queued')
-              .counter [data-prefix=@failed_work_metadata_count]
-                =t('.failed')
-              .counter [data-prefix=@not_started_work_metadata_count]
-                =t('.not_started')
-          -if @total_work_metadata_token_count.to_i > 0
-            .collection-stats_counters
-              .counter [data-prefix=@total_work_metadata_token_count]
-                =t('.total_tokens_used')
+    tr
+      td(colspan="2")
+        section.collection-stats
+          .collection-stats_counters
+            .counter [data-prefix=@works_count]
+              =t('.works')
+          .collection-stats_counters
+            .counter [data-prefix=@finished_work_metadata_count]
+              =t('.finished')
+            .counter [data-prefix=@queued_work_metadata_count]
+              =t('.queued')
+            .counter [data-prefix=@failed_work_metadata_count]
+              =t('.failed')
+            .counter [data-prefix=@not_started_work_metadata_count]
+              =t('.not_started')
+        -if @total_work_metadata_token_count.to_i > 0
+          .collection-stats_counters
+            .counter [data-prefix=@total_work_metadata_token_count]
+              =t('.total_tokens_used')
 
-      -if @failed_ai_work_metadata.present?
-        tr
-          td(colspan="2")
-            h4 =t('.failed_work_metadata_errors')
-            ul
-              -@failed_ai_work_metadata.each do |ai_work_metadata|
-                li
-                  =link_to ai_work_metadata.work.title, describe_collection_work_path(collection.owner, collection, ai_work_metadata.work)
-                  |  —
-                  =link_to ai_work_metadata.short_error_message, collection_ai_work_metadatum_path(user_slug: collection.owner.to_param, collection_id: collection.to_param, id: ai_work_metadata.id)
-            -if @failed_ai_work_metadata_hidden_count.positive?
-              p =t('.failed_work_metadata_errors_hidden', count: @failed_ai_work_metadata_hidden_count)
-    -else
+    -if @failed_ai_work_metadata.present?
       tr
         td(colspan="2")
-          h3 =t('.heading')
-          p =t('.no_metadata_fields')
+          h4 =t('.failed_work_metadata_errors')
+          ul
+            -@failed_ai_work_metadata.each do |ai_work_metadata|
+              li
+                =link_to ai_work_metadata.work.title, describe_collection_work_path(collection.owner, collection, ai_work_metadata.work)
+                |  —
+                =link_to ai_work_metadata.short_error_message, collection_ai_work_metadatum_path(user_slug: collection.owner.to_param, collection_id: collection.to_param, id: ai_work_metadata.id)
+          -if @failed_ai_work_metadata_hidden_count.positive?
+            p =t('.failed_work_metadata_errors_hidden', count: @failed_ai_work_metadata_hidden_count)
+  -else
+    tr
+      td(colspan="2")
+        h3 =t('.heading')
+        p =t('.no_metadata_fields')

--- a/app/views/work/ai_transcriptions/_form.html.slim
+++ b/app/views/work/ai_transcriptions/_form.html.slim
@@ -77,3 +77,6 @@
                   =link_to ai_transcription.short_error_message, collection_work_ai_transcription_path(user_slug: collection.owner.to_param, collection_id: collection.to_param, work_id: work.to_param, id: ai_transcription.id)
             -if @failed_ai_transcriptions_hidden_count.positive?
               p =t('.failed_transcription_errors_hidden', count: @failed_ai_transcriptions_hidden_count)
+
+  #ai-work-metadata-settings
+    =render partial: 'work/ai_work_metadata/form', locals: { collection: collection, work: work }

--- a/app/views/work/ai_transcriptions/edit.html.slim
+++ b/app/views/work/ai_transcriptions/edit.html.slim
@@ -3,5 +3,3 @@
   =render partial: 'work/edit_tabs', locals: { selected: 5 }
   #collection-settings
     =render partial: 'form', locals: { collection: @collection, work: @work }
-    #ai-work-metadata-settings
-      =render partial: 'work/ai_work_metadata/form', locals: { collection: @collection, work: @work }

--- a/app/views/work/ai_work_metadata/_form.html.slim
+++ b/app/views/work/ai_work_metadata/_form.html.slim
@@ -1,21 +1,20 @@
-.collection-settings-wrapper
-  table.form.collection-settings
+table.form.collection-settings
+  tr
+    td(colspan="2")
+      h3 =t('.heading')
+      -if collection.metadata_fields.exists?
+        p =t('.description')
+        div[style='margin: 5px 0']
+          =link_to(collection_work_ai_work_metadata_path(collection.owner, collection, work), class: 'button action-btn', data: { turbo: true, turbo_method: :post })
+            span =t('.generate')
+      -else
+        p =t('.no_metadata_fields')
+
+  -if work.ai_work_metadata.any?
     tr
       td(colspan="2")
-        h3 =t('.heading')
-        -if collection.metadata_fields.exists?
-          p =t('.description')
-          div[style='margin: 5px 0']
-            =link_to(collection_work_ai_work_metadata_path(collection.owner, collection, work), class: 'button action-btn', data: { turbo: true, turbo_method: :post })
-              span =t('.generate')
-        -else
-          p =t('.no_metadata_fields')
-
-      -if work.ai_work_metadata.any?
-        tr
-          td(colspan="2")
-            h4 =t('.drafts_heading')
-            ul
-              -work.ai_work_metadata.order(created_at: :desc).each do |ai_work_metadata|
-                li
-                  =link_to("#{ai_work_metadata.model} (#{ai_work_metadata.status})", collection_work_ai_work_metadatum_path(collection.owner, collection, work, ai_work_metadata))
+        h4 =t('.drafts_heading')
+        ul
+          -work.ai_work_metadata.order(created_at: :desc).each do |ai_work_metadata|
+            li
+              =link_to("#{ai_work_metadata.model} (#{ai_work_metadata.status})", collection_work_ai_work_metadatum_path(collection.owner, collection, work, ai_work_metadata))

--- a/spec/requests/collection/ai_transcriptions_controller_spec.rb
+++ b/spec/requests/collection/ai_transcriptions_controller_spec.rb
@@ -36,6 +36,16 @@ describe Collection::AiTranscriptionsController do
         expect(response).to render_template(:edit)
       end
 
+      it 'places metadata draft settings beneath transcription settings' do
+        login_as owner
+        subject
+
+        settings = response.parsed_body.at_css('#collection-settings > .collection-settings-wrapper')
+
+        expect(settings.at_css('#ai-work-metadata-settings')).to be_present
+        expect(response.parsed_body.css('#collection-settings > .collection-settings-wrapper').size).to eq(1)
+      end
+
       context 'with more than 1 result' do
         let!(:page_2) { create(:page, work: work) }
         let!(:ai_transcription_2) { create(:ai_transcription, page_id: page_2.id, status: :finished, source_text: nil, reasoning: nil) }

--- a/spec/requests/work/ai_transcriptions_controller_spec.rb
+++ b/spec/requests/work/ai_transcriptions_controller_spec.rb
@@ -41,6 +41,16 @@ describe Work::AiTranscriptionsController do
         expect(response).to render_template(:edit)
       end
 
+      it 'places metadata draft settings beneath transcription settings' do
+        login_as owner
+        subject
+
+        settings = response.parsed_body.at_css('#collection-settings > .collection-settings-wrapper')
+
+        expect(settings.at_css('#ai-work-metadata-settings')).to be_present
+        expect(response.parsed_body.css('#collection-settings > .collection-settings-wrapper').size).to eq(1)
+      end
+
       it 'shows the segmentation section' do
         login_as owner
         subject


### PR DESCRIPTION
### Motivation

- The AI metadata draft controls were rendering alongside navigation instead of beneath the draft transcription button/progress/stats, causing a misaligned layout for collection and work owners.

### Description

- Move the collection-level metadata partial so it is rendered inside the main settings wrapper by adding the `#ai-work-metadata-settings` render below the transcription settings in `app/views/collection/ai_transcriptions/_form.html.slim` and removing the duplicate outer wrapper from `app/views/collection/ai_transcriptions/edit.html.slim`.
- Apply the same change at the work level by rendering `work/ai_work_metadata/form` inside `app/views/work/ai_transcriptions/_form.html.slim` and removing the duplicate wrapper in `app/views/work/ai_transcriptions/edit.html.slim`.
- Simplify the ai work metadata partials to avoid their own `.collection-settings-wrapper` so they integrate cleanly into the parent settings wrapper by adjusting `app/views/collection/ai_work_metadata/_form.html.slim` and `app/views/work/ai_work_metadata/_form.html.slim`.
- Add request specs that verify the metadata draft settings are nested beneath the transcription settings in `spec/requests/collection/ai_transcriptions_controller_spec.rb` and `spec/requests/work/ai_transcriptions_controller_spec.rb`.

Files changed: `app/views/collection/ai_transcriptions/_form.html.slim`, `app/views/collection/ai_transcriptions/edit.html.slim`, `app/views/collection/ai_work_metadata/_form.html.slim`, `app/views/work/ai_transcriptions/_form.html.slim`, `app/views/work/ai_transcriptions/edit.html.slim`, `app/views/work/ai_work_metadata/_form.html.slim`, `spec/requests/collection/ai_transcriptions_controller_spec.rb`, `spec/requests/work/ai_transcriptions_controller_spec.rb`.

### Testing

- Ran `git diff --check` and `git status --short`, which passed and show the intended changes were staged and committed.
- Attempted to run the modified request specs with `bundle exec rspec ...`, but `bundler` reported the `rspec` executable is unavailable until project gems are installed, so the specs could not be executed here.
- Attempted to parse Slim templates with a small Ruby invocation to validate templates, but the `slim` gem was not available in the environment, so template parsing could not be validated here.
- Verified templates were updated and the repository committed locally as part of the branch (`Fix AI metadata settings alignment`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a982e8400388322a64ac2a33640fe4b)