### PR TITLE
Move metadata AI Draft button beside Save

### DIFF
--- a/app/views/work/describe.html.slim
+++ b/app/views/work/describe.html.slim
@@ -36,9 +36,6 @@
               -view_modes.each do |mode, text|
                 a(data-view-set="#{mode}")
                   span =text
-          -if @work.ai_metadata_draft_available? && (!@collection.ai_draft_disabled || current_user.like_owner?(@collection))
-            =button_tag t('.ai_draft_fields'), type: 'button', id: 'ai-draft-metadata-fields', class: 'button outline', title: "#{t('.ai_draft_fields_tooltip')}"
-
         .flex-toolbar_group.hide-m
           label.auto-fullscreen
             =check_box_tag 'auto-fullscreen', 'yes', @auto_fullscreen == 'yes'
@@ -53,6 +50,9 @@
             =f.check_box('needs_review', {checked: @work.description_status == Work::DescriptionStatus::NEEDS_REVIEW})
 
         .flex-toolbar_group class=(@collection.review_workflow ? 'push-right' : '')
+          -if @work.ai_metadata_draft_available? && (!@collection.ai_draft_disabled || current_user.like_owner?(@collection))
+            =button_tag t('.ai_draft_fields'), type: 'button', id: 'ai-draft-metadata-fields', class: 'button outline', title: "#{t('.ai_draft_fields_tooltip')}"
+
           / check status of page and configuration of collection
           -if @work.description_status.nil? || @work.description_status == Work::DescriptionStatus::INCOMPLETE || @work.description_status == Work::DescriptionStatus::UNDESCRIBED
             =button_tag t('.save_changes'), :name => 'save_to_incomplete', type: 'submit', id: 'save_button_top', onclick: 'unsavedNotes(event);', title: "#{t('.save_to_incomplete_tooltip')}"

--- a/app/views/work/describe.html.slim
+++ b/app/views/work/describe.html.slim
@@ -51,7 +51,7 @@
 
         .flex-toolbar_group class=(@collection.review_workflow ? 'push-right' : '')
           -if @work.ai_metadata_draft_available? && (!@collection.ai_draft_disabled || current_user.like_owner?(@collection))
-            =button_tag t('.ai_draft_fields'), type: 'button', id: 'ai-draft-metadata-fields', class: 'button outline', title: "#{t('.ai_draft_fields_tooltip')}"
+            =button_tag t('.ai_draft_fields'), type: 'button', id: 'ai-draft-metadata-fields', title: "#{t('.ai_draft_fields_tooltip')}"
 
           / check status of page and configuration of collection
           -if @work.description_status.nil? || @work.description_status == Work::DescriptionStatus::INCOMPLETE || @work.description_status == Work::DescriptionStatus::UNDESCRIBED
@@ -246,4 +246,3 @@ h2.legend =t('.notes_and_questions')
       $('.page-original').toggle(false);
       $('.page-ai').toggle(false);
     })
-

--- a/spec/requests/work_describe_ai_spec.rb
+++ b/spec/requests/work_describe_ai_spec.rb
@@ -25,6 +25,10 @@ describe WorkController, '#describe' do
 
     expect(response).to have_http_status(:ok)
     expect(response.body).to include('page-ai')
+
+    document = Nokogiri::HTML(response.body)
+    ai_draft_button = document.at_css('#ai-draft-metadata-fields')
+    expect(ai_draft_button.next_element['id']).to eq('save_button_top')
   end
 
   it 'renders describe page without an ai draft option when none is available' do

--- a/spec/requests/work_describe_ai_spec.rb
+++ b/spec/requests/work_describe_ai_spec.rb
@@ -28,6 +28,7 @@ describe WorkController, '#describe' do
 
     document = Nokogiri::HTML(response.body)
     ai_draft_button = document.at_css('#ai-draft-metadata-fields')
+    expect(ai_draft_button['class'].to_s.split).not_to include('outline')
     expect(ai_draft_button.next_element['id']).to eq('save_button_top')
   end
 


### PR DESCRIPTION
### Motivation
- Move the AI Metadata Draft button beside the Save controls in the work describe UI to match the transcription editor layout and improve consistency and discoverability.

### Description
- Move the `ai_draft_fields` button into the save-toolbar group in `app/views/work/describe.html.slim` so it appears immediately adjacent to the Save button.
- Add a request spec assertion in `spec/requests/work_describe_ai_spec.rb` that verifies the `#ai-draft-metadata-fields` button is rendered directly next to the `save_button_top` element.

### Testing
- Ran `git diff --check`, which passed in this environment.
- Attempted to run `bundle exec rspec spec/requests/work_describe_ai_spec.rb`, but RSpec could not be executed here due to a Ruby version mismatch (environment provides Ruby 3.4.4 while the Gemfile requires Ruby 3.3.5).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9ecd244e608322b40b39d4525e2801)