### PR TITLE
Restrict metadata editing in read-only projects

### DIFF
--- a/app/controllers/work_controller.rb
+++ b/app/controllers/work_controller.rb
@@ -28,6 +28,7 @@ class WorkController < ApplicationController
     :remove_scribe,
     :search_scribes
   ]
+  before_action :authorized_to_describe?, only: [:describe, :save_description]
 
   # no layout if xhr request
   layout :dynamic_layout, only: [:new, :create, :configurable_printout, :edit_scribes, :remove_scribe]
@@ -399,6 +400,12 @@ class WorkController < ApplicationController
   end
 
   private
+
+  def authorized_to_describe?
+    return if user_signed_in? && current_user.can_transcribe?(@work, @collection)
+
+    redirect_to metadata_overview_collection_work_path(@collection.owner, @collection, @work)
+  end
 
   def require_segmentation_feature
     return if @collection&.segmentation_feature_enabled?

--- a/app/views/collection/needs_metadata_works.html.slim
+++ b/app/views/collection/needs_metadata_works.html.slim
@@ -27,7 +27,7 @@ div.collection-work-list
               =t('collection.show.restricted_collaboratoration')
         -if @collection.metadata_entry? && work.description_status != Work::DescriptionStatus::DESCRIBED && !work.has_untranscribed_pages?
           p.collection-work_action
-            -if work.user_can_transcribe?(current_user)
+            -if current_user&.can_transcribe?(work, @collection)
               =t('collection.show.this_work_has_not_been_described')
               span &nbsp;
               =link_to(t('collection.show.help_create_metadata'), describe_collection_work_path(@collection.owner, @collection, work), onclick: "resultClicked();")

--- a/app/views/collection/show.html.slim
+++ b/app/views/collection/show.html.slim
@@ -73,7 +73,7 @@
 
             -if @collection.metadata_entry? && work.description_status != Work::DescriptionStatus::DESCRIBED && !work.has_untranscribed_pages?
               p.collection-work_action
-                -if work.user_can_transcribe?(current_user)
+                -if current_user&.can_transcribe?(work, @collection)
                   =t('.this_work_has_not_been_described')
                   span &nbsp;
                   =link_to(t('.help_create_metadata'), describe_collection_work_path(@collection.owner, @collection, work), onclick: "resultClicked();")

--- a/app/views/display/_multi_page.html.slim
+++ b/app/views/display/_multi_page.html.slim
@@ -59,7 +59,7 @@
               =button_to t('.translations_need_review'), {action: "read_work", work_id: @work.slug, needs_review: 'translation_review'}, class: 'review-button'
             -if @work.pages.needs_translation_index.any?
               =button_to t('.translations_need_indexing'), {action: "read_work", work_id: @work.slug, needs_review: 'translation_index'}, class: 'review-button'
-          -if @collection.metadata_entry?
+          -if @collection.metadata_entry? && current_user&.can_transcribe?(@work, @collection)
             =link_to t('.describe'), describe_collection_work_path(@collection.owner, @collection, @work.slug), class: 'button review-button'
 
       -if @article

--- a/app/views/display/_pages_view.html.slim
+++ b/app/views/display/_pages_view.html.slim
@@ -17,7 +17,7 @@
   -work_title = page.work.title
   -if !@work && work_title != old_work_title
     h3 =work_title
-    -if page.work.description_status == Work::DescriptionStatus::NEEDS_REVIEW && current_user&.can_review?(@collection)
+    -if page.work.description_status == Work::DescriptionStatus::NEEDS_REVIEW && current_user&.can_transcribe?(page.work, @collection) && current_user&.can_review?(@collection)
       =link_to t('.review_metadata'), describe_collection_work_path(@collection.owner, @collection, page.work), class: 'button review-button', onclick: "resultClicked();"
 
   .work-page

--- a/app/views/elastic/_work_partial.html.slim
+++ b/app/views/elastic/_work_partial.html.slim
@@ -20,7 +20,7 @@ p.collection-work_snippet = to_snippet(work.description)
 
 -if collection.metadata_entry? && work.description_status != Work::DescriptionStatus::DESCRIBED && !work.has_untranscribed_pages?
   p.collection-work_action
-    -if work.user_can_transcribe?(current_user)
+    -if current_user&.can_transcribe?(work, collection)
       =t('collection.show.this_work_has_not_been_described')
       span &nbsp;
       =link_to(t('collection.show.help_create_metadata'), describe_collection_work_path(collection.owner, collection, work), onclick: "resultClicked();")

--- a/app/views/shared/_description_tabs.html.slim
+++ b/app/views/shared/_description_tabs.html.slim
@@ -3,7 +3,8 @@
   :selected => 1,
   :path => metadata_overview_collection_work_path(@work.slug),
 }]
--if current_user.present?
+-can_describe = current_user&.can_transcribe?(@work, @collection)
+-if can_describe
   -tabs += [{\
     :name => t('.describe'),
     :selected => 2,
@@ -49,7 +50,7 @@
               -if next_page
                 =link_to(collection_transcribe_page_path(@collection.owner, @collection, @work, @work.pages.last.id), class: 'page-nav_next', title: t('.next_page'), 'aria-label' => t('.next_page'), onclick: 'unsavedTranscription(event);')
                   =svg_symbol '#icon-arrow-right', class: 'icon', title: 'Next page'
-              -else
+              -elsif can_describe
                 =link_to(describe_collection_work_path(@collection.owner, @collection, next_work), class: 'page-nav_next', title: t('.next_work'), 'aria-label' => t('.next_work'), onclick: 'unsavedTranscription(event);')
                   =svg_symbol '#icon-arrow-right', class: 'icon', title: 'Next work'
             -else
@@ -57,7 +58,7 @@
                 =svg_symbol '#icon-arrow-right', class: 'icon', title: 'Next page'
 
 
-        -else
+        -elsif can_describe
           -if index.present? && index > 0
             =link_to(describe_collection_work_path(@collection.owner, @collection, @collection.works[index-1]), class: 'page-nav_prev', title: t('.previous_work'), 'aria-label' => t('.previous_work'), onclick: 'unsavedTranscription(event);')
               =svg_symbol '#icon-arrow-left', class: 'icon', title: 'Previous work'
@@ -72,4 +73,3 @@
   -for tab in tabs
       =link_to_unless tab[:selected] == selected, tab[:name], tab[:path]
         a.active =tab[:name]
-

--- a/app/views/transcribe/_segmentation_success.html.slim
+++ b/app/views/transcribe/_segmentation_success.html.slim
@@ -2,7 +2,7 @@
   .segmentation-banner-content
     p.segmentation-banner-message =t('transcribe.display_page.segmentation_success', title: new_work_title, count: count)
     .segmentation-banner-actions
-      -if edit_metadata_after_split
+      -if edit_metadata_after_split && current_user&.can_transcribe?(new_work, collection)
         =link_to(t('transcribe.display_page.segmentation_edit_work_metadata'), describe_collection_work_path(collection.owner, collection, new_work), class: 'button outline', data: { turbo_frame: '_top' })
       -else
         =link_to(t('transcribe.display_page.segmentation_view_work'), collection_read_work_path(collection.owner, collection, new_work), class: 'button outline', data: { turbo_frame: '_top' })

--- a/app/views/work/metadata_overview.html.slim
+++ b/app/views/work/metadata_overview.html.slim
@@ -29,7 +29,7 @@
 
   .page-column
     .page-editarea(style=("display:none" if @preview_xml) *language_attrs(@collection))
-      -if @work.description_status == Work::DescriptionStatus::UNDESCRIBED
+      -if @work.description_status == Work::DescriptionStatus::UNDESCRIBED && current_user&.can_transcribe?(@work, @collection)
         p.collection-work_action
           =t('collection.show.this_work_has_not_been_described')
           span &nbsp;
@@ -122,4 +122,3 @@ h2.legend =t('.notes_and_questions')
         $('#page_needs_review').prop('checked', false);
       });
     });
-

--- a/spec/requests/work_controller_spec.rb
+++ b/spec/requests/work_controller_spec.rb
@@ -11,6 +11,61 @@ describe WorkController do
   let!(:page) { create(:page, work: work) }
   let!(:article) { create(:article, collection: collection, pages: [page]) }
 
+  describe 'metadata description authorization' do
+    let(:user) { create(:unique_user) }
+
+    shared_examples 'read-only metadata' do
+      it 'redirects non-owners away from the description editor' do
+        login_as user
+
+        get describe_collection_work_path(owner, access_object, work)
+
+        expect(response).to redirect_to(metadata_overview_collection_work_path(owner, access_object, work))
+        follow_redirect!
+        expect(response.body).not_to include(describe_collection_work_path(owner, access_object, work))
+      end
+
+      it 'does not let non-owners save metadata directly' do
+        login_as user
+        original_metadata = work.metadata_description
+
+        patch save_description_collection_work_path(owner, access_object, work), params: {
+          fields: { '0' => { label: 'Restricted field', value: 'Restricted value' } },
+          save_to_transcribed: '1'
+        }
+
+        expect(response).to redirect_to(metadata_overview_collection_work_path(owner, access_object, work))
+        expect(work.reload.metadata_description).to eq(original_metadata)
+      end
+
+      it 'still lets the owner open the description editor' do
+        login_as owner
+
+        get describe_collection_work_path(owner, access_object, work)
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(:describe)
+      end
+    end
+
+    context 'when the collection is read-only' do
+      before { collection.update!(visibility: :read_only) }
+
+      let(:access_object) { collection }
+
+      include_examples 'read-only metadata'
+    end
+
+    context 'when the document set is read-only' do
+      let!(:document_set) do
+        create(:document_set, :read_only, owner_user_id: owner.id, collection_id: collection.id, works: [work])
+      end
+      let(:access_object) { document_set }
+
+      include_examples 'read-only metadata'
+    end
+  end
+
   describe '#edit' do
     let(:action_path) { edit_collection_work_path(owner, collection, work) }
     let(:subject) { get action_path }


### PR DESCRIPTION
### Motivation

- Prevent non-owner/non-collaborator users from creating or editing work metadata when the work is located in a read-only `Collection` or `DocumentSet`, using the same authorization semantics as transcription.  

### Description

- Add a controller-level guard `authorized_to_describe?` and wire it into `WorkController` with `before_action` for `:describe` and `:save_description`, redirecting unauthorized users to the metadata overview with `metadata_overview_collection_work_path`.  
- Hide or conditionally render metadata entry links and actions in views when the current user cannot transcribe, replacing calls like `work.user_can_transcribe?(current_user)` with the transcription check `current_user&.can_transcribe?(work, collection)` where applicable (changes in `app/views/*` and `app/views/shared/_description_tabs.html.slim`).  
- Protect the post-segmentation "edit metadata" action so it only shows when the user can transcribe the new work.  
- Add request specs covering read-only `Collection` and read-only `DocumentSet` access attempts, including attempts to open the description editor and to `PATCH` `save_description`, and verify owner access remains allowed (`spec/requests/work_controller_spec.rb`).

### Testing

- Ran `git diff --check` to ensure no whitespace/merge issues and it passed.  
- Ran Ruby syntax checks with `ruby -c` on modified files: `app/controllers/work_controller.rb` and `spec/requests/work_controller_spec.rb`, both returned `Syntax OK`.  
- Attempted to run the new request specs with `bundle exec rspec spec/requests/work_controller_spec.rb` but the environment could not run them because the container Ruby is `3.4.4` while the project `Gemfile` requires `3.3.5` and the `rspec` executable is not available (bundler / Ruby mismatch), so the full spec run was not executed.  
- Manual inspection and local view logic checks were performed to ensure describe/save flows are redirected or hidden for unauthorized users.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa2c543c3848322a114a5f3c6a36ee6)