### PR TITLE
Render page-version Restore control as unclassed submit; update locales and spec

### DIFF
--- a/app/views/page_version/show.html.slim
+++ b/app/views/page_version/show.html.slim
@@ -49,7 +49,7 @@ table.diff-versions(data-fullheight='{ "bottom": 30, "cssrule": "min-height" }')
                       = t('.ai_draft_used')
                       = svg_symbol '#icon-robot', class: 'icon', style: 'margin-left: 5px; stroke: yellow;'
               - if current_user&.like_owner?(@work) && !@selected_version.current_version?
-                = button_to t('.revert_to_this_version'), page_version_revert_path(page_version_id: @selected_version.id), method: :post, class: 'button outline small', form_class: 'diff-title-action', data: { confirm: t('.revert_confirm') }
+                = button_to t('.restore'), page_version_revert_path(page_version_id: @selected_version.id), method: :post, form_class: 'diff-title-action', title: t('.restore_tooltip'), data: { confirm: t('.revert_confirm') }
           div.version-content
             - if @selected_version&.page_version && @previous_version&.page_version
               - if @selected_version.page_version > @previous_version.page_version

--- a/config/locales/page_version/page_version-de.yml
+++ b/config/locales/page_version/page_version-de.yml
@@ -21,6 +21,7 @@ de:
       page_version_status_review: Rezension
       page_version_status_transcribed: transkribiert
       revert_confirm: Sind Sie sicher, dass Sie auf diese Version zurücksetzen möchten? Sie werden zur Transkriptionsansicht weitergeleitet, um die Änderung zu prüfen und zu speichern.
-      revert_to_this_version: Auf diese Version zurücksetzen
+      restore: Wiederherstellen
+      restore_tooltip: Diese Version wiederherstellen
       translation: Übersetzung
       untitled: Ohne Titel

--- a/config/locales/page_version/page_version-de.yml
+++ b/config/locales/page_version/page_version-de.yml
@@ -20,8 +20,8 @@ de:
       page_version_status_needs_review: benötigt Überprüfung
       page_version_status_review: Rezension
       page_version_status_transcribed: transkribiert
-      revert_confirm: Sind Sie sicher, dass Sie auf diese Version zurücksetzen möchten? Sie werden zur Transkriptionsansicht weitergeleitet, um die Änderung zu prüfen und zu speichern.
       restore: Wiederherstellen
       restore_tooltip: Diese Version wiederherstellen
+      revert_confirm: Sind Sie sicher, dass Sie auf diese Version zurücksetzen möchten? Sie werden zur Transkriptionsansicht weitergeleitet, um die Änderung zu prüfen und zu speichern.
       translation: Übersetzung
       untitled: Ohne Titel

--- a/config/locales/page_version/page_version-en.yml
+++ b/config/locales/page_version/page_version-en.yml
@@ -21,6 +21,7 @@ en:
       page_version_status_review: review
       page_version_status_transcribed: transcribed
       revert_confirm: Are you sure you want to revert to this version? You will be taken to the transcription screen to review and save.
-      revert_to_this_version: Revert to this version
+      restore: Restore
+      restore_tooltip: Restore this version
       translation: Translation
       untitled: Untitled

--- a/config/locales/page_version/page_version-en.yml
+++ b/config/locales/page_version/page_version-en.yml
@@ -20,8 +20,8 @@ en:
       page_version_status_needs_review: needs review
       page_version_status_review: review
       page_version_status_transcribed: transcribed
-      revert_confirm: Are you sure you want to revert to this version? You will be taken to the transcription screen to review and save.
       restore: Restore
       restore_tooltip: Restore this version
+      revert_confirm: Are you sure you want to revert to this version? You will be taken to the transcription screen to review and save.
       translation: Translation
       untitled: Untitled

--- a/config/locales/page_version/page_version-es.yml
+++ b/config/locales/page_version/page_version-es.yml
@@ -20,8 +20,8 @@ es:
       page_version_status_needs_review: necesita revisión
       page_version_status_review: revisar
       page_version_status_transcribed: transcrito
-      revert_confirm: "¿Está seguro de que desea revertir a esta versión? Se le llevará a la pantalla de transcripción para revisar y guardar."
       restore: Restaurar
       restore_tooltip: Restaurar esta versión
+      revert_confirm: "¿Está seguro de que desea revertir a esta versión? Se le llevará a la pantalla de transcripción para revisar y guardar."
       translation: Traducción
       untitled: Intitulado

--- a/config/locales/page_version/page_version-es.yml
+++ b/config/locales/page_version/page_version-es.yml
@@ -21,6 +21,7 @@ es:
       page_version_status_review: revisar
       page_version_status_transcribed: transcrito
       revert_confirm: "¿Está seguro de que desea revertir a esta versión? Se le llevará a la pantalla de transcripción para revisar y guardar."
-      revert_to_this_version: Revertir a esta versión
+      restore: Restaurar
+      restore_tooltip: Restaurar esta versión
       translation: Traducción
       untitled: Intitulado

--- a/config/locales/page_version/page_version-fr.yml
+++ b/config/locales/page_version/page_version-fr.yml
@@ -21,6 +21,7 @@ fr:
       page_version_status_review: revoir
       page_version_status_transcribed: transcrit
       revert_confirm: Êtes-vous sûr de vouloir revenir à cette version ? Vous serez redirigé vers l’écran de transcription pour vérifier et enregistrer.
-      revert_to_this_version: Revenir à cette version
+      restore: Restaurer
+      restore_tooltip: Restaurer cette version
       translation: Traduction
       untitled: Sans titre

--- a/config/locales/page_version/page_version-fr.yml
+++ b/config/locales/page_version/page_version-fr.yml
@@ -20,8 +20,8 @@ fr:
       page_version_status_needs_review: nécessite révision
       page_version_status_review: revoir
       page_version_status_transcribed: transcrit
-      revert_confirm: Êtes-vous sûr de vouloir revenir à cette version ? Vous serez redirigé vers l’écran de transcription pour vérifier et enregistrer.
       restore: Restaurer
       restore_tooltip: Restaurer cette version
+      revert_confirm: Êtes-vous sûr de vouloir revenir à cette version ? Vous serez redirigé vers l’écran de transcription pour vérifier et enregistrer.
       translation: Traduction
       untitled: Sans titre

--- a/config/locales/page_version/page_version-pt.yml
+++ b/config/locales/page_version/page_version-pt.yml
@@ -20,8 +20,8 @@ pt:
       page_version_status_needs_review: necessita revisão
       page_version_status_review: análise
       page_version_status_transcribed: transcrito
-      revert_confirm: Tem certeza de que deseja reverter para esta versão? Você será levado à tela de transcrição para revisar e salvar.
       restore: Restaurar
       restore_tooltip: Restaurar esta versão
+      revert_confirm: Tem certeza de que deseja reverter para esta versão? Você será levado à tela de transcrição para revisar e salvar.
       translation: Tradução
       untitled: Sem título

--- a/config/locales/page_version/page_version-pt.yml
+++ b/config/locales/page_version/page_version-pt.yml
@@ -21,6 +21,7 @@ pt:
       page_version_status_review: análise
       page_version_status_transcribed: transcrito
       revert_confirm: Tem certeza de que deseja reverter para esta versão? Você será levado à tela de transcrição para revisar e salvar.
-      revert_to_this_version: Reverter para esta versão
+      restore: Restaurar
+      restore_tooltip: Restaurar esta versão
       translation: Tradução
       untitled: Sem título

--- a/spec/requests/page_version_controller_spec.rb
+++ b/spec/requests/page_version_controller_spec.rb
@@ -35,12 +35,15 @@ RSpec.describe PageVersionController do
       expect(response).to have_http_status(:ok)
     end
 
-    it 'renders the revert button inline for owners viewing a non-current version' do
+    it 'renders the restore button inline for owners viewing a non-current version' do
       get page_version_show_path, params: { page_version_id: first_version.id }
 
       rendered_page = Capybara.string(response.body)
+      restore_input = rendered_page.find("form.diff-title-action input[type='submit']")
 
-      expect(rendered_page).to have_css("form.diff-title-action input.button.outline.small[type='submit'][value='Revert to this version']")
+      expect(restore_input.value).to eq('Restore')
+      expect(restore_input[:title]).to eq('Restore this version')
+      expect(restore_input[:class].to_s.split).not_to include('button', 'outline', 'small')
     end
   end
 


### PR DESCRIPTION
### Motivation
- Prevent the Restore control from receiving the redundant `button` class so the generated `input[type="submit"]` uses the standard unclassed button styles and avoids the `.button:empty` fixed-size rule.
- Keep the inline form behavior, POST destination, confirmation prompt, and a translated tooltip when restoring a version.

### Description
- Update `app/views/page_version/show.html.slim` to render the action as `button_to t('.restore')` without `class: 'button ...'`, preserving `form_class: 'diff-title-action'`, `method: :post`, and `data: { confirm: t('.revert_confirm') }`, and add `title: t('.restore_tooltip')`.
- Add `restore` and `restore_tooltip` locale keys to `config/locales/page_version/page_version-{en,de,es,fr,pt}.yml` so the label and tooltip are translated.
- Update `spec/requests/page_version_controller_spec.rb` to locate the inline `input[type='submit']` in `form.diff-title-action` and assert the button label (`value`) and tooltip (`title`) and assert the `button`, `outline`, and `small` classes are not present.

### Testing
- Ran `git diff --check` to validate whitespace and diff issues, which passed.
- Ran `ruby -e "require 'yaml'; Dir['config/locales/page_version/page_version-*.yml'].each { |file| YAML.load_file(file, aliases: true) }; puts 'YAML OK'"` to validate locale files, which returned `YAML OK`.
- Attempted `bundle exec rspec spec/requests/page_version_controller_spec.rb` but tests could not be executed due to dependency installation failing for the `rmagick` gem (missing ImageMagick development libraries), so the request spec was not run under the test bundle environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa2d5a439a083229f894a2b272b860d)