### PR TITLE
Add restore controls for work metadata versions

### DIFF
--- a/app/assets/stylesheets/components/shared.scss
+++ b/app/assets/stylesheets/components/shared.scss
@@ -1306,6 +1306,11 @@ button, .button, .dropdown dd a {
     align-items: center;
     display: flex;
   }
+
+  .diff-title-with-action {
+    align-items: center;
+    display: flex;
+  }
   td {
     vertical-align: top;
     border-style: solid;

--- a/app/controllers/work_controller.rb
+++ b/app/controllers/work_controller.rb
@@ -138,14 +138,14 @@ class WorkController < ApplicationController
 
     if version.nil?
       flash[:error] = t('.version_not_found')
-      redirect_to description_versions_collection_work_path(@work.slug)
+      redirect_to description_versions_collection_work_path(@collection.owner, @collection, @work)
       return
     end
 
     @work.update!(metadata_description: version.metadata_description)
 
     flash[:notice] = t('.restored')
-    redirect_to describe_collection_work_path(@work.slug)
+    redirect_to describe_collection_work_path(@collection.owner, @collection, @work)
   end
 
   def delete

--- a/app/controllers/work_controller.rb
+++ b/app/controllers/work_controller.rb
@@ -26,7 +26,8 @@ class WorkController < ApplicationController
     :edit_scribes,
     :add_scribe,
     :remove_scribe,
-    :search_scribes
+    :search_scribes,
+    :restore_description_version
   ]
 
   # no layout if xhr request
@@ -114,14 +115,14 @@ class WorkController < ApplicationController
     # @previous_version = params[:compare_version_id] ? PageVersion.find(params[:compare_version_id]) : @selected_version.prev
     selected_version_id = params[:metadata_description_version_id]
     if selected_version_id
-      @selected_version= MetadataDescriptionVersion.find(selected_version_id)
+      @selected_version= @work.metadata_description_versions.find(selected_version_id)
     else
       @selected_version= @work.metadata_description_versions.first
     end
     # NB: Unlike in page versions (which are created when we first create the page), metadata description versions may be nil
     compare_version_id = params[:compare_version_id]
     if compare_version_id
-      @previous_version = MetadataDescriptionVersion.find(compare_version_id)
+      @previous_version = @work.metadata_description_versions.find(compare_version_id)
     else
       if @selected_version.version_number > 1
         @previous_version = @work.metadata_description_versions.second
@@ -130,6 +131,21 @@ class WorkController < ApplicationController
       end
     end
     # again, both may be blank here
+  end
+
+  def restore_description_version
+    version = @work.metadata_description_versions.find_by(id: params[:metadata_description_version_id])
+
+    if version.nil?
+      flash[:error] = t('.version_not_found')
+      redirect_to description_versions_collection_work_path(@work.slug)
+      return
+    end
+
+    @work.update!(metadata_description: version.metadata_description)
+
+    flash[:notice] = t('.restored')
+    redirect_to describe_collection_work_path(@work.slug)
   end
 
   def delete

--- a/app/views/work/description_versions.html.slim
+++ b/app/views/work/description_versions.html.slim
@@ -8,9 +8,13 @@ p.diff-help =t('.help_description').html_safe
 table.diff-versions(data-fullheight='{ "bottom": 30, "cssrule": "min-height" }')
   tr
     th: h5.nomargin =pluralize(@work.metadata_description_versions.size, t('.revision'))
-    th = t('.author_contributed_at', author: selected_version_user, date: selected_version_date).html_safe
     th
-      =form_tag(description_versions_collection_work_path(@work.slug), :method => 'get', :enforce_utf8 => false, :'data-compare-with' => '') do
+      .diff-title.diff-title-with-action
+        span.diff-title-label = t('.author_contributed_at', author: selected_version_user, date: selected_version_date).html_safe
+        - if current_user&.like_owner?(@work) && @selected_version != @work.metadata_description_versions.first
+          = button_to t('.restore'), restore_description_version_collection_work_path(@work.slug, metadata_description_version_id: @selected_version.id), method: :patch, form_class: 'diff-title-action', title: t('.restore_tooltip'), data: { confirm: t('.restore_confirm') }
+    th
+      =form_tag(description_versions_collection_work_path(@work.slug), :method => 'get', :enforce_utf8 => false, :'data-compare-with' => '', class: 'diff-title-compare-form') do
         =hidden_field_tag :metadata_description_version_id, @selected_version.id
         =label_tag :compare_version_id, t('.compared_with')
         =select_tag :compare_version_id, options_from_collection_for_select(@work.metadata_description_versions.all.to_a, :id, :display, (@previous_version ? @previous_version.id.to_s : ''))

--- a/config/locales/work/work-de.yml
+++ b/config/locales/work/work-de.yml
@@ -88,9 +88,6 @@ de:
       restore_confirm: Möchten Sie diese Version der Werkmetadaten wirklich wiederherstellen? Sie werden zur Metadatenseite weitergeleitet, um sie zu überprüfen.
       restore_tooltip: Die aktuellen Werkmetadaten durch diese Version ersetzen
       revision: Revision
-    restore_description_version:
-      restored: Die Werkmetadaten wurden auf die ausgewählte Version zurückgesetzt. Bitte überprüfen Sie sie.
-      version_not_found: Metadatenversion nicht gefunden.
     download:
       accessible_pdf: Barrierefreies PDF
       accessible_pdf_download_description: Laden Sie eine für Bildschirmleseprogramme und assistive Technologien optimierte PDF-Version dieses Werkes herunter.
@@ -238,6 +235,9 @@ de:
       transcribe: Transkribieren
       upload: Hochladen
       upload_page_image: "%{upload} Faksimile"
+    restore_description_version:
+      restored: Die Werkmetadaten wurden auf die ausgewählte Version zurückgesetzt. Bitte überprüfen Sie sie.
+      version_not_found: Metadatenversion nicht gefunden.
     save_description:
       work_described: Ihre Beschreibung wurde gespeichert
     search:

--- a/config/locales/work/work-de.yml
+++ b/config/locales/work/work-de.yml
@@ -84,7 +84,13 @@ de:
       author_contributed_at: "%{author} am %{date}"
       compared_with: Im Vergleich zu
       help_description: Anzeige und Vergleich der Änderungen, die in jeder Revision an dem Metadaten des Werkes vorgenommen wurden. Die linke Spalte zeigt die Metadaten in der ausgewählten Revision, die rechte Spalte zeigt, was geändert wurde. Unveränderter Text wird <span>weiß hervorgehoben</span>, gelöschter Text wird <del>rot hervorgehoben</del> und eingefügter Text wird <ins>grün hervorgehoben</ins>.
+      restore: Wiederherstellen
+      restore_confirm: Möchten Sie diese Version der Werkmetadaten wirklich wiederherstellen? Sie werden zur Metadatenseite weitergeleitet, um sie zu überprüfen.
+      restore_tooltip: Die aktuellen Werkmetadaten durch diese Version ersetzen
       revision: Revision
+    restore_description_version:
+      restored: Die Werkmetadaten wurden auf die ausgewählte Version zurückgesetzt. Bitte überprüfen Sie sie.
+      version_not_found: Metadatenversion nicht gefunden.
     download:
       accessible_pdf: Barrierefreies PDF
       accessible_pdf_download_description: Laden Sie eine für Bildschirmleseprogramme und assistive Technologien optimierte PDF-Version dieses Werkes herunter.

--- a/config/locales/work/work-en.yml
+++ b/config/locales/work/work-en.yml
@@ -88,9 +88,6 @@ en:
       restore_confirm: Are you sure you want to restore this version of the work metadata? You will be taken to the metadata screen to review it.
       restore_tooltip: Replace the current work metadata with this version
       revision: revision
-    restore_description_version:
-      restored: Work metadata has been restored to the selected version. Please review it.
-      version_not_found: Metadata version not found.
     download:
       accessible_pdf: Accessible PDF
       accessible_pdf_download_description: Download a PDF version of this work optimized for screen readers and assistive technologies.
@@ -238,6 +235,9 @@ en:
       transcribe: transcribe
       upload: Upload
       upload_page_image: "%{upload} page image"
+    restore_description_version:
+      restored: Work metadata has been restored to the selected version. Please review it.
+      version_not_found: Metadata version not found.
     save_description:
       work_described: Your description has been saved
     search:

--- a/config/locales/work/work-en.yml
+++ b/config/locales/work/work-en.yml
@@ -84,7 +84,13 @@ en:
       author_contributed_at: "%{author} at %{date}"
       compared_with: Compared with
       help_description: View and compare the changes that have been made in each revision to work metadata. The left column shows the metadata in the selected revision, right column shows what has been changed. Unchanged text is <span>highlighted in white</span>, deleted text is <del>highlighted in red</del>, and inserted text is <ins>highlighted in green</ins> color.
+      restore: Restore
+      restore_confirm: Are you sure you want to restore this version of the work metadata? You will be taken to the metadata screen to review it.
+      restore_tooltip: Replace the current work metadata with this version
       revision: revision
+    restore_description_version:
+      restored: Work metadata has been restored to the selected version. Please review it.
+      version_not_found: Metadata version not found.
     download:
       accessible_pdf: Accessible PDF
       accessible_pdf_download_description: Download a PDF version of this work optimized for screen readers and assistive technologies.

--- a/config/locales/work/work-es.yml
+++ b/config/locales/work/work-es.yml
@@ -85,12 +85,9 @@ es:
       compared_with: Comparado con
       help_description: Vea y compara los cambios que se han realizado en cada revisión a los metadatos de obra. La columna de la izquierda muestra los metadatos en la revisión seleccionada, la columna de la derecha muestra lo que se ha cambiado. El texto que no ha cambiado está <span>resaltado en blanco</span>, el texto eliminado está <del>resaltado en rojo</del> y el texto insertado está <ins>resaltado en color verde</ins>.
       restore: Restaurar
-      restore_confirm: ¿Está seguro de que desea restaurar esta versión de los metadatos de la obra? Se le llevará a la pantalla de metadatos para revisarla.
+      restore_confirm: "¿Está seguro de que desea restaurar esta versión de los metadatos de la obra? Se le llevará a la pantalla de metadatos para revisarla."
       restore_tooltip: Reemplazar los metadatos actuales de la obra con esta versión
       revision: revisión
-    restore_description_version:
-      restored: Los metadatos de la obra se han restaurado a la versión seleccionada. Revísela.
-      version_not_found: No se encontró la versión de los metadatos.
     download:
       accessible_pdf: PDF accesible
       accessible_pdf_download_description: Descargue una versión en PDF de esta obra optimizada para lectores de pantalla y tecnologías de asistencia.
@@ -238,6 +235,9 @@ es:
       transcribe: transcribir
       upload: Subir
       upload_page_image: Imagen de la página %{upload}
+    restore_description_version:
+      restored: Los metadatos de la obra se han restaurado a la versión seleccionada. Revísela.
+      version_not_found: No se encontró la versión de los metadatos.
     save_description:
       work_described: Tu descripción ha sido guardada
     search:

--- a/config/locales/work/work-es.yml
+++ b/config/locales/work/work-es.yml
@@ -84,7 +84,13 @@ es:
       author_contributed_at: "%{author} a %{date}"
       compared_with: Comparado con
       help_description: Vea y compara los cambios que se han realizado en cada revisión a los metadatos de obra. La columna de la izquierda muestra los metadatos en la revisión seleccionada, la columna de la derecha muestra lo que se ha cambiado. El texto que no ha cambiado está <span>resaltado en blanco</span>, el texto eliminado está <del>resaltado en rojo</del> y el texto insertado está <ins>resaltado en color verde</ins>.
+      restore: Restaurar
+      restore_confirm: ¿Está seguro de que desea restaurar esta versión de los metadatos de la obra? Se le llevará a la pantalla de metadatos para revisarla.
+      restore_tooltip: Reemplazar los metadatos actuales de la obra con esta versión
       revision: revisión
+    restore_description_version:
+      restored: Los metadatos de la obra se han restaurado a la versión seleccionada. Revísela.
+      version_not_found: No se encontró la versión de los metadatos.
     download:
       accessible_pdf: PDF accesible
       accessible_pdf_download_description: Descargue una versión en PDF de esta obra optimizada para lectores de pantalla y tecnologías de asistencia.

--- a/config/locales/work/work-fr.yml
+++ b/config/locales/work/work-fr.yml
@@ -88,9 +88,6 @@ fr:
       restore_confirm: Êtes-vous sûr de vouloir restaurer cette version des métadonnées de l’œuvre ? Vous serez redirigé vers l’écran des métadonnées pour la vérifier.
       restore_tooltip: Remplacer les métadonnées actuelles de l’œuvre par cette version
       revision: révision
-    restore_description_version:
-      restored: Les métadonnées de l’œuvre ont été restaurées à la version sélectionnée. Veuillez les vérifier.
-      version_not_found: Version des métadonnées introuvable.
     download:
       accessible_pdf: PDF accessible
       accessible_pdf_download_description: Téléchargez une version PDF de cet ouvrage optimisée pour les lecteurs d'écran et les technologies d'assistance.
@@ -238,6 +235,9 @@ fr:
       transcribe: Transcrire
       upload: Télécharger
       upload_page_image: Image de la page %{upload}
+    restore_description_version:
+      restored: Les métadonnées de l’œuvre ont été restaurées à la version sélectionnée. Veuillez les vérifier.
+      version_not_found: Version des métadonnées introuvable.
     save_description:
       work_described: Votre description a été enregistrée
     search:

--- a/config/locales/work/work-fr.yml
+++ b/config/locales/work/work-fr.yml
@@ -84,7 +84,13 @@ fr:
       author_contributed_at: "%{author} à %{date}"
       compared_with: Comparé à
       help_description: Afficher et comparer les modifications apportées dans chaque révision aux métadonnées de œuvre. La colonne de gauche montre les métadonnées dans la révision sélectionnée, la colonne de droite montre ce qui a été modifié. Le texte inchangé est <span>surligné en blanc</span>, le texte supprimé est <del>surligné en rouge</del> et le texte inséré est <ins>surligné en vert</ins>.
+      restore: Restaurer
+      restore_confirm: Êtes-vous sûr de vouloir restaurer cette version des métadonnées de l’œuvre ? Vous serez redirigé vers l’écran des métadonnées pour la vérifier.
+      restore_tooltip: Remplacer les métadonnées actuelles de l’œuvre par cette version
       revision: révision
+    restore_description_version:
+      restored: Les métadonnées de l’œuvre ont été restaurées à la version sélectionnée. Veuillez les vérifier.
+      version_not_found: Version des métadonnées introuvable.
     download:
       accessible_pdf: PDF accessible
       accessible_pdf_download_description: Téléchargez une version PDF de cet ouvrage optimisée pour les lecteurs d'écran et les technologies d'assistance.

--- a/config/locales/work/work-pt.yml
+++ b/config/locales/work/work-pt.yml
@@ -84,7 +84,13 @@ pt:
       author_contributed_at: "%{author} em %{date}"
       compared_with: Comparado com
       help_description: Visualize e compare as alterações que foram feitas em cada revisão aos metadados da obra. A coluna da esquerda mostra os metadados na revisão selecionada, a coluna da direita mostra o que foi alterado. O texto inalterado é <span>destacado em branco</span>, o texto excluído é <del>destacado em vermelho</del> e o texto inserido é <ins>destacado em verde</ins>.
+      restore: Restaurar
+      restore_confirm: Tem certeza de que deseja restaurar esta versão dos metadados da obra? Você será levado à tela de metadados para revisá-la.
+      restore_tooltip: Substituir os metadados atuais da obra por esta versão
       revision: revisão
+    restore_description_version:
+      restored: Os metadados da obra foram restaurados para a versão selecionada. Revise-os.
+      version_not_found: Versão dos metadados não encontrada.
     download:
       accessible_pdf: PDF acessível
       accessible_pdf_download_description: Baixe uma versão em PDF deste obra otimizada para leitores de tela e tecnologias assistivas.

--- a/config/locales/work/work-pt.yml
+++ b/config/locales/work/work-pt.yml
@@ -88,9 +88,6 @@ pt:
       restore_confirm: Tem certeza de que deseja restaurar esta versão dos metadados da obra? Você será levado à tela de metadados para revisá-la.
       restore_tooltip: Substituir os metadados atuais da obra por esta versão
       revision: revisão
-    restore_description_version:
-      restored: Os metadados da obra foram restaurados para a versão selecionada. Revise-os.
-      version_not_found: Versão dos metadados não encontrada.
     download:
       accessible_pdf: PDF acessível
       accessible_pdf_download_description: Baixe uma versão em PDF deste obra otimizada para leitores de tela e tecnologias assistivas.
@@ -238,6 +235,9 @@ pt:
       transcribe: Transcrever
       upload: Envio
       upload_page_image: "%{upload} imagem da página"
+    restore_description_version:
+      restored: Os metadados da obra foram restaurados para a versão selecionada. Revise-os.
+      version_not_found: Versão dos metadados não encontrada.
     save_description:
       work_described: Sua descrição foi salva
     search:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -572,6 +572,7 @@ Fromthepage::Application.routes.draw do
         get 'describe', on: :member
         patch 'save_description', on: :member, to: 'work#save_description'
         get 'description_versions', on: :member
+        patch 'description_versions/:metadata_description_version_id/restore', on: :member, to: 'work#restore_description_version', as: :restore_description_version
         get 'metadata_overview', on: :member
         get 'metadata_overview_monitor', on: :member
         get ':page_id/active_editing', on: :member, to: 'transcribe#active_editing', as: 'active_editing'

--- a/spec/requests/work_controller_spec.rb
+++ b/spec/requests/work_controller_spec.rb
@@ -344,4 +344,119 @@ describe WorkController do
       expect(response).to render_template(:search)
     end
   end
+
+  describe 'work metadata versions' do
+    let!(:older_version) do
+      create(
+        :metadata_description_version,
+        work: work,
+        user: owner,
+        version_number: 1,
+        metadata_description: [{ 'label' => 'Date', 'value' => '1901' }].to_json
+      )
+    end
+    let!(:current_version) do
+      create(
+        :metadata_description_version,
+        work: work,
+        user: owner,
+        version_number: 2,
+        metadata_description: [{ 'label' => 'Date', 'value' => '1902' }].to_json
+      )
+    end
+
+    describe 'GET #description_versions' do
+      it 'shows a restore button to an owner for a previous version' do
+        login_as owner
+
+        get description_versions_collection_work_path(
+          owner,
+          collection,
+          work,
+          metadata_description_version_id: older_version.id
+        )
+
+        rendered_page = Capybara.string(response.body)
+        expect(rendered_page).to have_css(
+          "form.diff-title-action input[type='submit'][value='Restore'][title='Replace the current work metadata with this version']"
+        )
+      end
+
+      it 'does not show a restore button for the current version' do
+        login_as owner
+
+        get description_versions_collection_work_path(owner, collection, work)
+
+        expect(response.body).not_to include('diff-title-action')
+      end
+
+      it 'does not show a restore button to a non-owner' do
+        login_as create(:unique_user)
+
+        get description_versions_collection_work_path(
+          owner,
+          collection,
+          work,
+          metadata_description_version_id: older_version.id
+        )
+
+        expect(response.body).not_to include('diff-title-action')
+      end
+    end
+
+    describe 'PATCH #restore_description_version' do
+      let(:action_path) do
+        restore_description_version_collection_work_path(
+          owner,
+          collection,
+          work,
+          metadata_description_version_id: older_version.id
+        )
+      end
+
+      it 'restores the selected metadata and records a new version for the owner' do
+        login_as owner
+
+        expect { patch action_path }.to change { work.metadata_description_versions.count }.by(1)
+
+        expect(response).to redirect_to(describe_collection_work_path(owner, collection, work))
+        expect(work.reload.metadata_description).to eq(older_version.metadata_description)
+        expect(work.metadata_description_versions.first.user).to eq(owner)
+        expect(flash[:notice]).to be_present
+      end
+
+      it 'does not allow a non-owner to restore metadata' do
+        user = create(:unique_user)
+        login_as user
+        original_metadata = work.metadata_description
+
+        patch action_path
+
+        expect(response).to redirect_to(dashboard_path)
+        expect(work.reload.metadata_description).to eq(original_metadata)
+      end
+
+      it 'does not restore a version belonging to another work' do
+        other_work = create(:work, collection: collection, owner_user_id: owner.id)
+        other_version = create(
+          :metadata_description_version,
+          work: other_work,
+          user: owner,
+          metadata_description: [{ 'label' => 'Date', 'value' => '1800' }].to_json
+        )
+        login_as owner
+
+        patch restore_description_version_collection_work_path(
+          owner,
+          collection,
+          work,
+          metadata_description_version_id: other_version.id
+        )
+
+        expect(response).to redirect_to(description_versions_collection_work_path(owner, collection, work))
+        expect(work.reload.metadata_description).not_to eq(other_version.metadata_description)
+        expect(flash[:error]).to be_present
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Motivation

- Provide project owners the ability to restore a work's metadata to a previous metadata version (parity with page-version restore) to correct unauthorized or mistaken metadata edits.

### Description

- Add an owner-only endpoint `restore_description_version` in `WorkController` that scopes lookups to `@work.metadata_description_versions` and updates `@work.metadata_description` from the selected version, then redirects to the metadata review screen.
- Add a patch route `description_versions/:metadata_description_version_id/restore` and wire the `Restore` control into `app/views/work/description_versions.html.slim`, showing the button only to owners and only for non-current versions; include confirmation and tooltip data attributes.
- Add localized copy for restore actions, confirmations, success notices, and missing-version errors in `config/locales/work/*.yml`.
- Add small layout/CSS adjustments in `app/assets/stylesheets/components/shared.scss` and comprehensive request specs in `spec/requests/work_controller_spec.rb` covering owner visibility, successful restore, non-owner denial, and cross-work protection.

### Testing

- Verified the new route with `mise exec ruby@3.3.5 -- bundle exec rails routes | rg 'restore_description|description_versions'` (route present). (success)
- Ran style/lint checks with `mise exec ruby@3.3.5 -- bundle exec rubocop app/controllers/work_controller.rb spec/requests/work_controller_spec.rb` and found no offenses. (success)
- Checked locale YAML validity with `ruby -e "require 'yaml'; Dir['config/locales/work/*.yml'].each { |f| YAML.load_file(f) }"`. (success)
- Ran `git diff --check` to ensure no whitespace/patch issues. (success)
- Attempted to run request specs with `mise exec ruby@3.3.5 -- bundle exec rspec spec/requests/work_controller_spec.rb` but the test run could not execute examples because MySQL was unavailable at `127.0.0.1:3306`; the change and specs are in place and will run once the test DB is reachable. (blocked by environment)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa2f4c6d214832298fb78364caa3b43)